### PR TITLE
Rename KAIZEN_PROVIDER to KAIZEN_BACKEND.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,14 @@ All configuration variables are prefixed with `KAIZEN_`.
 
 | Variable | Description                                                                   | Default                                  |
 |----------|-------------------------------------------------------------------------------|------------------------------------------|
-| `KAIZEN_PROVIDER` | Backend provider (`milvus` or `filesystem`)                                   | `milvus`                                 |
+| `KAIZEN_BACKEND` | Backend provider (`milvus` or `filesystem`)                                   | `milvus`                                 |
 | `KAIZEN_NAMESPACE_ID` | Namespace ID for isolation                                                    | `kaizen`                                 |
 | `KAIZEN_TIPS_MODEL` | Model for generating tips (e.g. `openai/gpt-4o` for proxy with custom models) | `gpt-4o`                                 |
 | `KAIZEN_CONFLICT_RESOLUTION_MODEL` | Model for resolving conflicts (e.g. `openai/gpt-4o` for proxy with custom models)  | `gpt-4o`                                 |
 | `KAIZEN_CUSTOM_LLM_PROVIDER` | LiteLLM provider (use `openai` for proxy with custom models) | `None`                                   |
 | `KAIZEN_EMBEDDING_MODEL` | Embedding model                                                               | `sentence-transformers/all-MiniLM-L6-v2` |
 
-**Milvus Backend Settings** (when `KAIZEN_PROVIDER=milvus`):
+**Milvus Backend Settings** (when `KAIZEN_BACKEND=milvus`):
 
 | Variable | Description | Default |
 |----------|-------------|---------|
@@ -73,7 +73,7 @@ All configuration variables are prefixed with `KAIZEN_`.
 | `KAIZEN_TOKEN` | Milvus token (optional) | `""` |
 | `KAIZEN_TIMEOUT` | Milvus timeout (optional) | `None` |
 
-**Filesystem Backend Settings** (when `KAIZEN_PROVIDER=filesystem`):
+**Filesystem Backend Settings** (when `KAIZEN_BACKEND=filesystem`):
 
 | Variable | Description | Default |
 |----------|-------------|---------|
@@ -88,14 +88,14 @@ Kaizen supports two storage backends:
 | **Milvus** (default) | Vector database with embeddings | Semantic similarity | Production |
 | **Filesystem** | JSON files, no embeddings | Text substring match | Development/testing |
 
-To switch backends, set the `KAIZEN_PROVIDER` environment variable:
+To switch backends, set the `KAIZEN_BACKEND` environment variable:
 
 ```bash
 # Use Milvus backend (default)
-export KAIZEN_PROVIDER=milvus
+export KAIZEN_BACKEND=milvus
 
 # Use Filesystem backend
-export KAIZEN_PROVIDER=filesystem
+export KAIZEN_BACKEND=filesystem
 ```
 
 ### Using the Filesystem Backend
@@ -172,13 +172,7 @@ npx @modelcontextprotocol/inspector@latest http://127.0.0.1:8202/sse --cli --met
 
 ### Running with Claude Code
 
-Install [Claude Code](https://code.claude.com/docs/en/overview) and set credentials:
-```bash
-export CLAUDE_CODE_SKIP_BEDROCK_AUTH=1
-export ANTHROPIC_BASE_URL="https://ete-litellm.bx.cloud9.ibm.com"
-export ANTHROPIC_AUTH_TOKEN="sk-..."
-export CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1 # Some people need this to get Claude Code to work.
-```
+Install [Claude Code](https://code.claude.com/docs/en/overview) and set credentials.
 
 Run Claude Code in the `demo/workdir` directory:
 ```bash

--- a/README_phoenix_sync.md
+++ b/README_phoenix_sync.md
@@ -24,7 +24,7 @@ No additional dependencies required - uses only stdlib for Phoenix API calls.
 | `PHOENIX_URL` | `http://localhost:6006` | Phoenix server URL |
 | `PHOENIX_PROJECT` | `default` | Phoenix project name |
 | `KAIZEN_NAMESPACE_ID` | `kaizen` | Target namespace for stored entities |
-| `KAIZEN_PROVIDER` | `milvus` | Backend provider (`milvus` or `filesystem`) |
+| `KAIZEN_BACKEND` | `milvus` | Backend provider (`milvus` or `filesystem`) |
 
 ## Usage
 

--- a/kaizen/config/kaizen.py
+++ b/kaizen/config/kaizen.py
@@ -3,7 +3,7 @@ from typing import Literal
 
 class KaizenConfig(BaseSettings):
     model_config = SettingsConfigDict(env_prefix='KAIZEN_')
-    provider: Literal['milvus', 'filesystem'] = 'milvus'
+    backend: Literal['milvus', 'filesystem'] = 'milvus'
     namespace_id: str = 'kaizen'
     settings: BaseSettings | None = None
 

--- a/kaizen/frontend/client/kaizen_client.py
+++ b/kaizen/frontend/client/kaizen_client.py
@@ -9,14 +9,14 @@ class KaizenClient:
     def __init__(self, config: KaizenConfig | None = None):
         """Initialize the Kaizen client."""
         self.config = config or KaizenConfig()
-        if self.config.provider == 'milvus':
+        if self.config.backend == 'milvus':
             from kaizen.backend.milvus import MilvusKataBackend
             self.backend = MilvusKataBackend(self.config.settings)
-        elif self.config.provider == 'filesystem':
+        elif self.config.backend == 'filesystem':
             from kaizen.backend.filesystem import FilesystemKataBackend
             self.backend = FilesystemKataBackend(self.config.settings)
         else:
-            raise NotImplementedError(f'Kata backend not implemented for provider {self.config.provider}')
+            raise NotImplementedError(f'Kata backend not implemented: {self.config.backend}')
 
     def ready(self) -> bool:
         """Check if the backend is healthy."""


### PR DESCRIPTION
The term "provider" may be confusing with LiteLLM providers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renamed backend configuration variable from `KAIZEN_PROVIDER` to `KAIZEN_BACKEND`. Updated all documentation and environment variable references to reflect the new naming.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->