### PR TITLE
docs: add blog post links to landing page and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 ![arXiv](https://img.shields.io/badge/arXiv-2603.10600-b31b1b) 
 ![License](https://img.shields.io/github/license/AgentToolkit/altk-evolve)
 ![Stars](https://img.shields.io/github/stars/AgentToolkit/altk-evolve?style=social)
+
+**Blog posts:** [IBM announcement](https://www.ibm.com/new/announcements/altk-evolve-on-the-job-learning-for-ai-agents) | [Hugging Face blog](https://huggingface.co/blog/ibm-research/altk-evolve)
 </div>
 
 Evolve is a system designed to help agents improve over time by learning from their trajectories. It uses a combination of an MCP server for tool integration, vector storage for memory, and LLM-based conflict resolution to refine its knowledge base.

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,8 +9,12 @@ hide:
 
 Coding agents repeat the same mistakes because they start fresh every session. Evolve gives agents memory — they learn from what worked and what didn't, so each session is better than the last.
 
-On the AppWorld benchmark, Evolve improved agent reliability by **+8.9 points** overall, with a **74% relative increase** on hard multi-step tasks. See the [full results](results/index.md) and the [paper (arXiv:2603.10600)](https://arxiv.org/abs/2603.10600).
 Evolve is a system designed to help agents improve over time by learning from their trajectories. It uses a combination of an MCP server for tool integration, vector storage for memory, and LLM-based conflict resolution to refine its knowledge base.
+
+On the AppWorld benchmark, Evolve improved agent reliability by **+8.9 points** overall, with a **74% relative increase** on hard multi-step tasks. See the [full results](results/index.md) and the [paper (arXiv:2603.10600)](https://arxiv.org/abs/2603.10600).
+
+**Blog posts:** [IBM announcement](https://www.ibm.com/new/announcements/altk-evolve-on-the-job-learning-for-ai-agents) | [Hugging Face blog](https://huggingface.co/blog/ibm-research/altk-evolve)
+
 
 > [!IMPORTANT]
 > ⭐ **Star the repo**: it helps others discover it.  


### PR DESCRIPTION
For #140 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added links to external blog posts (IBM announcement and Hugging Face blog) in the documentation.
  * Reorganized documentation content and adjusted formatting for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->