### PR TITLE
fix(claude): move marketplace.json back to .claude-plugin directory

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,13 +7,13 @@
   },
   "plugins": [
     {
-      "name": "evolve-lite",
+      "name": "evolve",
       "description": "Learn from conversations with auto-generated guidelines",
       "version": "1.0.0",
       "author": {
         "name": "Vinod Muthusamy"
       },
-      "source": "./plugins/evolve-lite",
+      "source": "./platform-integrations/claude/plugins/evolve-lite",
       "category": "productivity"
     }
   ]


### PR DESCRIPTION
The marketplace.json must be at .claude-plugin/marketplace.json for plugin discovery. Updated the plugin source path accordingly.

For #12 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Updated plugin marketplace metadata, including naming updates and reorganized source configuration to align with current infrastructure standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->