### PR TITLE
docs: add tutorials landing page and rename demos to Starter Example

### DIFF
--- a/docs/examples/hello_world/claude.md
+++ b/docs/examples/hello_world/claude.md
@@ -1,4 +1,4 @@
-# Starter Example 2 with Evolve and Claude Code
+# Starter Example with Evolve and Claude Code
 Agentic IDEs like Claude Code often repeat the same mistakes over and over again because they start from fresh every time. Using Evolve, we can alleviate this problem.
 In this tutorial, we will use Evolve and Claude Code to create a Python script to automate a simple task. Using Evolve, we will then instruct Claude Code that it should use this script in the future for similar tasks.
 

--- a/docs/examples/hello_world/codex.md
+++ b/docs/examples/hello_world/codex.md
@@ -1,4 +1,4 @@
-# Hello World with Evolve and Codex
+# Starter Example with Evolve and Codex
 
 In this tutorial, we will set up Codex with Evolve to demonstrate how agents can learn from past sessions.
 

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,0 +1,31 @@
+# Tutorials
+
+Get started with Evolve on your platform of choice. Each tutorial walks through installing Evolve and demonstrating how agents learn from past sessions.
+
+## Starter Example with IBM Bob
+
+<div class="video-wrapper">
+    <iframe width="1280" height="720" src="https://www.youtube.com/embed/YlTJoSJ4eDg" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+
+[Full tutorial →](../examples/hello_world/bob.md)
+
+---
+
+## Starter Example with Claude Code
+
+<div class="video-wrapper">
+    <iframe width="1280" height="720" src="https://www.youtube.com/embed/XIlYA79pYp4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+
+[Full tutorial →](../examples/hello_world/claude.md)
+
+---
+
+## Starter Example with Codex
+
+<div class="video-wrapper">
+    <iframe width="1280" height="720" src="https://www.youtube.com/embed/IBc59bLjdi8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+
+[Full tutorial →](../examples/hello_world/codex.md)

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -74,10 +74,10 @@ nav:
   - Home: index.md
   - Installation: installation/index.md
   - Tutorials:
-    - Hello World (IBM Bob IDE): examples/hello_world/bob.md
-    - Claude Code Demo: tutorials/claude-code-demo.md
-    - Starter Example 2 (Claude Code): examples/hello_world/claude.md
-    - Hello World (Codex): examples/hello_world/codex.md
+    - tutorials/index.md
+    - Starter Example (IBM Bob): examples/hello_world/bob.md
+    - Starter Example (Claude Code): examples/hello_world/claude.md
+    - Starter Example (Codex): examples/hello_world/codex.md
   - Guides:
     - Configuration: guides/configuration.md
     - Phoenix Sync: guides/phoenix-sync.md


### PR DESCRIPTION
For #140 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Renamed tutorial pages to "Starter Example" for consistency across IBM Bob, Claude Code, and Codex examples.
  * Added a new Tutorials landing page featuring three starter examples with embedded video content and direct links to full tutorials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->