### PR TITLE
fix: include jinja prompt templates in package artifacts

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include kaizen *.jinja2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,9 @@ where = ["."]
 exclude = ["explorations*"]
 include = ["kaizen*"]
 
+[tool.setuptools.package-data]
+kaizen = ["**/*.jinja2"]
+
 [tool.uv]
 package = true
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package configuration to ensure Jinja2 template files are properly included in package distributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->