### PR TITLE
Fix cicd

### DIFF
--- a/.github/workflows/release-github.yaml
+++ b/.github/workflows/release-github.yaml
@@ -87,6 +87,17 @@ jobs:
           cache: 'npm'
           cache-dependency-path: 'altk_evolve/frontend/ui/package-lock.json'
 
+      - name: Build UI
+        working-directory: altk_evolve/frontend/ui
+        run: npm ci && npm run build
+
+      - name: Verify UI build
+        run: |
+          if [ ! -s "altk_evolve/frontend/ui/dist/index.html" ]; then
+            echo "UI build failed: dist/index.html missing or empty"
+            exit 1
+          fi
+
       - name: Run semantic version release
         id: release
         # Adjust tag with desired version if applicable.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,8 +116,6 @@ build_command = '''
     perl -i -pe "s|\]\(docs/([^)]*)\)|](https://github.com/AgentToolkit/altk-evolve/blob/v$NEW_VERSION/docs/\$1)|g" README.md
     sed -i 's/^SCRIPT_VERSION="main"/SCRIPT_VERSION="v'"$NEW_VERSION"'"/' platform-integrations/install.sh
     git add platform-integrations/install.sh
-    (cd altk_evolve/frontend/ui && rm -rf dist && npm ci && npm run build)
-    if [ ! -s "altk_evolve/frontend/ui/dist/index.html" ]; then echo "UI build failed: dist/index.html missing or empty" && exit 1; fi
     uv build
     mv README.md.bak README.md
 '''


### PR DESCRIPTION
move UI build out

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js runtime from version 20 to version 24 for CI/CD testing and frontend build processes
  * Bumped application version to 1.0.5 with integrated version tracking in the release pipeline
  * Enhanced release workflow with frontend build artifact validation to ensure builds complete successfully before deployment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->