### PR TITLE
fix(claude): rename plugin to evolve-lite in marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "plugins": [
     {
-      "name": "evolve",
+      "name": "evolve-lite",
       "description": "Learn from conversations with auto-generated guidelines",
       "version": "1.0.0",
       "author": {


### PR DESCRIPTION
For #12 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin identifier to "evolve-lite" in marketplace configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->