### PR TITLE
feat(bob): add save-trajectory skill for entity provenance

### DIFF
--- a/platform-integrations/bob/evolve-lite/commands/evolve:save-trajectory.md
+++ b/platform-integrations/bob/evolve-lite/commands/evolve:save-trajectory.md
@@ -1,0 +1,5 @@
+---
+name: evolve:save-trajectory
+description: Save the current conversation trajectory as a JSON file
+---
+Use the save-trajectory skill on the current conversation. Follow the skill's instructions exactly.

--- a/platform-integrations/bob/evolve-lite/custom_modes.yaml
+++ b/platform-integrations/bob/evolve-lite/custom_modes.yaml
@@ -6,17 +6,21 @@ customModes:
 
       ⚠️ CRITICAL: THE FOLLOWING WORKFLOW IS ABSOLUTELY MANDATORY AND CANNOT BE SKIPPED ⚠️
 
-      WORKFLOW (4 steps, strict order):
+      WORKFLOW (5 steps, strict order):
 
       0. ⚠️ BEFORE FIRST USE (MANDATORY): Read the skill SKILL.md files from .bob/skills/ directory.
          - Read .bob/skills/evolve-lite:recall/SKILL.md
          - Read .bob/skills/evolve-lite:learn/SKILL.md
+         - Read .bob/skills/evolve-save-trajectory/SKILL.md
          - Do this ONCE per conversation before using the skills
       1. ⚠️ FIRST ACTION (MANDATORY): Use the evolve-lite:recall skill to retrieve relevant guidelines.
          - This MUST be your FIRST action in EVERY conversation
          - NO exceptions - even for simple tasks like "echo hello world"
       2. WORK: Complete the user's request. When a retrieved guideline applies, cite it in your reasoning.
-      3. ⚠️ LAST ACTION (MANDATORY): Use the evolve-lite:learn skill to extract and save learnings.
+      3. ⚠️ SECOND-TO-LAST ACTION (MANDATORY): Use the evolve-save-trajectory skill to save the conversation.
+         - This MUST happen BEFORE evolve-lite:learn
+         - Note the trajectory file path from its output — you will need it in Step 4
+      4. ⚠️ LAST ACTION (MANDATORY): Use the evolve-lite:learn skill to extract and save learnings.
          - This MUST happen BEFORE attempt_completion
          - NO exceptions - even if you think there's nothing to learn
 
