### PR TITLE
docs: add demo videos to landing page and create codex tutorial

### DIFF
--- a/docs/examples/hello_world/claude.md
+++ b/docs/examples/hello_world/claude.md
@@ -4,7 +4,7 @@ In this tutorial, we will use Evolve and Claude Code to create a Python script t
 
 ## Video Tutorial
 <div class="video-wrapper">
-    <iframe width="1280" height="720" src="https://www.youtube.com/embed/Hl_tgUdQWrc" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+    <iframe width="1280" height="720" src="https://www.youtube.com/embed/XIlYA79pYp4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 </div>
 
 ## Requirements

--- a/docs/examples/hello_world/codex.md
+++ b/docs/examples/hello_world/codex.md
@@ -1,0 +1,8 @@
+# Hello World with Evolve and Codex
+
+In this tutorial, we will set up Codex with Evolve to demonstrate how agents can learn from past sessions.
+
+## Video Tutorial
+<div class="video-wrapper">
+    <iframe width="1280" height="720" src="https://www.youtube.com/embed/IBc59bLjdi8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ Evolve is a system designed to help agents improve over time by learning from th
 
     [General Installation](installation/index.md){ .md-button }
 
-    [Claude Code](examples/hello_world/claude.md){ .md-button } [IBM Bob](examples/hello_world/bob.md){ .md-button } [Codex](#){ .md-button }
+    [Claude Code](examples/hello_world/claude.md){ .md-button } [IBM Bob](examples/hello_world/bob.md){ .md-button } [Codex](examples/hello_world/codex.md){ .md-button }
 
 === "Full"
     Total Control
@@ -61,6 +61,26 @@ Evolve is a system designed to help agents improve over time by learning from th
 
     - [CLI Reference](reference/cli.md): Manage namespaces, entities, and sync jobs from the command line.
     - [Policies](reference/policies.md): Structured policy entities and how to retrieve them with MCP tools.
+
+## Demos
+
+=== "Claude Code"
+
+    <div class="video-wrapper">
+        <iframe width="1280" height="720" src="https://www.youtube.com/embed/XIlYA79pYp4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+    </div>
+
+=== "IBM Bob"
+
+    <div class="video-wrapper">
+        <iframe width="1280" height="720" src="https://www.youtube.com/embed/YlTJoSJ4eDg" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+    </div>
+
+=== "Codex"
+
+    <div class="video-wrapper">
+        <iframe width="1280" height="720" src="https://www.youtube.com/embed/IBc59bLjdi8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+    </div>
 
 ## How It Works
 

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -77,6 +77,7 @@ nav:
     - Hello World (IBM Bob IDE): examples/hello_world/bob.md
     - Claude Code Demo: tutorials/claude-code-demo.md
     - Starter Example 2 (Claude Code): examples/hello_world/claude.md
+    - Hello World (Codex): examples/hello_world/codex.md
   - Guides:
     - Configuration: guides/configuration.md
     - Phoenix Sync: guides/phoenix-sync.md


### PR DESCRIPTION
- Add tabbed Demos section on index.md with Claude Code, IBM Bob, and Codex videos
- Update Claude Code tutorial video to new demo
- Create Codex hello world tutorial page with video embed
- Link Codex button on landing page to new tutorial
- Add Codex tutorial to mkdocs nav

For #140 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the video tutorial in the "Hello World" documentation with a new video link.
  * Added a new "Hello World with Codex" tutorial page with embedded video.
  * Expanded documentation homepage with a dedicated "Demos" section featuring video tutorials.
  * Updated navigation to include the new Codex tutorial.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->