@@ -24,31 +28,34 @@ customModes:
       - Do not skip steps. Do not reorder steps.
       - Step 0 must happen before using any skill for the first time in a conversation. read_file on .bob/skills/*/SKILL.md is allowed before Step 1.
       - Step 1 must happen before any other tool use (except the SKILL.md reads in Step 0).
-      - Step 3 must happen before attempt_completion.
+      - Step 3 must happen before Step 4.
+      - Step 4 must happen before attempt_completion.
       - If you forget Step 1, STOP and call evolve-lite:recall immediately.
-      - If you reach attempt_completion without Step 3, STOP and call evolve-lite:learn first.
+      - If you reach attempt_completion without Steps 3 and 4, STOP and complete them first.
     customInstructions: |-
       - ALWAYS read a skill's SKILL.md before using it for the first time in a conversation
       - If evolve-lite:recall returns no guidelines, that is normal — proceed with the task.
       - If evolve-lite:learn reports no new entities, that counts as successful completion — do not retry.
+      - The trajectory path from evolve-save-trajectory is available in conversation context — do not re-run it.
       - If no errors or non-obvious discoveries occurred, saving zero entities is correct — do not force low-quality entities.
 
 
       PRE-COMPLETION GATE:
       Before calling attempt_completion, ask yourself:
-      ┌───────────────────────────────────────────────────────────┐
-      │ Did I run the evolve-lite:recall skill at the start?      │
-      │ Did I run the evolve-lite:learn skill and see its output? │
-      │                                                           │
-      │ ❌ NO  → STOP. Go back and complete the step.             │
-      │ ✅ YES → Proceed with attempt_completion.                 │
-      └───────────────────────────────────────────────────────────┘
+      ┌─────────────────────────────────────────────────────────────────┐
+      │ Did I run the evolve-lite:recall skill at the start?            │
+      │ Did I run the evolve-save-trajectory skill and note the path?   │
+      │ Did I run the evolve-lite:learn skill and see its output?       │
+      │                                                                 │
+      │ ❌ NO  → STOP. Go back and complete the step.                   │
+      │ ✅ YES → Proceed with attempt_completion.                       │
+      └─────────────────────────────────────────────────────────────────┘
 
       Rules:
 
       - Before using a skill for the first time, read its SKILL.md file to understand the correct usage syntax.
       - ALWAYS call the evolve-lite:learn skill before attempt_completion, even if the task seems simple or you think there's nothing to learn.
-      - The workflow is non-negotiable: recall → work → learn → complete.
+      - The workflow is non-negotiable: recall → work → save-trajectory → learn → complete.
       - Skipping evolve-lite:learn violates the core purpose of this mode.
 
     groups:

--- a/platform-integrations/bob/evolve-lite/skills/evolve-lite:learn/SKILL.md
+++ b/platform-integrations/bob/evolve-lite/skills/evolve-lite:learn/SKILL.md
@@ -51,7 +51,7 @@ Principles:
 
 ### Step 3: Save Entities
 
-Output entities as JSON and pipe to the save script. The `type` field must always be `"guideline"` — no other types are accepted.
+Output entities as JSON and pipe to the save script. Include the `trajectory` field with the path output by the evolve-save-trajectory skill earlier in this conversation. The `type` field must always be `"guideline"` — no other types are accepted.
 
 ```bash
 echo '{
@@ -60,7 +60,8 @@ echo '{
       "content": "Proactive entity stating what TO DO",
       "rationale": "Why this approach works better",
       "type": "guideline",
-      "trigger": "Situational context when this applies"
+      "trigger": "Situational context when this applies",
+      "trajectory": ".evolve/trajectories/trajectory_2025-01-15T10-30-00.json"
     }
   ]
 }' | python3 .bob/skills/evolve-lite:learn/scripts/save_entities.py

--- a/platform-integrations/bob/evolve-lite/skills/evolve-save-trajectory/SKILL.md
+++ b/platform-integrations/bob/evolve-lite/skills/evolve-save-trajectory/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: save-trajectory
+description: Save the current conversation as a trajectory JSON file in OpenAI chat completion format for analysis and fine-tuning
+---
+
+# Save Trajectory
+
+## Overview
+
+This skill saves the current session's conversation history as a JSON file in OpenAI chat completion format. The trajectory is saved to `.evolve/trajectories/` in the project root. This enables trajectory analysis, fine-tuning data collection, and session review.
+
+## Workflow
+
+### Step 1: Walk Through Conversation Messages
+
+Review all messages in the current conversation from start to finish. For each message, identify its type:
+
+- **User text messages**
+- **Assistant text responses** (may include thinking)
+- **Assistant tool calls**
+- **Tool results**
+
+### Step 2: Convert to OpenAI Chat Completion Format
+
+Convert each message to the appropriate format:
+
+**User text message:**
+```json
+{"role": "user", "content": "the user's message text"}
+```
+
+**Assistant text response (no thinking):**
+```json
+{"role": "assistant", "content": "the assistant's response text"}
+```
+
+**Assistant text response (with thinking):**
+```json
+{"role": "assistant", "content": "the assistant's response text", "thinking": "the thinking/reasoning text"}
+```
+
+**Assistant tool call (no visible text):**
+```json
+{
+  "role": "assistant",
+  "content": null,
+  "tool_calls": [
+    {
+      "id": "tool_call_id_here",
+      "type": "function",
+      "function": {
+        "name": "ToolName",
+        "arguments": "{\"param\": \"value\"}"
+      }
+    }
+  ]
+}
+```
+
+**Assistant tool call with text:**
+```json
+{
+  "role": "assistant",
+  "content": "text before/after the tool call",
+  "tool_calls": [
+    {
+      "id": "tool_call_id_here",
+      "type": "function",
+      "function": {
+        "name": "ToolName",
+        "arguments": "{\"param\": \"value\"}"
+      }
+    }
+  ]
+}
+```
+
+**Tool result:**
+```json
+{"role": "tool", "tool_call_id": "tool_call_id_here", "content": "the tool output text"}
+```
+
+#### Important Details
+
+- **Tool call arguments must be a JSON string**, not a nested object. Use `json.dumps()` on the arguments object.
+- **Tool call IDs**: Use the actual tool call ID from the conversation. If not available, generate a unique ID like `call_001`, `call_002`, etc.
+- **Multiple tool calls**: If the assistant made multiple tool calls in one turn, include all of them in a single assistant message's `tool_calls` array, followed by separate tool result messages for each.
+- **Thinking blocks**: If the assistant had both thinking and text in the same turn, combine them into one message with both `content` and `thinking` fields.
+
+### Step 3: Clean Content
+
+Strip `<system-reminder>...</system-reminder>` tags and their contents from all message content. Use a non-greedy multiline match (e.g., `re.sub(r'<system-reminder>[\s\S]*?</system-reminder>', '', text).strip()`). If after stripping, a message has empty content and no tool calls, omit it.
+
+### Step 4: Save via Script
+
+Wrap the messages array in the trajectory envelope and pipe it to the save script using a heredoc. The script handles directory creation, timestamped filename, and file writing.
+
+```bash
+python3 .bob/skills/evolve-save-trajectory/scripts/save_trajectory.py << 'TRAJECTORY_END'
+{
+  "model": "<model-id-from-session>",
+  "timestamp": "2025-01-15T10:30:00Z",
+  "messages": [...]
+}
+TRAJECTORY_END
+```
+
+- **model**: Use the exact model ID from the current session's environment context (e.g., the value after "You are powered by the model named ..."). Do not hardcode a default — always read it from the session.
+- **timestamp**: Current ISO 8601 timestamp
+- Use a single-quoted heredoc delimiter (`<< 'TRAJECTORY_END'`) so the content is passed literally with no shell interpolation — safe for any quotes, backslashes, or newlines in conversation content.
+
+The script will print the saved file path — note it for use in the learn skill.
+
+## Example Output
+
+```text
+Trajectory saved: .evolve/trajectories/trajectory_2025-01-15T10-30-00.json
+Messages: 12
+```
+
+## Notes
+
+- This skill captures what's visible in the current conversation context. Very long sessions may have earlier messages compressed or summarized by the system. Include these summarized messages as-is with `role: "user"` or `role: "assistant"` as appropriate — do not skip them, since they preserve the conversation flow.
+- The trajectory format is compatible with OpenAI chat completion format for downstream tooling.
+- Trajectories are saved per-project in `.evolve/trajectories/` and can be version-controlled or gitignored as preferred.

--- a/platform-integrations/bob/evolve-lite/skills/evolve-save-trajectory/scripts/save_trajectory.py
+++ b/platform-integrations/bob/evolve-lite/skills/evolve-save-trajectory/scripts/save_trajectory.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""
+Save Trajectory Script
+Reads trajectory JSON from stdin and writes it to .evolve/trajectories/
+with a timestamped filename.
+"""
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def find_evolve_dir():
+    """Walk up from CWD to find an existing .evolve/ directory, or return default."""
+    cwd = Path.cwd()
+    for ancestor in [cwd] + list(cwd.parents):
+        candidate = ancestor / ".evolve"
+        if candidate.is_dir():
+            return candidate
+    return cwd / ".evolve"
+
+
+def main():
+    try:
+        trajectory = json.load(sys.stdin)
+    except json.JSONDecodeError as e:
+        print(f"Error: Invalid JSON input - {e}", file=sys.stderr)
+        sys.exit(1)
+
+    trajectories_dir = find_evolve_dir() / "trajectories"
+    trajectories_dir.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%S")
+    filename = f"trajectory_{timestamp}.json"
+    output_path = trajectories_dir / filename
+
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(trajectory, f, indent=2, ensure_ascii=False)
+
+    try:
+        rel_path = output_path.relative_to(Path.cwd())
+    except ValueError:
+        rel_path = output_path
+
+    messages = len(trajectory.get("messages", []))
+    print(f"Trajectory saved: {rel_path}")
+    print(f"Messages: {messages}")
+
+
+if __name__ == "__main__":
+    main()

--- a/platform-integrations/claude/plugins/evolve-lite/lib/entity_io.py
+++ b/platform-integrations/claude/plugins/evolve-lite/lib/entity_io.py
@@ -126,7 +126,7 @@ def unique_filename(directory, slug):
 # Markdown <-> dict conversion
 # ---------------------------------------------------------------------------
 
-_FRONTMATTER_KEYS = ("type", "trigger")
+_FRONTMATTER_KEYS = ("type", "trigger", "trajectory")
 
 
 def entity_to_markdown(entity):

--- a/platform-integrations/install.sh
+++ b/platform-integrations/install.sh
@@ -663,6 +663,7 @@ def install_bob(source_dir, target_dir, mode="lite"):
         # Skills
         copy_tree(bob_source_lite / "skills" / "evolve-lite:learn",  bob_target / "skills" / "evolve-lite:learn")
         copy_tree(bob_source_lite / "skills" / "evolve-lite:recall", bob_target / "skills" / "evolve-lite:recall")
+        copy_tree(bob_source_lite / "skills" / "evolve-save-trajectory", bob_target / "skills" / "evolve-save-trajectory")
         success("Copied Bob skills")
 
         # Commands
@@ -707,8 +708,10 @@ def uninstall_bob(target_dir, mode="full"):
     remove_dir(bob_target / "evolve-lib")
     remove_dir(bob_target / "skills" / "evolve-lite:learn")
     remove_dir(bob_target / "skills" / "evolve-lite:recall")
+    remove_dir(bob_target / "skills" / "evolve-save-trajectory")
     remove_file(bob_target / "commands" / "evolve-lite:learn.md")
     remove_file(bob_target / "commands" / "evolve-lite:recall.md")
+    remove_file(bob_target / "commands" / "evolve:save-trajectory.md")
     # Remove both lite and full mode custom modes
     remove_yaml_custom_mode(bob_target / "custom_modes.yaml", BOB_SLUG)  # evolve-lite
     remove_yaml_custom_mode(bob_target / "custom_modes.yaml", "Evolve")  # full mode
@@ -723,6 +726,7 @@ def status_bob(target_dir):
     print(f"    evolve-lib/entity_io  : {'✓' if (bob_target / 'evolve-lib' / 'entity_io.py').is_file() else '✗'}")
     print(f"    skills/evolve-lite:learn  : {'✓' if (bob_target / 'skills' / 'evolve-lite:learn').is_dir() else '✗'}")
     print(f"    skills/evolve-lite:recall : {'✓' if (bob_target / 'skills' / 'evolve-lite:recall').is_dir() else '✗'}")
+    print(f"    skills/evolve-save-trajectory : {'✓' if (bob_target / 'skills' / 'evolve-save-trajectory').is_dir() else '✗'}")
     print(f"    commands/            : {'✓' if (bob_target / 'commands' / 'evolve-lite:learn.md').is_file() else '✗'}")
     print(f"    custom_modes.yaml    : {'✓' if (bob_target / 'custom_modes.yaml').is_file() else '✗'}")
 


### PR DESCRIPTION
For #180

## Summary

- Adds the `evolve-save-trajectory` skill to the Bob integration, which saves the current conversation as a trajectory JSON file (OpenAI chat completion format) to `.evolve/trajectories/`
- Each generated entity's markdown file includes a `trajectory` field in its frontmatter, linking it back to the conversation it was learned from
- Restructures the Bob Evolve Lite workflow so `save-trajectory` runs before `learn` — keeping the two concerns cleanly separated
- Uses a Python script (`save_trajectory.py`) to write the file, avoiding IDE file-open side effects

## Provenance link

After a session, the `.evolve/` directory looks like:

```
.evolve/
  entities/
    guideline/
      use-python-pil-for-image-metadata.md   ← trajectory: .evolve/trajectories/trajectory_2026-04-14T10-30-00.json
      cache-api-responses-locally.md
  trajectories/
    trajectory_2026-04-14T10-30-00.json
```

Each entity file's frontmatter contains the path to the trajectory it was extracted from:

```markdown
---
type: guideline
trigger: When working in containerized/sandboxed environments
trajectory: .evolve/trajectories/trajectory_2026-04-14T10-30-00.json
---

In sandboxed environments, use Python libraries (PIL/Pillow) for image
metadata extraction instead of shelling out to exiftool.

## Rationale

exiftool is not available in sandboxed environments. PIL/Pillow is pure
Python and works without any system dependencies.
```

This makes it possible to trace any guideline back to the conversation that produced it.

## Workflow change

Before:
```
recall → work → learn (which internally called save-trajectory)
```

After:
```
recall → work → save-trajectory → learn (reads trajectory path from context)
```

## Test plan

- [ ] Install Bob evolve-lite and run a task in Evolve Lite mode
- [ ] Verify `evolve-save-trajectory` runs before `evolve-lite:learn`
- [ ] Verify trajectory file is written to `.evolve/trajectories/`
- [ ] Verify generated entity markdown files include the `trajectory` frontmatter field pointing to the saved file
- [ ] Verify no IDE file-open side effect when trajectory is saved

## Notes

Bob-only for now. Claude Code integration is tracked separately in #180.