### PR TITLE
feat(evolve-lite): add entity sharing skills and CI tests

### DIFF
--- a/platform-integrations/claude/plugins/evolve-lite/.claude-plugin/plugin.json
+++ b/platform-integrations/claude/plugins/evolve-lite/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "evolve-lite",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Learn from conversations with auto-generated entities",
   "author": {
     "name": "Vinod Muthusamy"

--- a/platform-integrations/claude/plugins/evolve-lite/README.md
+++ b/platform-integrations/claude/plugins/evolve-lite/README.md
@@ -90,7 +90,7 @@ Others can then subscribe using that remote URL.
 
 Use `/evolve-lite:subscribe` to pull in guidelines from another user's public repo:
 
-```
+```text
 /evolve-lite:subscribe
 > Remote URL: git@github.com:alice/evolve-guidelines.git
 > Short name: alice
@@ -102,7 +102,7 @@ The repo is cloned to `.evolve/subscribed/alice/` and mirrored into `.evolve/ent
 
 Use `/evolve-lite:sync` to pull the latest changes from all subscribed repos:
 
-```
+```text
 /evolve-lite:sync
 > Synced 2 repo(s): alice (+2 added, 0 updated, 0 removed), bob (+0 added, 1 updated, 0 removed)
 ```
@@ -113,7 +113,7 @@ If `sync.on_session_start: true` is set in config, this runs automatically at th
 
 Use `/evolve-lite:unsubscribe` to remove a subscription and delete its locally cloned files:
 
-```
+```text
 /evolve-lite:unsubscribe
 > Which subscription would you like to remove?
 > 1. alice

--- a/platform-integrations/claude/plugins/evolve-lite/README.md
+++ b/platform-integrations/claude/plugins/evolve-lite/README.md
@@ -55,6 +55,88 @@ You can also manually invoke `/evolve-lite:learn` at any time.
 > - Set a specific `"matcher"` string to restrict triggering to prompts that contain that text.
 > - Reduce `"timeout"` to cap how long the learn step can run.
 
+## Sharing Guidelines
+
+Evolve Lite supports sharing guidelines between users via public Git repositories. You can publish your own guidelines so others can subscribe to them, and subscribe to guidelines published by others.
+
+### Setup
+
+Sharing requires an `evolve.config.yaml` at the project root. If it doesn't exist, the subscribe or publish skills will prompt you to create one. Minimal structure:
+
+```yaml
+identity:
+  user: yourname          # used to stamp ownership on published guidelines
+public_repo:
+  remote: git@github.com:yourname/evolve-guidelines.git
+  branch: main
+subscriptions: []
+sync:
+  on_session_start: true  # auto-sync on each session start
+```
+
+The `.evolve/` directory is kept out of version control — the skills automatically add it to `.gitignore`.
+
+### Publishing Guidelines
+
+Use `/evolve-lite:publish` to share one or more of your local guidelines with others:
+
+1. The skill lists files in `.evolve/entities/guideline/`
+2. You pick which ones to publish
+3. Each selected file is copied to `.evolve/public/`, stamped with your username as the owner, committed, and pushed to your `public_repo.remote`
+
+Others can then subscribe using that remote URL.
+
+### Subscribing to Guidelines
+
+Use `/evolve-lite:subscribe` to pull in guidelines from another user's public repo:
+
+```
+/evolve-lite:subscribe
+> Remote URL: git@github.com:alice/evolve-guidelines.git
+> Short name: alice
+```
+
+The repo is cloned to `.evolve/subscribed/alice/` and mirrored into `.evolve/entities/subscribed/alice/` so recall picks them up immediately.
+
+### Syncing Subscriptions
+
+Use `/evolve-lite:sync` to pull the latest changes from all subscribed repos:
+
+```
+/evolve-lite:sync
+> Synced 2 repo(s): alice (+2 added, 0 updated, 0 removed), bob (+0 added, 1 updated, 0 removed)
+```
+
+If `sync.on_session_start: true` is set in config, this runs automatically at the start of each session.
+
+### Unsubscribing
+
+Use `/evolve-lite:unsubscribe` to remove a subscription and delete its locally cloned files:
+
+```
+/evolve-lite:unsubscribe
+> Which subscription would you like to remove?
+> 1. alice
+> 2. bob
+```
+
+The skill confirms before deleting `.evolve/subscribed/{name}/` and its mirror under `.evolve/entities/subscribed/{name}/`.
+
+### Sharing Storage Layout
+
+```text
+.evolve/
+  public/                     # git repo pushed to your public remote
+    guideline-name.md         # owner-stamped guideline
+  subscribed/
+    alice/                    # git clone of alice's public repo
+      her-guideline.md
+  entities/
+    subscribed/
+      alice/                  # mirrored for recall
+        her-guideline.md
+```
+
 ## Example Walkthrough
 
 See the [Evolve Lite guide](../../../../docs/integrations/claude/evolve-lite.md#example-walkthrough) for a step-by-step example showing the full learn-then-recall loop across two sessions.

--- a/platform-integrations/claude/plugins/evolve-lite/README.md
+++ b/platform-integrations/claude/plugins/evolve-lite/README.md
@@ -109,6 +109,8 @@ Use `/evolve-lite:sync` to pull the latest changes from all subscribed repos:
 
 If `sync.on_session_start: true` is set in config, this runs automatically at the start of each session.
 
+> **Note:** Sync uses `git fetch` + `git reset --hard` on each cloned subscription repo, so local state always matches the remote exactly. Accidentally deleted or modified files are automatically restored on the next sync.
+
 ### Unsubscribing
 
 Use `/evolve-lite:unsubscribe` to remove a subscription and delete its locally cloned files:

--- a/platform-integrations/claude/plugins/evolve-lite/hooks/hooks.json
+++ b/platform-integrations/claude/plugins/evolve-lite/hooks/hooks.json
@@ -11,6 +11,17 @@
         ]
       }
     ],
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/skills/sync/scripts/sync.py --quiet"
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "matcher": "",

--- a/platform-integrations/claude/plugins/evolve-lite/lib/audit.py
+++ b/platform-integrations/claude/plugins/evolve-lite/lib/audit.py
@@ -13,7 +13,7 @@ def append(project_root=".", **fields):
     """
     path = pathlib.Path(project_root) / ".evolve" / "audit.log"
     path.parent.mkdir(parents=True, exist_ok=True)
-    entry = {"ts": datetime.datetime.now(datetime.UTC).isoformat().replace("+00:00", "Z"), **fields}
+    entry = {**fields, "ts": datetime.datetime.now(datetime.UTC).isoformat().replace("+00:00", "Z")}
     with path.open("a", encoding="utf-8") as f:
         f.write(json.dumps(entry) + "\n")
 

--- a/platform-integrations/claude/plugins/evolve-lite/lib/audit.py
+++ b/platform-integrations/claude/plugins/evolve-lite/lib/audit.py
@@ -1,4 +1,5 @@
 """Append-only audit log writer for .evolve/audit.log."""
+
 import datetime
 import json
 import pathlib
@@ -20,6 +21,7 @@ def append(project_root=".", **fields):
 
 if __name__ == "__main__":
     import tempfile
+
     with tempfile.TemporaryDirectory() as d:
         append(project_root=d, action="test", actor="alice")
         log_path = __import__("pathlib").Path(d) / ".evolve" / "audit.log"

--- a/platform-integrations/claude/plugins/evolve-lite/lib/audit.py
+++ b/platform-integrations/claude/plugins/evolve-lite/lib/audit.py
@@ -1,0 +1,31 @@
+"""Append-only audit log writer for .evolve/audit.log."""
+import datetime
+import json
+import pathlib
+
+
+def append(project_root=".", **fields):
+    """Append a JSON audit entry to .evolve/audit.log.
+
+    Args:
+        project_root: Root directory that contains .evolve/.
+        **fields: Arbitrary key-value fields to include in the log entry.
+    """
+    path = pathlib.Path(project_root) / ".evolve" / "audit.log"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    entry = {"ts": datetime.datetime.now(datetime.UTC).isoformat().replace("+00:00", "Z"), **fields}
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+
+
+if __name__ == "__main__":
+    import tempfile
+    with tempfile.TemporaryDirectory() as d:
+        append(project_root=d, action="test", actor="alice")
+        log_path = __import__("pathlib").Path(d) / ".evolve" / "audit.log"
+        line = log_path.read_text(encoding="utf-8").strip()
+        entry = __import__("json").loads(line)
+        assert entry["action"] == "test"
+        assert entry["actor"] == "alice"
+        assert "ts" in entry
+    print("audit.py ok")

--- a/platform-integrations/claude/plugins/evolve-lite/lib/config.py
+++ b/platform-integrations/claude/plugins/evolve-lite/lib/config.py
@@ -4,12 +4,14 @@ pyyaml is not assumed to be installed. This module implements a minimal
 YAML reader/writer that handles the flat and single-level-nested structures
 used by evolve-lite config files (scalars and lists of scalar-valued dicts).
 """
+
 import pathlib
 
 
 # ---------------------------------------------------------------------------
 # Minimal YAML helpers (no pyyaml dependency)
 # ---------------------------------------------------------------------------
+
 
 def _strip_comment_preserving_quotes(line):
     """Strip a trailing YAML comment (#...) while preserving # inside quotes."""
@@ -21,10 +23,10 @@ def _strip_comment_preserving_quotes(line):
             in_double = not in_double
         elif c == "'" and not in_double:
             in_single = not in_single
-        elif c == '#' and not in_single and not in_double:
+        elif c == "#" and not in_single and not in_double:
             break
         result.append(c)
-    return ''.join(result).rstrip()
+    return "".join(result).rstrip()
 
 
 def _parse_block(lines, start, parent_indent):
@@ -180,8 +182,7 @@ def _cast(value):
     if value == "[]":
         return []
     # Strip surrounding quotes
-    if (value.startswith('"') and value.endswith('"')) or \
-       (value.startswith("'") and value.endswith("'")):
+    if (value.startswith('"') and value.endswith('"')) or (value.startswith("'") and value.endswith("'")):
         return value[1:-1]
     return value
 
@@ -256,13 +257,12 @@ def save_config(cfg, project_root="."):
 if __name__ == "__main__":
     # Quick self-test
     import tempfile, os
+
     with tempfile.TemporaryDirectory() as d:
         cfg = {
             "identity": {"user": "alice"},
             "public_repo": {"remote": "git@github.com:alice/evolve.git", "branch": "main"},
-            "subscriptions": [
-                {"name": "bob", "remote": "git@github.com:bob/evolve.git", "branch": "main"}
-            ],
+            "subscriptions": [{"name": "bob", "remote": "git@github.com:bob/evolve.git", "branch": "main"}],
             "sync": {"on_session_start": True},
         }
         save_config(cfg, d)

--- a/platform-integrations/claude/plugins/evolve-lite/lib/config.py
+++ b/platform-integrations/claude/plugins/evolve-lite/lib/config.py
@@ -1,0 +1,255 @@
+"""Shared config reader/writer for evolve.config.yaml (project root).
+
+pyyaml is not assumed to be installed. This module implements a minimal
+YAML reader/writer that handles the flat and single-level-nested structures
+used by evolve-lite config files (scalars and lists of scalar-valued dicts).
+"""
+import pathlib
+
+
+# ---------------------------------------------------------------------------
+# Minimal YAML helpers (no pyyaml dependency)
+# ---------------------------------------------------------------------------
+
+def _parse_block(lines, start, parent_indent):
+    """Parse an indented block starting at `start`.
+
+    Returns (value, next_index) where value is either:
+    - a list (if block starts with '- ')
+    - a dict (if block contains 'key: value' pairs at the same indent)
+
+    parent_indent is the indent level of the parent key line.
+    """
+    i = start
+    # Peek ahead to determine type: list or mapping
+    # Skip blank lines first
+    while i < len(lines):
+        stripped = lines[i].split("#", 1)[0].rstrip()
+        if stripped.strip():
+            break
+        i += 1
+    if i >= len(lines):
+        return {}, i
+
+    first_content = lines[i].split("#", 1)[0].rstrip()
+    block_indent = len(first_content) - len(first_content.lstrip())
+
+    if block_indent <= parent_indent:
+        # Nothing actually indented under this key
+        return {}, i
+
+    if first_content.strip().startswith("- "):
+        # List
+        items = []
+        while i < len(lines):
+            raw = lines[i].split("#", 1)[0].rstrip()
+            if not raw.strip():
+                i += 1
+                continue
+            cur_indent = len(raw) - len(raw.lstrip())
+            if cur_indent < block_indent:
+                break
+            content = raw.strip()
+            if content.startswith("- "):
+                item_text = content[2:].strip()
+                if ":" in item_text:
+                    item_dict = {}
+                    ik, _, iv = item_text.partition(":")
+                    item_dict[ik.strip()] = _cast(iv.strip())
+                    i += 1
+                    # Collect more keys at deeper indent for this list item
+                    while i < len(lines):
+                        cont = lines[i].split("#", 1)[0].rstrip()
+                        if not cont.strip():
+                            i += 1
+                            continue
+                        cont_indent = len(cont) - len(cont.lstrip())
+                        if cont_indent <= cur_indent:
+                            break
+                        cont_content = cont.strip()
+                        if ":" in cont_content:
+                            ck, _, cv = cont_content.partition(":")
+                            item_dict[ck.strip()] = _cast(cv.strip())
+                        i += 1
+                    items.append(item_dict)
+                else:
+                    items.append(_cast(item_text))
+                    i += 1
+            else:
+                i += 1
+        return items, i
+    else:
+        # Nested mapping
+        mapping = {}
+        while i < len(lines):
+            raw = lines[i].split("#", 1)[0].rstrip()
+            if not raw.strip():
+                i += 1
+                continue
+            cur_indent = len(raw) - len(raw.lstrip())
+            if cur_indent < block_indent:
+                break
+            content = raw.strip()
+            if ":" in content:
+                k, _, v = content.partition(":")
+                k = k.strip()
+                v = v.strip()
+                if v:
+                    mapping[k] = _cast(v)
+                    i += 1
+                else:
+                    # nested further — recurse
+                    nested, i = _parse_block(lines, i + 1, cur_indent)
+                    mapping[k] = nested
+            else:
+                i += 1
+        return mapping, i
+
+
+def _parse_yaml(text):
+    """Parse a minimal YAML subset into a Python dict.
+
+    Supports:
+    - Top-level ``key: value`` scalar pairs
+    - Top-level ``key:`` with indented nested mappings or list items
+    - Comments (#) are stripped
+    """
+    result = {}
+    lines = text.splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.split("#", 1)[0].rstrip()
+        if not stripped.strip():
+            i += 1
+            continue
+        indent = len(stripped) - len(stripped.lstrip())
+        if indent > 0:
+            # Skip lines that belong to a block we already consumed
+            i += 1
+            continue
+        key, sep, value = stripped.partition(":")
+        key = key.strip()
+        value = value.strip()
+        if not key:
+            i += 1
+            continue
+        if value:
+            result[key] = _cast(value)
+            i += 1
+        else:
+            # Block value (list or nested mapping)
+            block_val, i = _parse_block(lines, i + 1, 0)
+            result[key] = block_val
+    return result
+
+
+def _cast(value):
+    """Cast a YAML scalar string to an appropriate Python type."""
+    if value in ("true", "True", "yes"):
+        return True
+    if value in ("false", "False", "no"):
+        return False
+    if value in ("null", "~", ""):
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        pass
+    try:
+        return float(value)
+    except ValueError:
+        pass
+    # Empty list literal
+    if value == "[]":
+        return []
+    # Strip surrounding quotes
+    if (value.startswith('"') and value.endswith('"')) or \
+       (value.startswith("'") and value.endswith("'")):
+        return value[1:-1]
+    return value
+
+
+def _dump_yaml(obj, indent=0):
+    """Serialize a Python dict/list to a minimal YAML string."""
+    lines = []
+    prefix = "  " * indent
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            if isinstance(v, dict):
+                lines.append(f"{prefix}{k}:")
+                lines.extend(_dump_yaml(v, indent + 1).splitlines())
+            elif isinstance(v, list):
+                if not v:
+                    lines.append(f"{prefix}{k}: []")
+                    continue
+                lines.append(f"{prefix}{k}:")
+                for item in v:
+                    if isinstance(item, dict):
+                        first = True
+                        for ik, iv in item.items():
+                            if first:
+                                lines.append(f"{prefix}  - {ik}: {_scalar(iv)}")
+                                first = False
+                            else:
+                                lines.append(f"{prefix}    {ik}: {_scalar(iv)}")
+                    else:
+                        lines.append(f"{prefix}  - {_scalar(item)}")
+            else:
+                lines.append(f"{prefix}{k}: {_scalar(v)}")
+    return "\n".join(lines)
+
+
+def _scalar(v):
+    if v is True:
+        return "true"
+    if v is False:
+        return "false"
+    if v is None:
+        return "null"
+    return str(v)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def load_config(project_root="."):
+    """Read evolve.config.yaml from the project root and return a dict.
+
+    Returns {} if the file does not exist.
+    """
+    path = pathlib.Path(project_root) / "evolve.config.yaml"
+    if not path.exists():
+        return {}
+    text = path.read_text(encoding="utf-8")
+    return _parse_yaml(text)
+
+
+def save_config(cfg, project_root="."):
+    """Write *cfg* dict to evolve.config.yaml in the project root."""
+    path = pathlib.Path(project_root) / "evolve.config.yaml"
+    content = _dump_yaml(cfg)
+    path.write_text(content + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    # Quick self-test
+    import tempfile, os
+    with tempfile.TemporaryDirectory() as d:
+        cfg = {
+            "identity": {"user": "alice"},
+            "public_repo": {"remote": "git@github.com:alice/evolve.git", "branch": "main"},
+            "subscriptions": [
+                {"name": "bob", "remote": "git@github.com:bob/evolve.git", "branch": "main"}
+            ],
+            "sync": {"on_session_start": True},
+        }
+        save_config(cfg, d)
+        loaded = load_config(d)
+        assert loaded["identity"]["user"] == "alice", loaded
+        assert loaded["sync"]["on_session_start"] is True, loaded
+        assert isinstance(loaded["subscriptions"], list), loaded
+        assert loaded["subscriptions"][0]["name"] == "bob", loaded
+    print("config.py ok")

--- a/platform-integrations/claude/plugins/evolve-lite/lib/config.py
+++ b/platform-integrations/claude/plugins/evolve-lite/lib/config.py
@@ -256,7 +256,7 @@ def save_config(cfg, project_root="."):
 
 if __name__ == "__main__":
     # Quick self-test
-    import tempfile, os
+    import tempfile
 
     with tempfile.TemporaryDirectory() as d:
         cfg = {

--- a/platform-integrations/claude/plugins/evolve-lite/lib/config.py
+++ b/platform-integrations/claude/plugins/evolve-lite/lib/config.py
@@ -11,6 +11,22 @@ import pathlib
 # Minimal YAML helpers (no pyyaml dependency)
 # ---------------------------------------------------------------------------
 
+def _strip_comment_preserving_quotes(line):
+    """Strip a trailing YAML comment (#...) while preserving # inside quotes."""
+    result = []
+    in_single = False
+    in_double = False
+    for c in line:
+        if c == '"' and not in_single:
+            in_double = not in_double
+        elif c == "'" and not in_double:
+            in_single = not in_single
+        elif c == '#' and not in_single and not in_double:
+            break
+        result.append(c)
+    return ''.join(result).rstrip()
+
+
 def _parse_block(lines, start, parent_indent):
     """Parse an indented block starting at `start`.
 
@@ -24,14 +40,14 @@ def _parse_block(lines, start, parent_indent):
     # Peek ahead to determine type: list or mapping
     # Skip blank lines first
     while i < len(lines):
-        stripped = lines[i].split("#", 1)[0].rstrip()
+        stripped = _strip_comment_preserving_quotes(lines[i])
         if stripped.strip():
             break
         i += 1
     if i >= len(lines):
         return {}, i
 
-    first_content = lines[i].split("#", 1)[0].rstrip()
+    first_content = _strip_comment_preserving_quotes(lines[i])
     block_indent = len(first_content) - len(first_content.lstrip())
 
     if block_indent <= parent_indent:
@@ -42,7 +58,7 @@ def _parse_block(lines, start, parent_indent):
         # List
         items = []
         while i < len(lines):
-            raw = lines[i].split("#", 1)[0].rstrip()
+            raw = _strip_comment_preserving_quotes(lines[i])
             if not raw.strip():
                 i += 1
                 continue
@@ -59,7 +75,7 @@ def _parse_block(lines, start, parent_indent):
                     i += 1
                     # Collect more keys at deeper indent for this list item
                     while i < len(lines):
-                        cont = lines[i].split("#", 1)[0].rstrip()
+                        cont = _strip_comment_preserving_quotes(lines[i])
                         if not cont.strip():
                             i += 1
                             continue
@@ -82,7 +98,7 @@ def _parse_block(lines, start, parent_indent):
         # Nested mapping
         mapping = {}
         while i < len(lines):
-            raw = lines[i].split("#", 1)[0].rstrip()
+            raw = _strip_comment_preserving_quotes(lines[i])
             if not raw.strip():
                 i += 1
                 continue
@@ -119,7 +135,7 @@ def _parse_yaml(text):
     i = 0
     while i < len(lines):
         line = lines[i]
-        stripped = line.split("#", 1)[0].rstrip()
+        stripped = _strip_comment_preserving_quotes(line)
         if not stripped.strip():
             i += 1
             continue
@@ -207,6 +223,9 @@ def _scalar(v):
         return "false"
     if v is None:
         return "null"
+    if isinstance(v, str):
+        escaped = v.replace("\\", "\\\\").replace('"', '\\"')
+        return f'"{escaped}"'
     return str(v)
 
 

--- a/platform-integrations/claude/plugins/evolve-lite/lib/config.py
+++ b/platform-integrations/claude/plugins/evolve-lite/lib/config.py
@@ -168,7 +168,7 @@ def _cast(value):
         return True
     if value in ("false", "False", "no"):
         return False
-    if value in ("null", "~", ""):
+    if value in ("null", "~"):
         return None
     try:
         return int(value)
@@ -235,12 +235,13 @@ def _scalar(v):
 # ---------------------------------------------------------------------------
 
 
-def load_config(project_root="."):
+def load_config(project_root=".", filepath=None):
     """Read evolve.config.yaml from the project root and return a dict.
 
     Returns {} if the file does not exist.
+    If filepath is given, it is used directly instead of project_root.
     """
-    path = pathlib.Path(project_root) / "evolve.config.yaml"
+    path = pathlib.Path(filepath) if filepath is not None else pathlib.Path(project_root) / "evolve.config.yaml"
     if not path.exists():
         return {}
     text = path.read_text(encoding="utf-8")

--- a/platform-integrations/claude/plugins/evolve-lite/lib/config.py
+++ b/platform-integrations/claude/plugins/evolve-lite/lib/config.py
@@ -168,7 +168,7 @@ def _cast(value):
         return True
     if value in ("false", "False", "no"):
         return False
-    if value in ("null", "~"):
+    if value in ("null", "~", ""):
         return None
     try:
         return int(value)

--- a/platform-integrations/claude/plugins/evolve-lite/lib/entity_io.py
+++ b/platform-integrations/claude/plugins/evolve-lite/lib/entity_io.py
@@ -126,7 +126,7 @@ def unique_filename(directory, slug):
 # Markdown <-> dict conversion
 # ---------------------------------------------------------------------------
 
-_FRONTMATTER_KEYS = ("type", "trigger", "trajectory", "owner", "visibility", "published_at")
+_FRONTMATTER_KEYS = ("type", "trigger", "trajectory", "owner", "visibility", "published_at", "source")
 
 
 def entity_to_markdown(entity):

--- a/platform-integrations/claude/plugins/evolve-lite/lib/entity_io.py
+++ b/platform-integrations/claude/plugins/evolve-lite/lib/entity_io.py
@@ -126,7 +126,7 @@ def unique_filename(directory, slug):
 # Markdown <-> dict conversion
 # ---------------------------------------------------------------------------
 
-_FRONTMATTER_KEYS = ("type", "trigger", "trajectory")
+_FRONTMATTER_KEYS = ("type", "trigger", "trajectory", "owner", "visibility", "published_at")
 
 
 def entity_to_markdown(entity):

--- a/platform-integrations/claude/plugins/evolve-lite/skills/learn/SKILL.md
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/learn/SKILL.md
@@ -19,6 +19,7 @@ This skill analyzes the current conversation to extract guidelines that **correc
 - Observations about the codebase that can be derived by reading the code
 - Restatements of what the agent did successfully without any detour or correction
 - Vague advice that wouldn't change the agent's behavior on a concrete task
+- Instructions for the agent to invoke a skill, tool, or external command by name (e.g. "Run evolve-lite:learn", "call save_trajectory") — these trigger prompt-injection detection when retrieved via recall
 
 **DO extract guidelines for:** environment-specific constraints discovered through errors (e.g., tools not installed, permissions blocked, packages unavailable) — these are not "known" until encountered in a specific environment.
 
@@ -97,5 +98,6 @@ Before saving, review each entity against this checklist:
 - [ ] Does it fall into one of the three categories (shortcut, error prevention, user correction)?
 - [ ] Would knowing this guideline beforehand have changed the agent's behavior in a concrete way?
 - [ ] Is it specific enough that another agent could act on it without further context?
+- [ ] Does it avoid instructing the agent to invoke a named skill or tool?
 
 If any answer is no, drop the entity. **Zero entities is a valid output.**

--- a/platform-integrations/claude/plugins/evolve-lite/skills/learn/scripts/save_entities.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/learn/scripts/save_entities.py
@@ -5,6 +5,7 @@ Reads entities from stdin JSON and writes each as a markdown file
 in the entities directory, organized by type.
 """
 
+import argparse
 import json
 import sys
 from pathlib import Path
@@ -33,6 +34,10 @@ def normalize(text):
 
 
 def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--user", default=None, help="Stamp owner on every entity written")
+    args = parser.parse_args()
+
     # Read entities from stdin
     try:
         input_data = json.load(sys.stdin)
@@ -76,6 +81,11 @@ def main():
         if normalize(content) in existing_contents:
             log(f"Skipping duplicate: {content[:60]}")
             continue
+
+        if args.user and not entity.get("owner"):
+            entity["owner"] = args.user
+        if not entity.get("visibility"):
+            entity["visibility"] = "private"
 
         path = write_entity_file(entities_dir, entity)
         existing_contents.add(normalize(content))

--- a/platform-integrations/claude/plugins/evolve-lite/skills/publish/SKILL.md
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/publish/SKILL.md
@@ -18,7 +18,6 @@ Check whether `evolve.config.yaml` exists in the project root.
 **If it does not exist**, ask the user:
 
 > "No `evolve.config.yaml` found. What username would you like to use? (e.g. `vatche`)"
-
 > "What is the remote URL for your public guidelines repo? (e.g. `git@github.com:vatche/evolve-guidelines.git`)"
 
 Create `evolve.config.yaml`:

--- a/platform-integrations/claude/plugins/evolve-lite/skills/publish/SKILL.md
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/publish/SKILL.md
@@ -79,9 +79,11 @@ python3 ${CLAUDE_PLUGIN_ROOT}/skills/publish/scripts/publish.py \
 
 ### Step 5: Commit and push
 
+Build `{filenames_list}` as a comma-joined list of all selected filenames (e.g. `foo.md, bar.md`).
+
 ```bash
 git -C .evolve/public add .
-git -C .evolve/public commit -m "[evolve] publish: {name}"
+git -C .evolve/public commit -m "[evolve] publish: {filenames_list}"
 git -C .evolve/public push origin "{public_repo.branch}"
 ```
 
@@ -91,4 +93,4 @@ Where `{public_repo.branch}` defaults to `main` if not set in config.
 
 Tell the user:
 
-> "Published {name} to {public_repo.remote}."
+> "Published {filenames_list} to {public_repo.remote}."

--- a/platform-integrations/claude/plugins/evolve-lite/skills/publish/SKILL.md
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/publish/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: publish
+description: Publish a private guideline to your public repo so others can subscribe to it.
+---
+
+# Publish Guideline
+
+## Overview
+
+This skill publishes one or more private guidelines from your local `.evolve/entities/guideline/` directory to your public git repository, making them available for others to subscribe to.
+
+## Workflow
+
+### Step 1: Bootstrap config if missing or incomplete
+
+Check whether `evolve.config.yaml` exists in the project root.
+
+**If it does not exist**, ask the user:
+
+> "No `evolve.config.yaml` found. What username would you like to use? (e.g. `vatche`)"
+
+> "What is the remote URL for your public guidelines repo? (e.g. `git@github.com:vatche/evolve-guidelines.git`)"
+
+Create `evolve.config.yaml`:
+
+```yaml
+identity:
+  user: {username}
+public_repo:
+  remote: {remote}
+  branch: main
+subscriptions: []
+sync:
+  on_session_start: true
+```
+
+**If it exists** but `identity.user` is missing, ask for it and add it to the config.
+
+**If it exists** but `public_repo.remote` is missing, ask:
+
+> "What is the remote URL for your public guidelines repo? (e.g. `git@github.com:vatche/evolve-guidelines.git`)"
+
+Add it to the config.
+
+Read `identity.user` from config to use as `{user}` when stamping ownership.
+
+### Step 2: First-time setup
+
+Ensure `.evolve/` is gitignored at the project root:
+
+```bash
+grep -qxF '.evolve/' .gitignore 2>/dev/null || echo '.evolve/' >> .gitignore
+```
+
+If `.evolve/public/` does not already contain a `.git` directory, initialise it and add the remote:
+
+```bash
+git init .evolve/public
+git -C .evolve/public remote add origin {public_repo.remote}
+```
+
+### Step 3: List and select entities
+
+List the files in `.evolve/entities/guideline/` (filenames only) and display them numbered. Ask the user:
+
+> "Which guideline(s) would you like to publish? Enter a number or comma-separated list of numbers."
+
+Wait for the user's selection.
+
+### Step 4: Run publish script
+
+For each selected entity file, run:
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/publish/scripts/publish.py \
+  --entity {filename} \
+  --user {identity.user}
+```
+
+### Step 5: Commit and push
+
+```bash
+git -C .evolve/public add .
+git -C .evolve/public commit -m "[evolve] publish: {name}"
+git -C .evolve/public push origin {public_repo.branch}
+```
+
+Where `{public_repo.branch}` defaults to `main` if not set in config.
+
+### Step 6: Confirm
+
+Tell the user:
+
+> "Published {name} to {public_repo.remote}."

--- a/platform-integrations/claude/plugins/evolve-lite/skills/publish/SKILL.md
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/publish/SKILL.md
@@ -73,8 +73,8 @@ For each selected entity file, run:
 
 ```bash
 python3 ${CLAUDE_PLUGIN_ROOT}/skills/publish/scripts/publish.py \
-  --entity {filename} \
-  --user {identity.user}
+  --entity "{filename}" \
+  --user "{identity.user}"
 ```
 
 ### Step 5: Commit and push
@@ -82,7 +82,7 @@ python3 ${CLAUDE_PLUGIN_ROOT}/skills/publish/scripts/publish.py \
 ```bash
 git -C .evolve/public add .
 git -C .evolve/public commit -m "[evolve] publish: {name}"
-git -C .evolve/public push origin {public_repo.branch}
+git -C .evolve/public push origin "{public_repo.branch}"
 ```
 
 Where `{public_repo.branch}` defaults to `main` if not set in config.

--- a/platform-integrations/claude/plugins/evolve-lite/skills/publish/SKILL.md
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/publish/SKILL.md
@@ -17,8 +17,8 @@ Check whether `evolve.config.yaml` exists in the project root.
 
 **If it does not exist**, ask the user:
 
-> "No `evolve.config.yaml` found. What username would you like to use? (e.g. `vatche`)"
-> "What is the remote URL for your public guidelines repo? (e.g. `git@github.com:vatche/evolve-guidelines.git`)"
+> "No `evolve.config.yaml` found. What username would you like to use? (e.g. `alice`)"
+> "What is the remote URL for your public guidelines repo? (e.g. `git@github.com:alice/evolve-guidelines.git`)"
 
 Create `evolve.config.yaml`:
 
@@ -37,7 +37,7 @@ sync:
 
 **If it exists** but `public_repo.remote` is missing, ask:
 
-> "What is the remote URL for your public guidelines repo? (e.g. `git@github.com:vatche/evolve-guidelines.git`)"
+> "What is the remote URL for your public guidelines repo? (e.g. `git@github.com:alice/evolve-guidelines.git`)"
 
 Add it to the config.
 

--- a/platform-integrations/claude/plugins/evolve-lite/skills/publish/scripts/publish.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/publish/scripts/publish.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Publish a private guideline entity to the public directory.
 
-- Reads source from .evolve/entities/guideline/{filename}
-- Copies to .evolve/public/guideline/{filename}
+- Moves source from .evolve/entities/guideline/{filename}
+- to .evolve/public/guideline/{filename}
 - Updates frontmatter: visibility=public, owner={user}, published_at={now}
 - Appends to audit.log
 """
@@ -10,6 +10,7 @@
 import argparse
 import datetime
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -17,6 +18,23 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent.parent / "lib"))
 from entity_io import markdown_to_entity, entity_to_markdown
 from audit import append as audit_append
+from config import load_config
+
+
+def _resolve_source(cfg, user_arg):
+    """Derive a source label from config or fallback to user arg."""
+    remote = cfg.get("public_repo", {})
+    if isinstance(remote, dict):
+        remote = remote.get("remote", "")
+    if remote:
+        # Extract user/repo from SSH or HTTPS remote URLs
+        m = re.search(r"[:/]([^/:]+/[^/]+?)(?:\.git)?$", remote)
+        if m:
+            return m.group(1)
+    identity = cfg.get("identity", {})
+    if isinstance(identity, dict) and identity.get("user"):
+        return identity["user"]
+    return user_arg
 
 
 def main():
@@ -46,6 +64,10 @@ def main():
     if args.user:
         entity["owner"] = args.user
     entity["published_at"] = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    cfg = load_config(str(evolve_dir.resolve().parent))
+    source = _resolve_source(cfg, args.user)
+    if source:
+        entity["source"] = source
 
     # Write to public directory
     dest_dir = evolve_dir / "public" / "guideline"
@@ -58,6 +80,7 @@ def main():
 
     content = entity_to_markdown(entity)
     dest_path.write_text(content, encoding="utf-8")
+    src_path.unlink()
 
     # Audit log
     audit_append(

--- a/platform-integrations/claude/plugins/evolve-lite/skills/publish/scripts/publish.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/publish/scripts/publish.py
@@ -6,6 +6,7 @@
 - Updates frontmatter: visibility=public, owner={user}, published_at={now}
 - Appends to audit.log
 """
+
 import argparse
 import datetime
 import os

--- a/platform-integrations/claude/plugins/evolve-lite/skills/publish/scripts/publish.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/publish/scripts/publish.py
@@ -45,7 +45,11 @@ def main():
 
     evolve_dir = Path(os.environ.get("EVOLVE_DIR", ".evolve"))
 
-    # Validate entity name: resolve and confirm it stays within the intended dir
+    # Validate entity name: must be a plain filename with no path components
+    if len(Path(args.entity).parts) != 1 or args.entity in (".", ".."):
+        print(f"Error: invalid entity name: {args.entity!r}", file=sys.stderr)
+        sys.exit(1)
+
     src_base = (evolve_dir / "entities" / "guideline").resolve()
     src_path = (evolve_dir / "entities" / "guideline" / args.entity).resolve()
     if not src_path.is_relative_to(src_base):

--- a/platform-integrations/claude/plugins/evolve-lite/skills/publish/scripts/publish.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/publish/scripts/publish.py
@@ -26,7 +26,13 @@ def main():
     args = parser.parse_args()
 
     evolve_dir = Path(os.environ.get("EVOLVE_DIR", ".evolve"))
-    src_path = evolve_dir / "entities" / "guideline" / args.entity
+
+    # Validate entity name: resolve and confirm it stays within the intended dir
+    src_base = (evolve_dir / "entities" / "guideline").resolve()
+    src_path = (evolve_dir / "entities" / "guideline" / args.entity).resolve()
+    if not src_path.is_relative_to(src_base):
+        print(f"Error: invalid entity name: {args.entity!r}", file=sys.stderr)
+        sys.exit(1)
 
     if not src_path.exists():
         print(f"Error: entity file not found: {src_path}", file=sys.stderr)
@@ -44,7 +50,11 @@ def main():
     # Write to public directory
     dest_dir = evolve_dir / "public" / "guideline"
     dest_dir.mkdir(parents=True, exist_ok=True)
-    dest_path = dest_dir / args.entity
+    dest_base = dest_dir.resolve()
+    dest_path = (dest_dir / args.entity).resolve()
+    if not dest_path.is_relative_to(dest_base):
+        print(f"Error: invalid entity name: {args.entity!r}", file=sys.stderr)
+        sys.exit(1)
 
     content = entity_to_markdown(entity)
     dest_path.write_text(content, encoding="utf-8")

--- a/platform-integrations/claude/plugins/evolve-lite/skills/publish/scripts/publish.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/publish/scripts/publish.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Publish a private guideline entity to the public directory.
+
+- Reads source from .evolve/entities/guideline/{filename}
+- Copies to .evolve/public/guideline/{filename}
+- Updates frontmatter: visibility=public, owner={user}, published_at={now}
+- Appends to audit.log
+"""
+import argparse
+import datetime
+import os
+import shutil
+import sys
+from pathlib import Path
+
+# Add lib to path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent.parent / "lib"))
+from entity_io import markdown_to_entity, entity_to_markdown
+from audit import append as audit_append
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--entity", required=True, help="Basename of the .md file to publish")
+    parser.add_argument("--user", default=None, help="Username to stamp as owner")
+    args = parser.parse_args()
+
+    evolve_dir = Path(os.environ.get("EVOLVE_DIR", ".evolve"))
+    src_path = evolve_dir / "entities" / "guideline" / args.entity
+
+    if not src_path.exists():
+        print(f"Error: entity file not found: {src_path}", file=sys.stderr)
+        sys.exit(1)
+
+    # Parse entity
+    entity = markdown_to_entity(src_path)
+
+    # Update frontmatter fields
+    entity["visibility"] = "public"
+    if args.user:
+        entity["owner"] = args.user
+    entity["published_at"] = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    # Write to public directory
+    dest_dir = evolve_dir / "public" / "guideline"
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest_path = dest_dir / args.entity
+
+    content = entity_to_markdown(entity)
+    dest_path.write_text(content, encoding="utf-8")
+
+    # Audit log
+    audit_append(
+        project_root=str(evolve_dir.parent) if evolve_dir.name != ".evolve" else ".",
+        action="publish",
+        actor=args.user or "unknown",
+        entity=args.entity,
+    )
+
+    print(f"Published: {args.entity} -> {dest_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/platform-integrations/claude/plugins/evolve-lite/skills/publish/scripts/publish.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/publish/scripts/publish.py
@@ -59,13 +59,16 @@ def main():
     # Parse entity
     entity = markdown_to_entity(src_path)
 
+    cfg = load_config(str(evolve_dir.resolve().parent))
+    identity = cfg.get("identity", {})
+    effective_user = args.user or (identity.get("user") if isinstance(identity, dict) else None)
+
     # Update frontmatter fields
     entity["visibility"] = "public"
-    if args.user:
-        entity["owner"] = args.user
+    if effective_user:
+        entity["owner"] = effective_user
     entity["published_at"] = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
-    cfg = load_config(str(evolve_dir.resolve().parent))
-    source = _resolve_source(cfg, args.user)
+    source = _resolve_source(cfg, effective_user)
     if source:
         entity["source"] = source
 
@@ -78,6 +81,10 @@ def main():
         print(f"Error: invalid entity name: {args.entity!r}", file=sys.stderr)
         sys.exit(1)
 
+    if dest_path.exists():
+        print(f"Error: already published: {dest_path}\nUnpublish it first or delete it manually.", file=sys.stderr)
+        sys.exit(1)
+
     content = entity_to_markdown(entity)
     dest_path.write_text(content, encoding="utf-8")
     src_path.unlink()
@@ -86,7 +93,7 @@ def main():
     audit_append(
         project_root=str(evolve_dir.resolve().parent),
         action="publish",
-        actor=args.user or "unknown",
+        actor=effective_user or "unknown",
         entity=args.entity,
     )
 

--- a/platform-integrations/claude/plugins/evolve-lite/skills/publish/scripts/publish.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/publish/scripts/publish.py
@@ -10,7 +10,6 @@
 import argparse
 import datetime
 import os
-import shutil
 import sys
 from pathlib import Path
 

--- a/platform-integrations/claude/plugins/evolve-lite/skills/publish/scripts/publish.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/publish/scripts/publish.py
@@ -61,7 +61,7 @@ def main():
 
     # Audit log
     audit_append(
-        project_root=str(evolve_dir.parent) if evolve_dir.name != ".evolve" else ".",
+        project_root=str(evolve_dir.resolve().parent),
         action="publish",
         actor=args.user or "unknown",
         entity=args.entity,

--- a/platform-integrations/claude/plugins/evolve-lite/skills/publish/scripts/publish.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/publish/scripts/publish.py
@@ -12,6 +12,7 @@ import datetime
 import os
 import re
 import sys
+import tempfile
 from pathlib import Path
 
 # Add lib to path
@@ -90,16 +91,28 @@ def main():
         sys.exit(1)
 
     content = entity_to_markdown(entity)
-    dest_path.write_text(content, encoding="utf-8")
+    tmp_fd, tmp_path = tempfile.mkstemp(dir=dest_path.parent, suffix=".tmp")
+    try:
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
+            f.write(content)
+        Path(tmp_path).replace(dest_path)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
     src_path.unlink()
 
-    # Audit log
-    audit_append(
-        project_root=str(evolve_dir.resolve().parent),
-        action="publish",
-        actor=effective_user or "unknown",
-        entity=args.entity,
-    )
+    try:
+        audit_append(
+            project_root=str(evolve_dir.resolve().parent),
+            action="publish",
+            actor=effective_user or "unknown",
+            entity=args.entity,
+        )
+    except Exception as e:
+        print(f"Warning: audit log failed: {e}", file=sys.stderr)
 
     print(f"Published: {args.entity} -> {dest_path}")
 

--- a/platform-integrations/claude/plugins/evolve-lite/skills/recall/SKILL.md
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/recall/SKILL.md
@@ -22,7 +22,7 @@ This skill retrieves relevant entities from a stored knowledge base based on the
 
 Entities are loaded from two locations:
 
-```
+```text
 .evolve/entities/
   guideline/
     use-context-managers-for-file-operations.md   ← private

--- a/platform-integrations/claude/plugins/evolve-lite/skills/recall/SKILL.md
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/recall/SKILL.md
@@ -14,19 +14,26 @@ This skill retrieves relevant entities from a stored knowledge base based on the
 
 1. Hook fires on user prompt submission
 2. Script reads prompt from stdin (JSON with `prompt` field)
-3. Loads all entities from the entities directory (`.evolve/entities/`)
+3. Loads entities from two sources: `.evolve/entities/` (private + subscribed) and `.evolve/public/` (your published guidelines)
 4. Outputs formatted entities to stdout
 5. Claude receives entities as additional context and applies relevant ones
 
 ## Entities Storage
 
-Entities are stored as individual markdown files in `.evolve/entities/`, nested by type:
+Entities are loaded from two locations:
 
 ```
 .evolve/entities/
   guideline/
-    use-context-managers-for-file-operations.md
-    cache-api-responses-locally.md
+    use-context-managers-for-file-operations.md   ← private
+  subscribed/
+    alice/
+      guideline/
+        alice-tip.md                              ← annotated [from: alice]
+
+.evolve/public/
+  guideline/
+    published-tip.md                              ← your own public, no annotation
 ```
 
 Each file uses markdown with YAML frontmatter:

--- a/platform-integrations/claude/plugins/evolve-lite/skills/recall/scripts/retrieve_entities.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/recall/scripts/retrieve_entities.py
@@ -88,7 +88,7 @@ def load_entities_with_source(entities_dir):
             if rel_parts[0] == "subscribed" and len(rel_parts) > 1:
                 entity["_source"] = rel_parts[1]
             entities.append(entity)
-        except OSError:
+        except (OSError, UnicodeError):
             pass
     return entities
 

--- a/platform-integrations/claude/plugins/evolve-lite/skills/recall/scripts/retrieve_entities.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/recall/scripts/retrieve_entities.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 # Add lib to path so we can import entity_io
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent.parent / "lib"))
-from entity_io import find_entities_dir, load_all_entities, log as _log
+from entity_io import find_entities_dir, markdown_to_entity, log as _log
 
 
 def log(message):
@@ -36,7 +36,12 @@ log("=== End Command-Line Arguments ===")
 
 
 def format_entities(entities):
-    """Format all entities for Claude to review."""
+    """Format all entities for Claude to review.
+
+    Entities that came from a subscribed source have their path recorded in
+    the private ``_source`` key (set by load_entities_with_source). These are
+    annotated with ``[from: {name}]`` so Claude knows their provenance.
+    """
     header = """## Entities for this task
 
 Review these entities and apply any relevant ones:
@@ -47,6 +52,9 @@ Review these entities and apply any relevant ones:
         content = e.get("content")
         if not content:
             continue
+        source = e.get("_source")
+        if source:
+            content = f"[from: {source}] {content}"
         item = f"- **[{e.get('type', 'general')}]** {content}"
         if e.get("rationale"):
             item += f"\n  - _Rationale: {e['rationale']}_"
@@ -55,6 +63,33 @@ Review these entities and apply any relevant ones:
         items.append(item)
 
     return header + "\n".join(items)
+
+
+def load_entities_with_source(entities_dir):
+    """Glob all .md files under entities_dir and parse each.
+
+    Entities stored under entities/subscribed/{name}/ have ``_source`` set to
+    the subscription name so format_entities can annotate them. The owner field
+    written by publish.py is preserved; _source is just a routing key used
+    internally and is never written to disk.
+    """
+    entities_dir = Path(entities_dir)
+    entities = []
+    for md in sorted(entities_dir.glob("**/*.md")):
+        try:
+            entity = markdown_to_entity(md)
+            if not entity.get("content"):
+                continue
+            # Detect subscribed entities by path: .../entities/subscribed/{name}/...
+            parts = md.parts
+            for i, part in enumerate(parts):
+                if part == "subscribed" and i + 1 < len(parts):
+                    entity["_source"] = parts[i + 1]
+                    break
+            entities.append(entity)
+        except OSError:
+            pass
+    return entities
 
 
 def main():
@@ -69,22 +104,18 @@ def main():
         log(f"Failed to parse JSON input: {e}")
         return
 
-    # Load all entities from directory
     entities_dir = find_entities_dir()
     log(f"Entities dir: {entities_dir}")
-
     if not entities_dir:
         log("No entities directory found")
         return
 
-    entities = load_all_entities(entities_dir)
+    entities = load_entities_with_source(entities_dir)
     if not entities:
         log("No entities found")
         return
 
     log(f"Loaded {len(entities)} entities")
-
-    # Output all entities - Claude will filter for relevance
     output = format_entities(entities)
     print(output)
     log(f"Output {len(output)} chars to stdout")

--- a/platform-integrations/claude/plugins/evolve-lite/skills/recall/scripts/retrieve_entities.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/recall/scripts/retrieve_entities.py
@@ -80,11 +80,15 @@ def load_entities_with_source(entities_dir):
             entity = markdown_to_entity(md)
             if not entity.get("content"):
                 continue
-            # Detect subscribed entities by path: .../entities/subscribed/{name}/...
-            parts = md.parts
-            for i, part in enumerate(parts):
-                if part == "subscribed" and i + 1 < len(parts):
-                    entity["_source"] = parts[i + 1]
+            # Detect subscribed entities using path relative to entities_dir
+            # to avoid matching "subscribed" in ancestor directory names.
+            try:
+                rel_parts = md.relative_to(entities_dir).parts
+            except ValueError:
+                rel_parts = md.parts
+            for i, part in enumerate(rel_parts):
+                if part == "subscribed" and i + 1 < len(rel_parts):
+                    entity["_source"] = rel_parts[i + 1]
                     break
             entities.append(entity)
         except OSError:

--- a/platform-integrations/claude/plugins/evolve-lite/skills/recall/scripts/retrieve_entities.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/recall/scripts/retrieve_entities.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 # Add lib to path so we can import entity_io
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent.parent / "lib"))
-from entity_io import find_entities_dir, markdown_to_entity, log as _log
+from entity_io import find_entities_dir, get_evolve_dir, markdown_to_entity, log as _log
 
 
 def log(message):
@@ -110,11 +110,16 @@ def main():
 
     entities_dir = find_entities_dir()
     log(f"Entities dir: {entities_dir}")
-    if not entities_dir:
-        log("No entities directory found")
-        return
 
-    entities = load_entities_with_source(entities_dir)
+    entities = []
+    if entities_dir:
+        entities = load_entities_with_source(entities_dir)
+
+    public_dir = get_evolve_dir() / "public"
+    if public_dir.is_dir():
+        log(f"Loading public entities from: {public_dir}")
+        entities += load_entities_with_source(public_dir)
+
     if not entities:
         log("No entities found")
         return

--- a/platform-integrations/claude/plugins/evolve-lite/skills/recall/scripts/retrieve_entities.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/recall/scripts/retrieve_entities.py
@@ -78,18 +78,15 @@ def load_entities_with_source(entities_dir):
     for md in sorted(entities_dir.glob("**/*.md")):
         try:
             entity = markdown_to_entity(md)
+            entity.pop("_source", None)
             if not entity.get("content"):
                 continue
-            # Detect subscribed entities using path relative to entities_dir
-            # to avoid matching "subscribed" in ancestor directory names.
             try:
                 rel_parts = md.relative_to(entities_dir).parts
             except ValueError:
                 rel_parts = md.parts
-            for i, part in enumerate(rel_parts):
-                if part == "subscribed" and i + 1 < len(rel_parts):
-                    entity["_source"] = rel_parts[i + 1]
-                    break
+            if rel_parts[0] == "subscribed" and len(rel_parts) > 1:
+                entity["_source"] = rel_parts[1]
             entities.append(entity)
         except OSError:
             pass

--- a/platform-integrations/claude/plugins/evolve-lite/skills/recall/scripts/retrieve_entities.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/recall/scripts/retrieve_entities.py
@@ -75,7 +75,7 @@ def load_entities_with_source(entities_dir):
     """
     entities_dir = Path(entities_dir)
     entities = []
-    for md in sorted(entities_dir.glob("**/*.md")):
+    for md in sorted(p for p in entities_dir.glob("**/*.md") if ".git" not in p.parts):
         try:
             entity = markdown_to_entity(md)
             entity.pop("_source", None)

--- a/platform-integrations/claude/plugins/evolve-lite/skills/subscribe/SKILL.md
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/subscribe/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: subscribe
+description: Subscribe to another user's public guidelines repo.
+---
+
+# Subscribe to Guidelines
+
+## Overview
+
+This skill subscribes to another user's public guidelines repository. Their guidelines will be cloned locally and made available in your recall context.
+
+## Workflow
+
+### Step 1: Bootstrap config if missing
+
+Check whether `evolve.config.yaml` exists in the project root.
+
+If it does **not** exist, ask the user:
+
+> "No `evolve.config.yaml` found. What username would you like to use? (e.g. `vatche`)"
+
+Then create `evolve.config.yaml` with this minimal content:
+
+```yaml
+identity:
+  user: {username}
+subscriptions: []
+sync:
+  on_session_start: true
+```
+
+Also ensure `.evolve/` is gitignored:
+
+```bash
+grep -qxF '.evolve/' .gitignore 2>/dev/null || echo '.evolve/' >> .gitignore
+```
+
+### Step 2: Gather details
+
+Ask the user:
+
+> "What is the remote URL for the guidelines repo? (e.g. `git@github.com:alice/evolve-guidelines.git`)"
+
+Then ask:
+
+> "What short name would you like for this subscription? (e.g. `alice`)"
+
+### Step 3: Check for duplicates
+
+Read `evolve.config.yaml` from the project root. If the name already exists in the `subscriptions` list, tell the user:
+
+> "A subscription named '{name}' already exists. Please unsubscribe first or choose a different name."
+
+Then stop.
+
+### Step 4: Run subscribe script
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/subscribe/scripts/subscribe.py \
+  --name {name} \
+  --remote {remote} \
+  --branch main
+```
+
+### Step 5: Confirm
+
+Tell the user:
+
+> "Subscribed to {name}. Run /sync to pull their guidelines."

--- a/platform-integrations/claude/plugins/evolve-lite/skills/subscribe/SKILL.md
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/subscribe/SKILL.md
@@ -57,8 +57,8 @@ Then stop.
 
 ```bash
 python3 ${CLAUDE_PLUGIN_ROOT}/skills/subscribe/scripts/subscribe.py \
-  --name {name} \
-  --remote {remote} \
+  --name "{name}" \
+  --remote "{remote}" \
   --branch main
 ```
 

--- a/platform-integrations/claude/plugins/evolve-lite/skills/subscribe/SKILL.md
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/subscribe/SKILL.md
@@ -17,7 +17,7 @@ Check whether `evolve.config.yaml` exists in the project root.
 
 If it does **not** exist, ask the user:
 
-> "No `evolve.config.yaml` found. What username would you like to use? (e.g. `vatche`)"
+> "No `evolve.config.yaml` found. What username would you like to use? (e.g. `alice`)"
 
 Then create `evolve.config.yaml` with this minimal content:
 

--- a/platform-integrations/claude/plugins/evolve-lite/skills/subscribe/scripts/subscribe.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/subscribe/scripts/subscribe.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Subscribe to another user's public guidelines repo.
+
+- Adds entry to subscriptions list in evolve.config.yaml
+- Clones the remote into .evolve/subscribed/{name}
+- Appends to audit.log
+"""
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# Add lib to path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent.parent / "lib"))
+from config import load_config, save_config
+from audit import append as audit_append
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--name", required=True, help="Short subscription name (e.g. alice)")
+    parser.add_argument("--remote", required=True, help="Git remote URL")
+    parser.add_argument("--branch", default="main", help="Branch to track (default: main)")
+    args = parser.parse_args()
+
+    project_root = "."
+    evolve_dir = Path(os.environ.get("EVOLVE_DIR", ".evolve"))
+
+    cfg = load_config(project_root)
+
+    # Ensure subscriptions list exists
+    subscriptions = cfg.get("subscriptions", [])
+    if not isinstance(subscriptions, list):
+        subscriptions = []
+
+    # Check for duplicate
+    for sub in subscriptions:
+        if isinstance(sub, dict) and sub.get("name") == args.name:
+            print(
+                f"Error: subscription '{args.name}' already exists in config.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+    # Clone the repo
+    dest = evolve_dir / "subscribed" / args.name
+    if dest.exists():
+        print(f"Warning: {dest} already exists, skipping clone.", file=sys.stderr)
+    else:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        subprocess.run(
+            [
+                "git", "clone",
+                args.remote,
+                str(dest),
+                "--branch", args.branch,
+                "--depth", "1",
+            ],
+            check=True,
+        )
+
+    # Update config
+    subscriptions.append({"name": args.name, "remote": args.remote, "branch": args.branch})
+    cfg["subscriptions"] = subscriptions
+    save_config(cfg, project_root)
+
+    # Read identity.user for audit
+    identity = cfg.get("identity", {})
+    actor = identity.get("user", "unknown") if isinstance(identity, dict) else "unknown"
+
+    audit_append(
+        project_root=project_root,
+        action="subscribe",
+        actor=actor,
+        name=args.name,
+        remote=args.remote,
+    )
+
+    print(f"Subscribed to '{args.name}' from {args.remote}")
+
+
+if __name__ == "__main__":
+    main()

--- a/platform-integrations/claude/plugins/evolve-lite/skills/subscribe/scripts/subscribe.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/subscribe/scripts/subscribe.py
@@ -31,7 +31,7 @@ def main():
     # Validate name: resolve and confirm it stays within the subscribed directory
     subscribed_base = (evolve_dir / "subscribed").resolve()
     dest = (evolve_dir / "subscribed" / args.name).resolve()
-    if not dest.is_relative_to(subscribed_base):
+    if not dest.is_relative_to(subscribed_base) or dest == subscribed_base:
         print(f"Error: invalid subscription name: {args.name!r}", file=sys.stderr)
         sys.exit(1)
 

--- a/platform-integrations/claude/plugins/evolve-lite/skills/subscribe/scripts/subscribe.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/subscribe/scripts/subscribe.py
@@ -53,22 +53,26 @@ def main():
 
     # Clone the repo
     if dest.exists():
-        print(f"Warning: {dest} already exists, skipping clone.", file=sys.stderr)
-    else:
-        dest.parent.mkdir(parents=True, exist_ok=True)
-        subprocess.run(
-            [
-                "git",
-                "clone",
-                args.remote,
-                str(dest),
-                "--branch",
-                args.branch,
-                "--depth",
-                "1",
-            ],
-            check=True,
+        print(
+            f"Error: directory already exists: {dest}\nRun /evolve-lite:unsubscribe to remove it before re-subscribing.",
+            file=sys.stderr,
         )
+        sys.exit(1)
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        [
+            "git",
+            "clone",
+            args.remote,
+            str(dest),
+            "--branch",
+            args.branch,
+            "--depth",
+            "1",
+        ],
+        check=True,
+    )
 
     # Update config
     subscriptions.append({"name": args.name, "remote": args.remote, "branch": args.branch})

--- a/platform-integrations/claude/plugins/evolve-lite/skills/subscribe/scripts/subscribe.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/subscribe/scripts/subscribe.py
@@ -24,8 +24,8 @@ def main():
     parser.add_argument("--branch", default="main", help="Branch to track (default: main)")
     args = parser.parse_args()
 
-    project_root = "."
     evolve_dir = Path(os.environ.get("EVOLVE_DIR", ".evolve"))
+    project_root = str(evolve_dir.resolve().parent)
 
     # Validate name: resolve and confirm it stays within the subscribed directory
     subscribed_base = (evolve_dir / "subscribed").resolve()

--- a/platform-integrations/claude/plugins/evolve-lite/skills/subscribe/scripts/subscribe.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/subscribe/scripts/subscribe.py
@@ -5,6 +5,7 @@
 - Clones the remote into .evolve/subscribed/{name}
 - Appends to audit.log
 """
+
 import argparse
 import os
 import subprocess
@@ -57,11 +58,14 @@ def main():
         dest.parent.mkdir(parents=True, exist_ok=True)
         subprocess.run(
             [
-                "git", "clone",
+                "git",
+                "clone",
                 args.remote,
                 str(dest),
-                "--branch", args.branch,
-                "--depth", "1",
+                "--branch",
+                args.branch,
+                "--depth",
+                "1",
             ],
             check=True,
         )

--- a/platform-integrations/claude/plugins/evolve-lite/skills/subscribe/scripts/subscribe.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/subscribe/scripts/subscribe.py
@@ -27,6 +27,13 @@ def main():
     project_root = "."
     evolve_dir = Path(os.environ.get("EVOLVE_DIR", ".evolve"))
 
+    # Validate name: resolve and confirm it stays within the subscribed directory
+    subscribed_base = (evolve_dir / "subscribed").resolve()
+    dest = (evolve_dir / "subscribed" / args.name).resolve()
+    if not dest.is_relative_to(subscribed_base):
+        print(f"Error: invalid subscription name: {args.name!r}", file=sys.stderr)
+        sys.exit(1)
+
     cfg = load_config(project_root)
 
     # Ensure subscriptions list exists
@@ -44,7 +51,6 @@ def main():
             sys.exit(1)
 
     # Clone the repo
-    dest = evolve_dir / "subscribed" / args.name
     if dest.exists():
         print(f"Warning: {dest} already exists, skipping clone.", file=sys.stderr)
     else:

--- a/platform-integrations/claude/plugins/evolve-lite/skills/subscribe/scripts/subscribe.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/subscribe/scripts/subscribe.py
@@ -2,7 +2,7 @@
 """Subscribe to another user's public guidelines repo.
 
 - Adds entry to subscriptions list in evolve.config.yaml
-- Clones the remote into .evolve/subscribed/{name}
+- Clones the remote into .evolve/entities/subscribed/{name}
 - Appends to audit.log
 """
 
@@ -29,8 +29,8 @@ def main():
     project_root = str(evolve_dir.resolve().parent)
 
     # Validate name: resolve and confirm it stays within the subscribed directory
-    subscribed_base = (evolve_dir / "subscribed").resolve()
-    dest = (evolve_dir / "subscribed" / args.name).resolve()
+    subscribed_base = (evolve_dir / "entities" / "subscribed").resolve()
+    dest = (evolve_dir / "entities" / "subscribed" / args.name).resolve()
     if not dest.is_relative_to(subscribed_base) or dest == subscribed_base:
         print(f"Error: invalid subscription name: {args.name!r}", file=sys.stderr)
         sys.exit(1)

--- a/platform-integrations/claude/plugins/evolve-lite/skills/sync/SKILL.md
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/sync/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: sync
+description: Pull the latest guidelines from all subscribed repos.
+---
+
+# Sync Subscriptions
+
+## Overview
+
+This skill pulls the latest guidelines from all repos you have subscribed to, keeping your local copies up to date.
+
+## Workflow
+
+### Step 1: Run sync script
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/sync/scripts/sync.py
+```
+
+### Step 2: Display summary
+
+Display the summary output from the script to the user. For example:
+
+> "Synced 2 repo(s): alice (+2 added, 0 updated, 0 removed), bob (+0 added, 1 updated, 0 removed)"
+
+If there is nothing to report (no subscriptions or no changes), confirm:
+
+> "All subscriptions are up to date."

--- a/platform-integrations/claude/plugins/evolve-lite/skills/sync/scripts/sync.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/sync/scripts/sync.py
@@ -67,6 +67,10 @@ def count_delta(repo_path):
         text=True,
         timeout=_GIT_TIMEOUT,
     )
+    if result.returncode != 0:
+        # HEAD@{1} doesn't exist (initial sync) — count all .md files as added
+        added = len(list(repo_path.glob("**/*.md")))
+        return {"added": added, "updated": 0, "removed": 0}
     added = updated = removed = 0
     for line in result.stdout.splitlines():
         if not line.strip():
@@ -96,19 +100,12 @@ def main():
     )
     args = parser.parse_args()
 
-    project_root = "."
     evolve_dir = Path(os.environ.get("EVOLVE_DIR", ".evolve"))
+    project_root = str(evolve_dir.parent) if "EVOLVE_DIR" in os.environ else "."
 
     # Determine config path
     if args.config:
-        cfg_path = Path(args.config)
-        # Load config from explicit path by temporarily reading the file
-        if cfg_path.exists():
-            from config import _parse_yaml
-
-            cfg = _parse_yaml(cfg_path.read_text(encoding="utf-8"))
-        else:
-            cfg = {}
+        cfg = load_config(filepath=args.config)
     else:
         cfg = load_config(project_root)
 

--- a/platform-integrations/claude/plugins/evolve-lite/skills/sync/scripts/sync.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/sync/scripts/sync.py
@@ -147,7 +147,10 @@ def main():
             total_delta[name] = {"added": 0, "updated": 0, "removed": 0}
             continue
 
-        delta = count_delta(repo_path)
+        if "Already up to date" in (pull_result.stdout or ""):
+            delta = {"added": 0, "updated": 0, "removed": 0}
+        else:
+            delta = count_delta(repo_path)
         total_delta[name] = delta
 
         has_changes = any(v > 0 for v in delta.values())

--- a/platform-integrations/claude/plugins/evolve-lite/skills/sync/scripts/sync.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/sync/scripts/sync.py
@@ -12,6 +12,7 @@ Usage:
 
 import argparse
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -50,6 +51,8 @@ def copy_entities(subscribed_repo_path, entities_subscribed_path):
     if entities_subscribed_path.exists():
         shutil.rmtree(entities_subscribed_path)
     for md in sorted(subscribed_repo_path.glob("**/*.md")):
+        if md.is_symlink():
+            continue
         rel = md.relative_to(subscribed_repo_path)
         dest = entities_subscribed_path / rel
         dest.parent.mkdir(parents=True, exist_ok=True)
@@ -109,9 +112,10 @@ def main():
     else:
         cfg = load_config(project_root)
 
-    # Check sync.on_session_start
+    # Check sync.on_session_start — only short-circuits automatic hook runs
+    # (which pass --quiet). Manual invocations always execute.
     sync_cfg = cfg.get("sync", {})
-    if isinstance(sync_cfg, dict) and sync_cfg.get("on_session_start") is False:
+    if args.quiet and isinstance(sync_cfg, dict) and sync_cfg.get("on_session_start") is False:
         sys.exit(0)
 
     subscriptions = cfg.get("subscriptions", [])
@@ -130,11 +134,18 @@ def main():
     total_delta = {}
     any_changes = False
 
+    _SAFE_NAME = re.compile(r'^[A-Za-z0-9._-]+$')
+
     for sub in subscriptions:
         if not isinstance(sub, dict):
             continue
         name = sub.get("name", "unknown")
         branch = sub.get("branch", "main")
+
+        if not _SAFE_NAME.match(name):
+            summaries.append(f"{name!r} (skipped — invalid subscription name)")
+            continue
+
         repo_path = evolve_dir / "subscribed" / name
 
         if not repo_path.is_dir():

--- a/platform-integrations/claude/plugins/evolve-lite/skills/sync/scripts/sync.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/sync/scripts/sync.py
@@ -9,6 +9,7 @@ Usage:
   --quiet        Suppress output if no changes.
   --config PATH  Path to config file (default: evolve.config.yaml at project root).
 """
+
 import argparse
 import os
 import shutil
@@ -104,6 +105,7 @@ def main():
         # Load config from explicit path by temporarily reading the file
         if cfg_path.exists():
             from config import _parse_yaml
+
             cfg = _parse_yaml(cfg_path.read_text(encoding="utf-8"))
         else:
             cfg = {}
@@ -159,11 +161,7 @@ def main():
         entities_subscribed = evolve_dir / "entities" / "subscribed" / name
         copy_entities(repo_path, entities_subscribed)
 
-        delta_str = (
-            f"+{delta['added']} added, "
-            f"{delta['updated']} updated, "
-            f"{delta['removed']} removed"
-        )
+        delta_str = f"+{delta['added']} added, {delta['updated']} updated, {delta['removed']} removed"
         summaries.append(f"{name} ({delta_str})")
 
     # Audit

--- a/platform-integrations/claude/plugins/evolve-lite/skills/sync/scripts/sync.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/sync/scripts/sync.py
@@ -134,7 +134,7 @@ def main():
     total_delta = {}
     any_changes = False
 
-    _SAFE_NAME = re.compile(r'^[A-Za-z0-9._-]+$')
+    _SAFE_NAME = re.compile(r"^[A-Za-z0-9._-]+$")
 
     for sub in subscriptions:
         if not isinstance(sub, dict):

--- a/platform-integrations/claude/plugins/evolve-lite/skills/sync/scripts/sync.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/sync/scripts/sync.py
@@ -22,13 +22,21 @@ from config import load_config
 from audit import append as audit_append
 
 
+_GIT_TIMEOUT = 30  # seconds
+
+
 def git_pull(repo_path, branch):
-    """Pull latest from origin. Returns CompletedProcess."""
-    return subprocess.run(
-        ["git", "-C", str(repo_path), "pull", "origin", branch, "--ff-only"],
-        capture_output=True,
-        text=True,
-    )
+    """Pull latest from origin. Returns CompletedProcess, or None on timeout."""
+    try:
+        return subprocess.run(
+            ["git", "-C", str(repo_path), "pull", "origin", branch, "--ff-only"],
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired:
+        print(f"Warning: git pull timed out for {repo_path} (branch: {branch})", file=sys.stderr)
+        return None
 
 
 def copy_entities(subscribed_repo_path, entities_subscribed_path):
@@ -56,6 +64,7 @@ def count_delta(repo_path):
         ["git", "-C", str(repo_path), "diff", "--name-status", "HEAD@{1}", "HEAD"],
         capture_output=True,
         text=True,
+        timeout=_GIT_TIMEOUT,
     )
     added = updated = removed = 0
     for line in result.stdout.splitlines():
@@ -134,6 +143,11 @@ def main():
             continue
 
         pull_result = git_pull(repo_path, branch)
+        if pull_result is None or pull_result.returncode != 0:
+            summaries.append(f"{name} (pull failed — skipping mirror)")
+            total_delta[name] = {"added": 0, "updated": 0, "removed": 0}
+            continue
+
         delta = count_delta(repo_path)
         total_delta[name] = delta
 

--- a/platform-integrations/claude/plugins/evolve-lite/skills/sync/scripts/sync.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/sync/scripts/sync.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Pull the latest guidelines from all subscribed repos.
+
+After pulling, copies .md files from .evolve/subscribed/{name}/ into
+.evolve/entities/subscribed/{name}/ so the existing recall hook picks them
+up without any changes.
+
+Usage:
+  --quiet        Suppress output if no changes.
+  --config PATH  Path to config file (default: evolve.config.yaml at project root).
+"""
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+# Add lib to path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent.parent / "lib"))
+from config import load_config
+from audit import append as audit_append
+
+
+def git_pull(repo_path, branch):
+    """Pull latest from origin. Returns CompletedProcess."""
+    return subprocess.run(
+        ["git", "-C", str(repo_path), "pull", "origin", branch, "--ff-only"],
+        capture_output=True,
+        text=True,
+    )
+
+
+def copy_entities(subscribed_repo_path, entities_subscribed_path):
+    """Mirror .md files from the subscribed git clone into entities/subscribed/{name}/.
+
+    Clears the destination first so removed files don't linger.
+    The owner field stamped at publish time travels with the file — no
+    frontmatter manipulation needed here.
+    """
+    if entities_subscribed_path.exists():
+        shutil.rmtree(entities_subscribed_path)
+    for md in sorted(subscribed_repo_path.glob("**/*.md")):
+        rel = md.relative_to(subscribed_repo_path)
+        dest = entities_subscribed_path / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(md, dest)
+
+
+def count_delta(repo_path):
+    """Count added/modified/deleted .md files since last pull.
+
+    Returns dict: {added: int, updated: int, removed: int}
+    """
+    result = subprocess.run(
+        ["git", "-C", str(repo_path), "diff", "--name-status", "HEAD@{1}", "HEAD"],
+        capture_output=True,
+        text=True,
+    )
+    added = updated = removed = 0
+    for line in result.stdout.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\t", 1)
+        if len(parts) < 2:
+            continue
+        status, filename = parts[0].strip(), parts[1].strip()
+        if not filename.endswith(".md"):
+            continue
+        if status.startswith("A"):
+            added += 1
+        elif status.startswith("M"):
+            updated += 1
+        elif status.startswith("D"):
+            removed += 1
+    return {"added": added, "updated": updated, "removed": removed}
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--quiet", action="store_true", help="Suppress output if no changes")
+    parser.add_argument(
+        "--config",
+        default=None,
+        help="Path to config file (default: evolve.config.yaml in project root)",
+    )
+    args = parser.parse_args()
+
+    project_root = "."
+    evolve_dir = Path(os.environ.get("EVOLVE_DIR", ".evolve"))
+
+    # Determine config path
+    if args.config:
+        cfg_path = Path(args.config)
+        # Load config from explicit path by temporarily reading the file
+        if cfg_path.exists():
+            from config import _parse_yaml
+            cfg = _parse_yaml(cfg_path.read_text(encoding="utf-8"))
+        else:
+            cfg = {}
+    else:
+        cfg = load_config(project_root)
+
+    # Check sync.on_session_start
+    sync_cfg = cfg.get("sync", {})
+    if isinstance(sync_cfg, dict) and sync_cfg.get("on_session_start") is False:
+        sys.exit(0)
+
+    subscriptions = cfg.get("subscriptions", [])
+    if not isinstance(subscriptions, list):
+        subscriptions = []
+
+    if not subscriptions:
+        if not args.quiet:
+            print("No subscriptions configured.")
+        sys.exit(0)
+
+    identity = cfg.get("identity", {})
+    actor = identity.get("user", "unknown") if isinstance(identity, dict) else "unknown"
+
+    summaries = []
+    total_delta = {}
+    any_changes = False
+
+    for sub in subscriptions:
+        if not isinstance(sub, dict):
+            continue
+        name = sub.get("name", "unknown")
+        branch = sub.get("branch", "main")
+        repo_path = evolve_dir / "subscribed" / name
+
+        if not repo_path.is_dir():
+            summaries.append(f"{name} (not cloned — run /evolve-lite-subscribe first)")
+            continue
+
+        pull_result = git_pull(repo_path, branch)
+        delta = count_delta(repo_path)
+        total_delta[name] = delta
+
+        has_changes = any(v > 0 for v in delta.values())
+        if has_changes:
+            any_changes = True
+
+        # Mirror entities into .evolve/entities/subscribed/{name}/
+        entities_subscribed = evolve_dir / "entities" / "subscribed" / name
+        copy_entities(repo_path, entities_subscribed)
+
+        delta_str = (
+            f"+{delta['added']} added, "
+            f"{delta['updated']} updated, "
+            f"{delta['removed']} removed"
+        )
+        summaries.append(f"{name} ({delta_str})")
+
+    # Audit
+    audit_append(
+        project_root=project_root,
+        action="sync",
+        actor=actor,
+        delta=total_delta,
+    )
+
+    if args.quiet and not any_changes:
+        sys.exit(0)
+
+    n = len(summaries)
+    summary_line = f"Synced {n} repo(s): " + ", ".join(summaries)
+    print(summary_line)
+
+
+if __name__ == "__main__":
+    main()

--- a/platform-integrations/claude/plugins/evolve-lite/skills/sync/scripts/sync.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/sync/scripts/sync.py
@@ -32,9 +32,10 @@ def git_sync(repo_path, branch):
     files, discards any local modifications. Subscribed repos are read-only mirrors
     so there is nothing worth preserving locally.
     """
+    git_base = ["git", "-c", f"safe.directory={repo_path}", "-C", str(repo_path)]
     try:
         fetch = subprocess.run(
-            ["git", "-C", str(repo_path), "fetch", "origin", branch],
+            [*git_base, "fetch", "origin", branch],
             capture_output=True,
             text=True,
             timeout=_GIT_TIMEOUT,
@@ -42,7 +43,7 @@ def git_sync(repo_path, branch):
         if fetch.returncode != 0:
             return fetch
         return subprocess.run(
-            ["git", "-C", str(repo_path), "reset", "--hard", f"origin/{branch}"],
+            [*git_base, "reset", "--hard", f"origin/{branch}"],
             capture_output=True,
             text=True,
             timeout=_GIT_TIMEOUT,
@@ -58,7 +59,7 @@ def count_delta(repo_path):
     Returns dict: {added: int, updated: int, removed: int}
     """
     result = subprocess.run(
-        ["git", "-C", str(repo_path), "diff", "--name-status", "HEAD@{1}", "HEAD"],
+        ["git", "-c", f"safe.directory={repo_path}", "-C", str(repo_path), "diff", "--name-status", "HEAD@{1}", "HEAD"],
         capture_output=True,
         text=True,
         timeout=_GIT_TIMEOUT,

--- a/platform-integrations/claude/plugins/evolve-lite/skills/sync/scripts/sync.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/sync/scripts/sync.py
@@ -143,8 +143,21 @@ def main():
         repo_path = evolve_dir / "entities" / "subscribed" / name
 
         if not repo_path.is_dir():
-            summaries.append(f"{name} (not cloned — run /evolve-lite-subscribe first)")
-            continue
+            remote = sub.get("remote")
+            if not remote:
+                summaries.append(f"{name} (not cloned — no remote in config, run /evolve-lite:subscribe first)")
+                continue
+            repo_path.parent.mkdir(parents=True, exist_ok=True)
+            clone_result = subprocess.run(
+                ["git", "clone", remote, str(repo_path), "--branch", branch, "--depth", "1"],
+                capture_output=True,
+                text=True,
+                timeout=_GIT_TIMEOUT,
+            )
+            if clone_result.returncode != 0:
+                summaries.append(f"{name} (re-clone failed: {clone_result.stderr.strip()})")
+                total_delta[name] = {"added": 0, "updated": 0, "removed": 0}
+                continue
 
         pull_result = git_sync(repo_path, branch)
         if pull_result is None or pull_result.returncode != 0:

--- a/platform-integrations/claude/plugins/evolve-lite/skills/sync/scripts/sync.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/sync/scripts/sync.py
@@ -25,17 +25,30 @@ from audit import append as audit_append
 _GIT_TIMEOUT = 30  # seconds
 
 
-def git_pull(repo_path, branch):
-    """Pull latest from origin. Returns CompletedProcess, or None on timeout."""
+def git_sync(repo_path, branch):
+    """Fetch and hard-reset to origin. Returns CompletedProcess, or None on timeout.
+
+    Hard reset ensures local clone always matches remote exactly — restores deleted
+    files, discards any local modifications. Subscribed repos are read-only mirrors
+    so there is nothing worth preserving locally.
+    """
     try:
+        fetch = subprocess.run(
+            ["git", "-C", str(repo_path), "fetch", "origin", branch],
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT,
+        )
+        if fetch.returncode != 0:
+            return fetch
         return subprocess.run(
-            ["git", "-C", str(repo_path), "pull", "origin", branch, "--ff-only"],
+            ["git", "-C", str(repo_path), "reset", "--hard", f"origin/{branch}"],
             capture_output=True,
             text=True,
             timeout=_GIT_TIMEOUT,
         )
     except subprocess.TimeoutExpired:
-        print(f"Warning: git pull timed out for {repo_path} (branch: {branch})", file=sys.stderr)
+        print(f"Warning: git sync timed out for {repo_path} (branch: {branch})", file=sys.stderr)
         return None
 
 
@@ -132,16 +145,13 @@ def main():
             summaries.append(f"{name} (not cloned — run /evolve-lite-subscribe first)")
             continue
 
-        pull_result = git_pull(repo_path, branch)
+        pull_result = git_sync(repo_path, branch)
         if pull_result is None or pull_result.returncode != 0:
-            summaries.append(f"{name} (pull failed — skipping mirror)")
+            summaries.append(f"{name} (sync failed — skipping)")
             total_delta[name] = {"added": 0, "updated": 0, "removed": 0}
             continue
 
-        if "Already up to date" in (pull_result.stdout or ""):
-            delta = {"added": 0, "updated": 0, "removed": 0}
-        else:
-            delta = count_delta(repo_path)
+        delta = count_delta(repo_path)
         total_delta[name] = delta
 
         has_changes = any(v > 0 for v in delta.values())

--- a/platform-integrations/claude/plugins/evolve-lite/skills/sync/scripts/sync.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/sync/scripts/sync.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
 """Pull the latest guidelines from all subscribed repos.
 
-After pulling, copies .md files from .evolve/subscribed/{name}/ into
-.evolve/entities/subscribed/{name}/ so the existing recall hook picks them
-up without any changes.
+Subscribed repos are cloned directly into .evolve/entities/subscribed/{name}/
+so the recall hook can read them without a separate mirror step.
 
 Usage:
   --quiet        Suppress output if no changes.
@@ -13,7 +12,6 @@ Usage:
 import argparse
 import os
 import re
-import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -39,24 +37,6 @@ def git_pull(repo_path, branch):
     except subprocess.TimeoutExpired:
         print(f"Warning: git pull timed out for {repo_path} (branch: {branch})", file=sys.stderr)
         return None
-
-
-def copy_entities(subscribed_repo_path, entities_subscribed_path):
-    """Mirror .md files from the subscribed git clone into entities/subscribed/{name}/.
-
-    Clears the destination first so removed files don't linger.
-    The owner field stamped at publish time travels with the file — no
-    frontmatter manipulation needed here.
-    """
-    if entities_subscribed_path.exists():
-        shutil.rmtree(entities_subscribed_path)
-    for md in sorted(subscribed_repo_path.glob("**/*.md")):
-        if md.is_symlink():
-            continue
-        rel = md.relative_to(subscribed_repo_path)
-        dest = entities_subscribed_path / rel
-        dest.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(md, dest)
 
 
 def count_delta(repo_path):
@@ -146,7 +126,7 @@ def main():
             summaries.append(f"{name!r} (skipped — invalid subscription name)")
             continue
 
-        repo_path = evolve_dir / "subscribed" / name
+        repo_path = evolve_dir / "entities" / "subscribed" / name
 
         if not repo_path.is_dir():
             summaries.append(f"{name} (not cloned — run /evolve-lite-subscribe first)")
@@ -167,10 +147,6 @@ def main():
         has_changes = any(v > 0 for v in delta.values())
         if has_changes:
             any_changes = True
-
-        # Mirror entities into .evolve/entities/subscribed/{name}/
-        entities_subscribed = evolve_dir / "entities" / "subscribed" / name
-        copy_entities(repo_path, entities_subscribed)
 
         delta_str = f"+{delta['added']} added, {delta['updated']} updated, {delta['removed']} removed"
         summaries.append(f"{name} ({delta_str})")

--- a/platform-integrations/claude/plugins/evolve-lite/skills/unsubscribe/SKILL.md
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/unsubscribe/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: unsubscribe
+description: Remove a subscription and delete the locally synced guidelines.
+---
+
+# Unsubscribe from Guidelines
+
+## Overview
+
+This skill removes a subscription and deletes the locally cloned guidelines for that subscription.
+
+## Workflow
+
+### Step 1: List subscriptions
+
+Run the following and display the output as a numbered list:
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/unsubscribe/scripts/unsubscribe.py --list
+```
+
+### Step 2: Pick one
+
+Ask the user:
+
+> "Which subscription would you like to remove? Enter the number."
+
+### Step 3: Confirm
+
+Ask the user:
+
+> "This will remove '{name}' and delete `.evolve/subscribed/{name}/`. Continue? (y/n)"
+
+If the user answers anything other than `y` or `yes`, stop and tell them the operation was cancelled.
+
+### Step 4: Run unsubscribe script
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/unsubscribe/scripts/unsubscribe.py --name {name}
+```
+
+### Step 5: Confirm
+
+Tell the user:
+
+> "Unsubscribed from {name}."

--- a/platform-integrations/claude/plugins/evolve-lite/skills/unsubscribe/SKILL.md
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/unsubscribe/SKILL.md
@@ -29,7 +29,7 @@ Ask the user:
 
 Ask the user:
 
-> "This will remove '{name}' and delete `.evolve/subscribed/{name}/`. Continue? (y/n)"
+> "This will remove '{name}' and delete `.evolve/subscribed/{name}/` and `.evolve/entities/subscribed/{name}/`. Continue? (y/n)"
 
 If the user answers anything other than `y` or `yes`, stop and tell them the operation was cancelled.
 

--- a/platform-integrations/claude/plugins/evolve-lite/skills/unsubscribe/scripts/unsubscribe.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/unsubscribe/scripts/unsubscribe.py
@@ -26,8 +26,8 @@ def main():
     group.add_argument("--name", help="Name of subscription to remove")
     args = parser.parse_args()
 
-    project_root = "."
     evolve_dir = Path(os.environ.get("EVOLVE_DIR", ".evolve"))
+    project_root = str(evolve_dir.parent) if "EVOLVE_DIR" in os.environ else "."
 
     cfg = load_config(project_root)
     subscriptions = cfg.get("subscriptions", [])

--- a/platform-integrations/claude/plugins/evolve-lite/skills/unsubscribe/scripts/unsubscribe.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/unsubscribe/scripts/unsubscribe.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Remove a subscription and delete the locally cloned directory.
+
+Usage:
+  --list          Print subscriptions as a JSON array and exit.
+  --name {name}   Remove named subscription from config and delete local dir.
+"""
+import argparse
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+
+# Add lib to path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent.parent / "lib"))
+from config import load_config, save_config
+from audit import append as audit_append
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--list", action="store_true", help="Print subscriptions as JSON array")
+    group.add_argument("--name", help="Name of subscription to remove")
+    args = parser.parse_args()
+
+    project_root = "."
+    evolve_dir = Path(os.environ.get("EVOLVE_DIR", ".evolve"))
+
+    cfg = load_config(project_root)
+    subscriptions = cfg.get("subscriptions", [])
+    if not isinstance(subscriptions, list):
+        subscriptions = []
+
+    if args.list:
+        print(json.dumps(subscriptions, indent=2))
+        return
+
+    # --name: remove the named subscription
+    name = args.name
+    new_subs = [s for s in subscriptions if not (isinstance(s, dict) and s.get("name") == name)]
+
+    if len(new_subs) == len(subscriptions):
+        print(f"Error: subscription '{name}' not found.", file=sys.stderr)
+        sys.exit(1)
+
+    # Delete local clone
+    dest = evolve_dir / "subscribed" / name
+    if dest.exists():
+        shutil.rmtree(dest)
+        print(f"Deleted {dest}")
+    else:
+        print(f"Warning: {dest} did not exist.", file=sys.stderr)
+
+    # Delete mirrored entities so they stop appearing in recall
+    entities_dest = evolve_dir / "entities" / "subscribed" / name
+    if entities_dest.exists():
+        shutil.rmtree(entities_dest)
+        print(f"Deleted {entities_dest}")
+
+    # Update config
+    cfg["subscriptions"] = new_subs
+    save_config(cfg, project_root)
+
+    # Audit
+    identity = cfg.get("identity", {})
+    actor = identity.get("user", "unknown") if isinstance(identity, dict) else "unknown"
+    audit_append(
+        project_root=project_root,
+        action="unsubscribe",
+        actor=actor,
+        name=name,
+    )
+
+    print(f"Removed subscription '{name}' from config.")
+
+
+if __name__ == "__main__":
+    main()

--- a/platform-integrations/claude/plugins/evolve-lite/skills/unsubscribe/scripts/unsubscribe.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/unsubscribe/scripts/unsubscribe.py
@@ -39,6 +39,21 @@ def main():
 
     # --name: remove the named subscription
     name = args.name
+
+    # Validate name: resolve both deletion targets and confirm they stay within
+    # their intended directories before any filesystem operations
+    subscribed_base = (evolve_dir / "subscribed").resolve()
+    dest = (evolve_dir / "subscribed" / name).resolve()
+    if not dest.is_relative_to(subscribed_base):
+        print(f"Error: invalid subscription name: {name!r}", file=sys.stderr)
+        sys.exit(1)
+
+    entities_base = (evolve_dir / "entities" / "subscribed").resolve()
+    entities_dest = (evolve_dir / "entities" / "subscribed" / name).resolve()
+    if not entities_dest.is_relative_to(entities_base):
+        print(f"Error: invalid subscription name: {name!r}", file=sys.stderr)
+        sys.exit(1)
+
     new_subs = [s for s in subscriptions if not (isinstance(s, dict) and s.get("name") == name)]
 
     if len(new_subs) == len(subscriptions):
@@ -46,7 +61,6 @@ def main():
         sys.exit(1)
 
     # Delete local clone
-    dest = evolve_dir / "subscribed" / name
     if dest.exists():
         shutil.rmtree(dest)
         print(f"Deleted {dest}")
@@ -54,7 +68,6 @@ def main():
         print(f"Warning: {dest} did not exist.", file=sys.stderr)
 
     # Delete mirrored entities so they stop appearing in recall
-    entities_dest = evolve_dir / "entities" / "subscribed" / name
     if entities_dest.exists():
         shutil.rmtree(entities_dest)
         print(f"Deleted {entities_dest}")

--- a/platform-integrations/claude/plugins/evolve-lite/skills/unsubscribe/scripts/unsubscribe.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/unsubscribe/scripts/unsubscribe.py
@@ -5,6 +5,7 @@ Usage:
   --list          Print subscriptions as a JSON array and exit.
   --name {name}   Remove named subscription from config and delete local dir.
 """
+
 import argparse
 import json
 import os

--- a/platform-integrations/claude/plugins/evolve-lite/skills/unsubscribe/scripts/unsubscribe.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/unsubscribe/scripts/unsubscribe.py
@@ -41,17 +41,10 @@ def main():
     # --name: remove the named subscription
     name = args.name
 
-    # Validate name: resolve both deletion targets and confirm they stay within
-    # their intended directories before any filesystem operations
-    subscribed_base = (evolve_dir / "subscribed").resolve()
-    dest = (evolve_dir / "subscribed" / name).resolve()
+    # Validate name: resolve and confirm it stays within the subscribed directory
+    subscribed_base = (evolve_dir / "entities" / "subscribed").resolve()
+    dest = (evolve_dir / "entities" / "subscribed" / name).resolve()
     if not dest.is_relative_to(subscribed_base):
-        print(f"Error: invalid subscription name: {name!r}", file=sys.stderr)
-        sys.exit(1)
-
-    entities_base = (evolve_dir / "entities" / "subscribed").resolve()
-    entities_dest = (evolve_dir / "entities" / "subscribed" / name).resolve()
-    if not entities_dest.is_relative_to(entities_base):
         print(f"Error: invalid subscription name: {name!r}", file=sys.stderr)
         sys.exit(1)
 
@@ -61,17 +54,12 @@ def main():
         print(f"Error: subscription '{name}' not found.", file=sys.stderr)
         sys.exit(1)
 
-    # Delete local clone
+    # Delete local clone (also removes mirrored entities since they live here)
     if dest.exists():
         shutil.rmtree(dest)
         print(f"Deleted {dest}")
     else:
         print(f"Warning: {dest} did not exist.", file=sys.stderr)
-
-    # Delete mirrored entities so they stop appearing in recall
-    if entities_dest.exists():
-        shutil.rmtree(entities_dest)
-        print(f"Deleted {entities_dest}")
 
     # Update config
     cfg["subscriptions"] = new_subs

--- a/platform-integrations/claude/plugins/evolve-lite/skills/unsubscribe/scripts/unsubscribe.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/unsubscribe/scripts/unsubscribe.py
@@ -44,7 +44,7 @@ def main():
     # Validate name: resolve and confirm it stays within the subscribed directory
     subscribed_base = (evolve_dir / "entities" / "subscribed").resolve()
     dest = (evolve_dir / "entities" / "subscribed" / name).resolve()
-    if not dest.is_relative_to(subscribed_base):
+    if not dest.is_relative_to(subscribed_base) or dest == subscribed_base:
         print(f"Error: invalid subscription name: {name!r}", file=sys.stderr)
         sys.exit(1)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,5 +174,7 @@ module = [
     "psycopg.*",
     "entity_io.*",
     "local_mcp_server",
+    "config",
+    "audit",
 ]
 ignore_missing_imports = true

--- a/tests/platform_integrations/conftest.py
+++ b/tests/platform_integrations/conftest.py
@@ -16,6 +16,7 @@ import pytest
 def pytest_configure(config):
     """Register custom markers."""
     config.addinivalue_line("markers", "platform_integrations: tests for platform-integrations/install.sh")
+    config.addinivalue_line("markers", "integration: tests that require git and perform subprocess I/O")
 
 
 @pytest.fixture
@@ -533,3 +534,70 @@ def bob_fixtures():
 def codex_fixtures():
     """Provide Codex platform test fixtures."""
     return CodexFixtures()
+
+
+# ---------------------------------------------------------------------------
+# Evolve-lite plugin fixtures
+# ---------------------------------------------------------------------------
+
+EVOLVE_PLUGIN_ROOT = (
+    Path(__file__).parent.parent.parent
+    / "platform-integrations/claude/plugins/evolve-lite"
+)
+
+
+@pytest.fixture
+def git_env():
+    """git environment with author info set so commits work in CI without ~/.gitconfig."""
+    return {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "Test User",
+        "GIT_AUTHOR_EMAIL": "test@example.com",
+        "GIT_COMMITTER_NAME": "Test User",
+        "GIT_COMMITTER_EMAIL": "test@example.com",
+    }
+
+
+@pytest.fixture
+def local_repo(tmp_path, git_env):
+    """A local bare git repo acting as a mock remote for subscribe/sync tests.
+
+    Returns a dict:
+      bare  — Path to the bare repo (pass as --remote to subscribe.py)
+      work  — Path to a working clone (push new commits here to simulate updates)
+      env   — git env dict (reuse for any git subprocess calls in tests)
+    """
+    # 1. Init a scratch working dir and pin the default branch to 'main'
+    init = tmp_path / "init_work"
+    init.mkdir()
+    subprocess.run(["git", "init", str(init)], check=True, capture_output=True, env=git_env)
+    subprocess.run(
+        ["git", "-C", str(init), "symbolic-ref", "HEAD", "refs/heads/main"],
+        check=True, capture_output=True, env=git_env,
+    )
+
+    # Seed one entity
+    guideline = init / "guideline"
+    guideline.mkdir()
+    (guideline / "tip-one.md").write_text("---\ntype: guideline\n---\n\nAlways write tests.\n")
+    subprocess.run(["git", "-C", str(init), "add", "."], check=True, capture_output=True, env=git_env)
+    subprocess.run(
+        ["git", "-C", str(init), "commit", "-m", "init"],
+        check=True, capture_output=True, env=git_env,
+    )
+
+    # 2. Create a bare clone (this is the "remote")
+    bare = tmp_path / "remote.git"
+    subprocess.run(
+        ["git", "clone", "--bare", str(init), str(bare)],
+        check=True, capture_output=True, env=git_env,
+    )
+
+    # 3. Create a working clone of the bare (for pushing new commits in tests)
+    work = tmp_path / "work"
+    subprocess.run(
+        ["git", "clone", str(bare), str(work)],
+        check=True, capture_output=True, env=git_env,
+    )
+
+    return {"bare": bare, "work": work, "env": git_env}

--- a/tests/platform_integrations/conftest.py
+++ b/tests/platform_integrations/conftest.py
@@ -17,6 +17,7 @@ def pytest_configure(config):
     """Register custom markers."""
     config.addinivalue_line("markers", "platform_integrations: tests for platform-integrations/install.sh")
     config.addinivalue_line("markers", "integration: tests that require git and perform subprocess I/O")
+    config.addinivalue_line("markers", "e2e: end-to-end tests that exercise real filesystem and subprocesses")
 
 
 @pytest.fixture
@@ -540,10 +541,7 @@ def codex_fixtures():
 # Evolve-lite plugin fixtures
 # ---------------------------------------------------------------------------
 
-EVOLVE_PLUGIN_ROOT = (
-    Path(__file__).parent.parent.parent
-    / "platform-integrations/claude/plugins/evolve-lite"
-)
+EVOLVE_PLUGIN_ROOT = Path(__file__).parent.parent.parent / "platform-integrations/claude/plugins/evolve-lite"
 
 
 @pytest.fixture
@@ -573,7 +571,9 @@ def local_repo(tmp_path, git_env):
     subprocess.run(["git", "init", str(init)], check=True, capture_output=True, env=git_env)
     subprocess.run(
         ["git", "-C", str(init), "symbolic-ref", "HEAD", "refs/heads/main"],
-        check=True, capture_output=True, env=git_env,
+        check=True,
+        capture_output=True,
+        env=git_env,
     )
 
     # Seed one entity
@@ -583,21 +583,27 @@ def local_repo(tmp_path, git_env):
     subprocess.run(["git", "-C", str(init), "add", "."], check=True, capture_output=True, env=git_env)
     subprocess.run(
         ["git", "-C", str(init), "commit", "-m", "init"],
-        check=True, capture_output=True, env=git_env,
+        check=True,
+        capture_output=True,
+        env=git_env,
     )
 
     # 2. Create a bare clone (this is the "remote")
     bare = tmp_path / "remote.git"
     subprocess.run(
         ["git", "clone", "--bare", str(init), str(bare)],
-        check=True, capture_output=True, env=git_env,
+        check=True,
+        capture_output=True,
+        env=git_env,
     )
 
     # 3. Create a working clone of the bare (for pushing new commits in tests)
     work = tmp_path / "work"
     subprocess.run(
         ["git", "clone", str(bare), str(work)],
-        check=True, capture_output=True, env=git_env,
+        check=True,
+        capture_output=True,
+        env=git_env,
     )
 
     return {"bare": bare, "work": work, "env": git_env}

--- a/tests/platform_integrations/test_audit.py
+++ b/tests/platform_integrations/test_audit.py
@@ -16,40 +16,40 @@ pytestmark = pytest.mark.platform_integrations
 
 
 class TestAuditAppend:
-    def test_creates_log_file_on_first_call(self, tmp_path):
-        audit.append(project_root=str(tmp_path), action="test")
-        assert (tmp_path / ".evolve" / "audit.log").exists()
+    def test_creates_log_file_on_first_call(self, temp_project_dir):
+        audit.append(project_root=str(temp_project_dir), action="test")
+        assert (temp_project_dir / ".evolve" / "audit.log").exists()
 
-    def test_creates_parent_directories(self, tmp_path):
-        nested = tmp_path / "deep" / "project"
+    def test_creates_parent_directories(self, temp_project_dir):
+        nested = temp_project_dir / "deep" / "project"
         nested.mkdir(parents=True)
         audit.append(project_root=str(nested), action="test")
         assert (nested / ".evolve" / "audit.log").exists()
 
-    def test_entry_is_valid_json(self, tmp_path):
-        audit.append(project_root=str(tmp_path), action="publish", actor="alice", entity="tip.md")
-        line = (tmp_path / ".evolve" / "audit.log").read_text().strip()
+    def test_entry_is_valid_json(self, temp_project_dir):
+        audit.append(project_root=str(temp_project_dir), action="publish", actor="alice", entity="tip.md")
+        line = (temp_project_dir / ".evolve" / "audit.log").read_text().strip()
         entry = json.loads(line)
         assert entry["action"] == "publish"
         assert entry["actor"] == "alice"
         assert entry["entity"] == "tip.md"
 
-    def test_timestamp_field_present_and_utc(self, tmp_path):
-        audit.append(project_root=str(tmp_path), action="sync")
-        entry = json.loads((tmp_path / ".evolve" / "audit.log").read_text().strip())
+    def test_timestamp_field_present_and_utc(self, temp_project_dir):
+        audit.append(project_root=str(temp_project_dir), action="sync")
+        entry = json.loads((temp_project_dir / ".evolve" / "audit.log").read_text().strip())
         assert "ts" in entry
         assert entry["ts"].endswith("Z")
 
-    def test_multiple_calls_produce_multiple_lines(self, tmp_path):
-        audit.append(project_root=str(tmp_path), action="subscribe", name="alice")
-        audit.append(project_root=str(tmp_path), action="sync")
-        audit.append(project_root=str(tmp_path), action="unsubscribe", name="alice")
-        lines = (tmp_path / ".evolve" / "audit.log").read_text().splitlines()
+    def test_multiple_calls_produce_multiple_lines(self, temp_project_dir):
+        audit.append(project_root=str(temp_project_dir), action="subscribe", name="alice")
+        audit.append(project_root=str(temp_project_dir), action="sync")
+        audit.append(project_root=str(temp_project_dir), action="unsubscribe", name="alice")
+        lines = (temp_project_dir / ".evolve" / "audit.log").read_text().splitlines()
         assert len(lines) == 3
         actions = [json.loads(l)["action"] for l in lines]
         assert actions == ["subscribe", "sync", "unsubscribe"]
 
-    def test_extra_fields_are_preserved(self, tmp_path):
-        audit.append(project_root=str(tmp_path), action="sync", delta={"alice": {"added": 2}})
-        entry = json.loads((tmp_path / ".evolve" / "audit.log").read_text().strip())
+    def test_extra_fields_are_preserved(self, temp_project_dir):
+        audit.append(project_root=str(temp_project_dir), action="sync", delta={"alice": {"added": 2}})
+        entry = json.loads((temp_project_dir / ".evolve" / "audit.log").read_text().strip())
         assert entry["delta"]["alice"]["added"] == 2

--- a/tests/platform_integrations/test_audit.py
+++ b/tests/platform_integrations/test_audit.py
@@ -1,0 +1,55 @@
+"""Tests for evolve-lite lib/audit.py — append-only JSON audit log."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(
+    0,
+    str(Path(__file__).parent.parent.parent / "platform-integrations/claude/plugins/evolve-lite/lib"),
+)
+import audit
+
+pytestmark = pytest.mark.platform_integrations
+
+
+class TestAuditAppend:
+    def test_creates_log_file_on_first_call(self, tmp_path):
+        audit.append(project_root=str(tmp_path), action="test")
+        assert (tmp_path / ".evolve" / "audit.log").exists()
+
+    def test_creates_parent_directories(self, tmp_path):
+        nested = tmp_path / "deep" / "project"
+        nested.mkdir(parents=True)
+        audit.append(project_root=str(nested), action="test")
+        assert (nested / ".evolve" / "audit.log").exists()
+
+    def test_entry_is_valid_json(self, tmp_path):
+        audit.append(project_root=str(tmp_path), action="publish", actor="alice", entity="tip.md")
+        line = (tmp_path / ".evolve" / "audit.log").read_text().strip()
+        entry = json.loads(line)
+        assert entry["action"] == "publish"
+        assert entry["actor"] == "alice"
+        assert entry["entity"] == "tip.md"
+
+    def test_timestamp_field_present_and_utc(self, tmp_path):
+        audit.append(project_root=str(tmp_path), action="sync")
+        entry = json.loads((tmp_path / ".evolve" / "audit.log").read_text().strip())
+        assert "ts" in entry
+        assert entry["ts"].endswith("Z")
+
+    def test_multiple_calls_produce_multiple_lines(self, tmp_path):
+        audit.append(project_root=str(tmp_path), action="subscribe", name="alice")
+        audit.append(project_root=str(tmp_path), action="sync")
+        audit.append(project_root=str(tmp_path), action="unsubscribe", name="alice")
+        lines = (tmp_path / ".evolve" / "audit.log").read_text().splitlines()
+        assert len(lines) == 3
+        actions = [json.loads(l)["action"] for l in lines]
+        assert actions == ["subscribe", "sync", "unsubscribe"]
+
+    def test_extra_fields_are_preserved(self, tmp_path):
+        audit.append(project_root=str(tmp_path), action="sync", delta={"alice": {"added": 2}})
+        entry = json.loads((tmp_path / ".evolve" / "audit.log").read_text().strip())
+        assert entry["delta"]["alice"]["added"] == 2

--- a/tests/platform_integrations/test_audit.py
+++ b/tests/platform_integrations/test_audit.py
@@ -46,7 +46,7 @@ class TestAuditAppend:
         audit.append(project_root=str(temp_project_dir), action="unsubscribe", name="alice")
         lines = (temp_project_dir / ".evolve" / "audit.log").read_text().splitlines()
         assert len(lines) == 3
-        actions = [json.loads(l)["action"] for l in lines]
+        actions = [json.loads(line)["action"] for line in lines]
         assert actions == ["subscribe", "sync", "unsubscribe"]
 
     def test_extra_fields_are_preserved(self, temp_project_dir):

--- a/tests/platform_integrations/test_config.py
+++ b/tests/platform_integrations/test_config.py
@@ -1,0 +1,160 @@
+"""Tests for evolve-lite lib/config.py — minimal YAML reader/writer."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(
+    0,
+    str(Path(__file__).parent.parent.parent / "platform-integrations/claude/plugins/evolve-lite/lib"),
+)
+import config as cfg_module
+
+pytestmark = pytest.mark.platform_integrations
+
+
+class TestCast:
+    """_cast() converts YAML scalar strings to Python types."""
+
+    def test_true_variants(self):
+        assert cfg_module._cast("true") is True
+        assert cfg_module._cast("True") is True
+        assert cfg_module._cast("yes") is True
+
+    def test_false_variants(self):
+        assert cfg_module._cast("false") is False
+        assert cfg_module._cast("False") is False
+        assert cfg_module._cast("no") is False
+
+    def test_null_variants(self):
+        assert cfg_module._cast("null") is None
+        assert cfg_module._cast("~") is None
+        assert cfg_module._cast("") is None
+
+    def test_integer(self):
+        assert cfg_module._cast("0") == 0
+        assert cfg_module._cast("42") == 42
+        assert cfg_module._cast("-7") == -7
+
+    def test_float(self):
+        assert cfg_module._cast("3.14") == pytest.approx(3.14)
+
+    def test_empty_list_literal(self):
+        assert cfg_module._cast("[]") == []
+
+    def test_double_quoted_string(self):
+        assert cfg_module._cast('"hello world"') == "hello world"
+
+    def test_single_quoted_string(self):
+        assert cfg_module._cast("'single quoted'") == "single quoted"
+
+    def test_plain_string_passthrough(self):
+        remote = "git@github.com:alice/evolve.git"
+        assert cfg_module._cast(remote) == remote
+
+
+class TestParseYaml:
+    """_parse_yaml() reads the minimal YAML subset used by evolve.config.yaml."""
+
+    def test_simple_scalar(self):
+        result = cfg_module._parse_yaml("key: value\n")
+        assert result["key"] == "value"
+
+    def test_integer_scalar(self):
+        result = cfg_module._parse_yaml("port: 8080\n")
+        assert result["port"] == 8080
+
+    def test_comment_stripped(self):
+        result = cfg_module._parse_yaml("key: value # inline comment\n")
+        assert result["key"] == "value"
+
+    def test_nested_mapping(self):
+        text = "identity:\n  user: alice\n  email: alice@example.com\n"
+        result = cfg_module._parse_yaml(text)
+        assert result["identity"]["user"] == "alice"
+        assert result["identity"]["email"] == "alice@example.com"
+
+    def test_boolean_nested(self):
+        text = "sync:\n  on_session_start: true\n"
+        result = cfg_module._parse_yaml(text)
+        assert result["sync"]["on_session_start"] is True
+
+    def test_list_of_dicts(self):
+        text = (
+            "subscriptions:\n"
+            "  - name: bob\n"
+            "    remote: git@github.com:bob/evolve.git\n"
+            "    branch: main\n"
+        )
+        result = cfg_module._parse_yaml(text)
+        subs = result["subscriptions"]
+        assert isinstance(subs, list)
+        assert len(subs) == 1
+        assert subs[0]["name"] == "bob"
+        assert subs[0]["branch"] == "main"
+
+    def test_multiple_subscriptions(self):
+        text = (
+            "subscriptions:\n"
+            "  - name: alice\n"
+            "    remote: git@github.com:alice/evolve.git\n"
+            "    branch: main\n"
+            "  - name: bob\n"
+            "    remote: git@github.com:bob/evolve.git\n"
+            "    branch: main\n"
+        )
+        result = cfg_module._parse_yaml(text)
+        assert len(result["subscriptions"]) == 2
+
+    def test_empty_input(self):
+        assert cfg_module._parse_yaml("") == {}
+
+    def test_blank_lines_ignored(self):
+        result = cfg_module._parse_yaml("\n\nkey: value\n\n")
+        assert result["key"] == "value"
+
+
+class TestLoadConfig:
+    def test_returns_empty_dict_when_file_missing(self, tmp_path):
+        assert cfg_module.load_config(str(tmp_path)) == {}
+
+    def test_parses_existing_file(self, tmp_path):
+        (tmp_path / "evolve.config.yaml").write_text("identity:\n  user: alice\n")
+        result = cfg_module.load_config(str(tmp_path))
+        assert result["identity"]["user"] == "alice"
+
+
+class TestSaveConfig:
+    def test_creates_file(self, tmp_path):
+        cfg_module.save_config({"key": "val"}, str(tmp_path))
+        assert (tmp_path / "evolve.config.yaml").exists()
+
+    def test_content_is_readable(self, tmp_path):
+        cfg_module.save_config({"key": "val"}, str(tmp_path))
+        text = (tmp_path / "evolve.config.yaml").read_text()
+        assert "key: val" in text
+
+
+class TestRoundtrip:
+    def test_full_config_roundtrip(self, tmp_path):
+        original = {
+            "identity": {"user": "alice"},
+            "public_repo": {"remote": "git@github.com:alice/evolve.git", "branch": "main"},
+            "subscriptions": [
+                {"name": "bob", "remote": "git@github.com:bob/evolve.git", "branch": "main"}
+            ],
+            "sync": {"on_session_start": True},
+        }
+        cfg_module.save_config(original, str(tmp_path))
+        loaded = cfg_module.load_config(str(tmp_path))
+
+        assert loaded["identity"]["user"] == "alice"
+        assert loaded["public_repo"]["branch"] == "main"
+        assert loaded["sync"]["on_session_start"] is True
+        assert loaded["subscriptions"][0]["name"] == "bob"
+
+    def test_empty_subscriptions_roundtrip(self, tmp_path):
+        cfg_module.save_config({"subscriptions": []}, str(tmp_path))
+        loaded = cfg_module.load_config(str(tmp_path))
+        assert loaded["subscriptions"] == []

--- a/tests/platform_integrations/test_config.py
+++ b/tests/platform_integrations/test_config.py
@@ -81,12 +81,7 @@ class TestParseYaml:
         assert result["sync"]["on_session_start"] is True
 
     def test_list_of_dicts(self):
-        text = (
-            "subscriptions:\n"
-            "  - name: bob\n"
-            "    remote: git@github.com:bob/evolve.git\n"
-            "    branch: main\n"
-        )
+        text = "subscriptions:\n  - name: bob\n    remote: git@github.com:bob/evolve.git\n    branch: main\n"
         result = cfg_module._parse_yaml(text)
         subs = result["subscriptions"]
         assert isinstance(subs, list)
@@ -116,45 +111,43 @@ class TestParseYaml:
 
 
 class TestLoadConfig:
-    def test_returns_empty_dict_when_file_missing(self, tmp_path):
-        assert cfg_module.load_config(str(tmp_path)) == {}
+    def test_returns_empty_dict_when_file_missing(self, temp_project_dir):
+        assert cfg_module.load_config(str(temp_project_dir)) == {}
 
-    def test_parses_existing_file(self, tmp_path):
-        (tmp_path / "evolve.config.yaml").write_text("identity:\n  user: alice\n")
-        result = cfg_module.load_config(str(tmp_path))
+    def test_parses_existing_file(self, temp_project_dir):
+        (temp_project_dir / "evolve.config.yaml").write_text("identity:\n  user: alice\n")
+        result = cfg_module.load_config(str(temp_project_dir))
         assert result["identity"]["user"] == "alice"
 
 
 class TestSaveConfig:
-    def test_creates_file(self, tmp_path):
-        cfg_module.save_config({"key": "val"}, str(tmp_path))
-        assert (tmp_path / "evolve.config.yaml").exists()
+    def test_creates_file(self, temp_project_dir):
+        cfg_module.save_config({"key": "val"}, str(temp_project_dir))
+        assert (temp_project_dir / "evolve.config.yaml").exists()
 
-    def test_content_is_readable(self, tmp_path):
-        cfg_module.save_config({"key": "val"}, str(tmp_path))
-        text = (tmp_path / "evolve.config.yaml").read_text()
+    def test_content_is_readable(self, temp_project_dir):
+        cfg_module.save_config({"key": "val"}, str(temp_project_dir))
+        text = (temp_project_dir / "evolve.config.yaml").read_text()
         assert 'key: "val"' in text
 
 
 class TestRoundtrip:
-    def test_full_config_roundtrip(self, tmp_path):
+    def test_full_config_roundtrip(self, temp_project_dir):
         original = {
             "identity": {"user": "alice"},
             "public_repo": {"remote": "git@github.com:alice/evolve.git", "branch": "main"},
-            "subscriptions": [
-                {"name": "bob", "remote": "git@github.com:bob/evolve.git", "branch": "main"}
-            ],
+            "subscriptions": [{"name": "bob", "remote": "git@github.com:bob/evolve.git", "branch": "main"}],
             "sync": {"on_session_start": True},
         }
-        cfg_module.save_config(original, str(tmp_path))
-        loaded = cfg_module.load_config(str(tmp_path))
+        cfg_module.save_config(original, str(temp_project_dir))
+        loaded = cfg_module.load_config(str(temp_project_dir))
 
         assert loaded["identity"]["user"] == "alice"
         assert loaded["public_repo"]["branch"] == "main"
         assert loaded["sync"]["on_session_start"] is True
         assert loaded["subscriptions"][0]["name"] == "bob"
 
-    def test_empty_subscriptions_roundtrip(self, tmp_path):
-        cfg_module.save_config({"subscriptions": []}, str(tmp_path))
-        loaded = cfg_module.load_config(str(tmp_path))
+    def test_empty_subscriptions_roundtrip(self, temp_project_dir):
+        cfg_module.save_config({"subscriptions": []}, str(temp_project_dir))
+        loaded = cfg_module.load_config(str(temp_project_dir))
         assert loaded["subscriptions"] == []

--- a/tests/platform_integrations/test_config.py
+++ b/tests/platform_integrations/test_config.py
@@ -133,7 +133,7 @@ class TestSaveConfig:
     def test_content_is_readable(self, tmp_path):
         cfg_module.save_config({"key": "val"}, str(tmp_path))
         text = (tmp_path / "evolve.config.yaml").read_text()
-        assert "key: val" in text
+        assert 'key: "val"' in text
 
 
 class TestRoundtrip:

--- a/tests/platform_integrations/test_entity_io_core.py
+++ b/tests/platform_integrations/test_entity_io_core.py
@@ -42,31 +42,31 @@ class TestSlugify:
 
 
 class TestUniqueFilename:
-    def test_returns_slug_md_when_no_collision(self, tmp_path):
-        path = entity_io.unique_filename(tmp_path, "my-tip")
-        assert path == tmp_path / "my-tip.md"
+    def test_returns_slug_md_when_no_collision(self, temp_project_dir):
+        path = entity_io.unique_filename(temp_project_dir, "my-tip")
+        assert path == temp_project_dir / "my-tip.md"
 
-    def test_increments_suffix_on_collision(self, tmp_path):
-        (tmp_path / "my-tip.md").touch()
-        path = entity_io.unique_filename(tmp_path, "my-tip")
-        assert path == tmp_path / "my-tip-2.md"
+    def test_increments_suffix_on_collision(self, temp_project_dir):
+        (temp_project_dir / "my-tip.md").touch()
+        path = entity_io.unique_filename(temp_project_dir, "my-tip")
+        assert path == temp_project_dir / "my-tip-2.md"
 
-    def test_keeps_incrementing(self, tmp_path):
-        (tmp_path / "my-tip.md").touch()
-        (tmp_path / "my-tip-2.md").touch()
-        path = entity_io.unique_filename(tmp_path, "my-tip")
-        assert path == tmp_path / "my-tip-3.md"
+    def test_keeps_incrementing(self, temp_project_dir):
+        (temp_project_dir / "my-tip.md").touch()
+        (temp_project_dir / "my-tip-2.md").touch()
+        path = entity_io.unique_filename(temp_project_dir, "my-tip")
+        assert path == temp_project_dir / "my-tip-3.md"
 
 
 class TestEntityMarkdownRoundtrip:
-    def test_basic_roundtrip(self, tmp_path):
+    def test_basic_roundtrip(self, temp_project_dir):
         entity = {
             "type": "guideline",
             "trigger": "when writing tests",
             "content": "Prefer real databases over mocks.",
             "rationale": "Mocks hide real integration bugs.",
         }
-        path = tmp_path / "test.md"
+        path = temp_project_dir / "test.md"
         path.write_text(entity_io.entity_to_markdown(entity))
         result = entity_io.markdown_to_entity(path)
 
@@ -75,16 +75,16 @@ class TestEntityMarkdownRoundtrip:
         assert result["trigger"] == "when writing tests"
         assert result["rationale"] == "Mocks hide real integration bugs."
 
-    def test_entity_without_optional_fields(self, tmp_path):
+    def test_entity_without_optional_fields(self, temp_project_dir):
         entity = {"type": "guideline", "content": "Keep functions small."}
-        path = tmp_path / "test.md"
+        path = temp_project_dir / "test.md"
         path.write_text(entity_io.entity_to_markdown(entity))
         result = entity_io.markdown_to_entity(path)
 
         assert result["content"] == "Keep functions small."
         assert "rationale" not in result
 
-    def test_visibility_owner_published_at_preserved(self, tmp_path):
+    def test_visibility_owner_published_at_preserved(self, temp_project_dir):
         entity = {
             "type": "guideline",
             "content": "Document public APIs.",
@@ -92,7 +92,7 @@ class TestEntityMarkdownRoundtrip:
             "owner": "alice",
             "published_at": "2026-01-01T00:00:00Z",
         }
-        path = tmp_path / "test.md"
+        path = temp_project_dir / "test.md"
         path.write_text(entity_io.entity_to_markdown(entity))
         result = entity_io.markdown_to_entity(path)
 
@@ -100,65 +100,61 @@ class TestEntityMarkdownRoundtrip:
         assert result["owner"] == "alice"
         assert result["published_at"] == "2026-01-01T00:00:00Z"
 
-    def test_file_without_frontmatter(self, tmp_path):
-        path = tmp_path / "test.md"
+    def test_file_without_frontmatter(self, temp_project_dir):
+        path = temp_project_dir / "test.md"
         path.write_text("Some content here.")
         result = entity_io.markdown_to_entity(path)
         assert result["content"] == "Some content here."
 
 
 class TestWriteEntityFile:
-    def test_writes_file_in_type_subdirectory(self, tmp_path):
+    def test_writes_file_in_type_subdirectory(self, temp_project_dir):
         entity = {"type": "guideline", "content": "Use semantic versioning."}
-        path = entity_io.write_entity_file(tmp_path, entity)
-        assert path.parent == tmp_path / "guideline"
+        path = entity_io.write_entity_file(temp_project_dir, entity)
+        assert path.parent == temp_project_dir / "guideline"
         assert path.suffix == ".md"
         assert path.exists()
 
-    def test_preference_type_goes_in_preference_dir(self, tmp_path):
+    def test_preference_type_goes_in_preference_dir(self, temp_project_dir):
         entity = {"type": "preference", "content": "Prefer tabs over spaces."}
-        path = entity_io.write_entity_file(tmp_path, entity)
-        assert path.parent == tmp_path / "preference"
+        path = entity_io.write_entity_file(temp_project_dir, entity)
+        assert path.parent == temp_project_dir / "preference"
 
-    def test_invalid_type_defaults_to_guideline(self, tmp_path):
+    def test_invalid_type_defaults_to_guideline(self, temp_project_dir):
         entity = {"type": "badtype", "content": "Some content."}
-        path = entity_io.write_entity_file(tmp_path, entity)
-        assert path.parent == tmp_path / "guideline"
+        path = entity_io.write_entity_file(temp_project_dir, entity)
+        assert path.parent == temp_project_dir / "guideline"
 
-    def test_written_file_is_readable(self, tmp_path):
+    def test_written_file_is_readable(self, temp_project_dir):
         entity = {"type": "guideline", "content": "Write clear commit messages."}
-        path = entity_io.write_entity_file(tmp_path, entity)
+        path = entity_io.write_entity_file(temp_project_dir, entity)
         result = entity_io.markdown_to_entity(path)
         assert result["content"] == "Write clear commit messages."
 
-    def test_no_collision_on_duplicate_slug(self, tmp_path):
+    def test_no_collision_on_duplicate_slug(self, temp_project_dir):
         entity = {"type": "guideline", "content": "No magic numbers."}
-        path1 = entity_io.write_entity_file(tmp_path, entity)
-        path2 = entity_io.write_entity_file(tmp_path, entity)
+        path1 = entity_io.write_entity_file(temp_project_dir, entity)
+        path2 = entity_io.write_entity_file(temp_project_dir, entity)
         assert path1 != path2
         assert path1.exists()
         assert path2.exists()
 
 
 class TestLoadAllEntities:
-    def test_loads_from_nested_type_dirs(self, tmp_path):
-        (tmp_path / "guideline").mkdir()
-        (tmp_path / "guideline" / "tip.md").write_text(
-            "---\ntype: guideline\n---\n\nKeep it simple.\n"
-        )
-        (tmp_path / "preference").mkdir()
-        (tmp_path / "preference" / "pref.md").write_text(
-            "---\ntype: preference\n---\n\nUse snake_case.\n"
-        )
-        entities = entity_io.load_all_entities(tmp_path)
+    def test_loads_from_nested_type_dirs(self, temp_project_dir):
+        (temp_project_dir / "guideline").mkdir()
+        (temp_project_dir / "guideline" / "tip.md").write_text("---\ntype: guideline\n---\n\nKeep it simple.\n")
+        (temp_project_dir / "preference").mkdir()
+        (temp_project_dir / "preference" / "pref.md").write_text("---\ntype: preference\n---\n\nUse snake_case.\n")
+        entities = entity_io.load_all_entities(temp_project_dir)
         contents = {e["content"] for e in entities}
         assert "Keep it simple." in contents
         assert "Use snake_case." in contents
 
-    def test_skips_files_without_content(self, tmp_path):
-        (tmp_path / "guideline").mkdir()
-        (tmp_path / "guideline" / "empty.md").write_text("---\ntype: guideline\n---\n\n")
-        assert entity_io.load_all_entities(tmp_path) == []
+    def test_skips_files_without_content(self, temp_project_dir):
+        (temp_project_dir / "guideline").mkdir()
+        (temp_project_dir / "guideline" / "empty.md").write_text("---\ntype: guideline\n---\n\n")
+        assert entity_io.load_all_entities(temp_project_dir) == []
 
-    def test_empty_directory_returns_empty_list(self, tmp_path):
-        assert entity_io.load_all_entities(tmp_path) == []
+    def test_empty_directory_returns_empty_list(self, temp_project_dir):
+        assert entity_io.load_all_entities(temp_project_dir) == []

--- a/tests/platform_integrations/test_entity_io_core.py
+++ b/tests/platform_integrations/test_entity_io_core.py
@@ -1,0 +1,164 @@
+"""Tests for entity_io.py — slugify, serialization, write, and load functions.
+
+The existing test_entity_io.py covers directory-resolution helpers. This file
+covers the serialization and I/O functions needed by the sharing feature.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(
+    0,
+    str(Path(__file__).parent.parent.parent / "platform-integrations/claude/plugins/evolve-lite/lib"),
+)
+import entity_io
+
+pytestmark = pytest.mark.platform_integrations
+
+
+class TestSlugify:
+    def test_lowercases_and_replaces_spaces(self):
+        assert entity_io.slugify("Hello World") == "hello-world"
+
+    def test_strips_special_characters(self):
+        assert entity_io.slugify("Use temp files for JSON transfer!") == "use-temp-files-for-json-transfer"
+
+    def test_collapses_multiple_separators(self):
+        assert entity_io.slugify("foo  --  bar") == "foo-bar"
+
+    def test_truncates_at_max_length_on_word_boundary(self):
+        long_text = "alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu"
+        result = entity_io.slugify(long_text, max_length=30)
+        assert len(result) <= 30
+        assert not result.endswith("-")
+
+    def test_empty_string_returns_entity(self):
+        assert entity_io.slugify("") == "entity"
+
+    def test_all_special_chars_returns_entity(self):
+        assert entity_io.slugify("!!!") == "entity"
+
+
+class TestUniqueFilename:
+    def test_returns_slug_md_when_no_collision(self, tmp_path):
+        path = entity_io.unique_filename(tmp_path, "my-tip")
+        assert path == tmp_path / "my-tip.md"
+
+    def test_increments_suffix_on_collision(self, tmp_path):
+        (tmp_path / "my-tip.md").touch()
+        path = entity_io.unique_filename(tmp_path, "my-tip")
+        assert path == tmp_path / "my-tip-2.md"
+
+    def test_keeps_incrementing(self, tmp_path):
+        (tmp_path / "my-tip.md").touch()
+        (tmp_path / "my-tip-2.md").touch()
+        path = entity_io.unique_filename(tmp_path, "my-tip")
+        assert path == tmp_path / "my-tip-3.md"
+
+
+class TestEntityMarkdownRoundtrip:
+    def test_basic_roundtrip(self, tmp_path):
+        entity = {
+            "type": "guideline",
+            "trigger": "when writing tests",
+            "content": "Prefer real databases over mocks.",
+            "rationale": "Mocks hide real integration bugs.",
+        }
+        path = tmp_path / "test.md"
+        path.write_text(entity_io.entity_to_markdown(entity))
+        result = entity_io.markdown_to_entity(path)
+
+        assert result["content"] == "Prefer real databases over mocks."
+        assert result["type"] == "guideline"
+        assert result["trigger"] == "when writing tests"
+        assert result["rationale"] == "Mocks hide real integration bugs."
+
+    def test_entity_without_optional_fields(self, tmp_path):
+        entity = {"type": "guideline", "content": "Keep functions small."}
+        path = tmp_path / "test.md"
+        path.write_text(entity_io.entity_to_markdown(entity))
+        result = entity_io.markdown_to_entity(path)
+
+        assert result["content"] == "Keep functions small."
+        assert "rationale" not in result
+
+    def test_visibility_owner_published_at_preserved(self, tmp_path):
+        entity = {
+            "type": "guideline",
+            "content": "Document public APIs.",
+            "visibility": "public",
+            "owner": "alice",
+            "published_at": "2026-01-01T00:00:00Z",
+        }
+        path = tmp_path / "test.md"
+        path.write_text(entity_io.entity_to_markdown(entity))
+        result = entity_io.markdown_to_entity(path)
+
+        assert result["visibility"] == "public"
+        assert result["owner"] == "alice"
+        assert result["published_at"] == "2026-01-01T00:00:00Z"
+
+    def test_file_without_frontmatter(self, tmp_path):
+        path = tmp_path / "test.md"
+        path.write_text("Some content here.")
+        result = entity_io.markdown_to_entity(path)
+        assert result["content"] == "Some content here."
+
+
+class TestWriteEntityFile:
+    def test_writes_file_in_type_subdirectory(self, tmp_path):
+        entity = {"type": "guideline", "content": "Use semantic versioning."}
+        path = entity_io.write_entity_file(tmp_path, entity)
+        assert path.parent == tmp_path / "guideline"
+        assert path.suffix == ".md"
+        assert path.exists()
+
+    def test_preference_type_goes_in_preference_dir(self, tmp_path):
+        entity = {"type": "preference", "content": "Prefer tabs over spaces."}
+        path = entity_io.write_entity_file(tmp_path, entity)
+        assert path.parent == tmp_path / "preference"
+
+    def test_invalid_type_defaults_to_guideline(self, tmp_path):
+        entity = {"type": "badtype", "content": "Some content."}
+        path = entity_io.write_entity_file(tmp_path, entity)
+        assert path.parent == tmp_path / "guideline"
+
+    def test_written_file_is_readable(self, tmp_path):
+        entity = {"type": "guideline", "content": "Write clear commit messages."}
+        path = entity_io.write_entity_file(tmp_path, entity)
+        result = entity_io.markdown_to_entity(path)
+        assert result["content"] == "Write clear commit messages."
+
+    def test_no_collision_on_duplicate_slug(self, tmp_path):
+        entity = {"type": "guideline", "content": "No magic numbers."}
+        path1 = entity_io.write_entity_file(tmp_path, entity)
+        path2 = entity_io.write_entity_file(tmp_path, entity)
+        assert path1 != path2
+        assert path1.exists()
+        assert path2.exists()
+
+
+class TestLoadAllEntities:
+    def test_loads_from_nested_type_dirs(self, tmp_path):
+        (tmp_path / "guideline").mkdir()
+        (tmp_path / "guideline" / "tip.md").write_text(
+            "---\ntype: guideline\n---\n\nKeep it simple.\n"
+        )
+        (tmp_path / "preference").mkdir()
+        (tmp_path / "preference" / "pref.md").write_text(
+            "---\ntype: preference\n---\n\nUse snake_case.\n"
+        )
+        entities = entity_io.load_all_entities(tmp_path)
+        contents = {e["content"] for e in entities}
+        assert "Keep it simple." in contents
+        assert "Use snake_case." in contents
+
+    def test_skips_files_without_content(self, tmp_path):
+        (tmp_path / "guideline").mkdir()
+        (tmp_path / "guideline" / "empty.md").write_text("---\ntype: guideline\n---\n\n")
+        assert entity_io.load_all_entities(tmp_path) == []
+
+    def test_empty_directory_returns_empty_list(self, tmp_path):
+        assert entity_io.load_all_entities(tmp_path) == []

--- a/tests/platform_integrations/test_plugin_structure.py
+++ b/tests/platform_integrations/test_plugin_structure.py
@@ -7,10 +7,7 @@ import pytest
 
 pytestmark = pytest.mark.platform_integrations
 
-_PLUGIN_ROOT = (
-    Path(__file__).parent.parent.parent
-    / "platform-integrations/claude/plugins/evolve-lite"
-)
+_PLUGIN_ROOT = Path(__file__).parent.parent.parent / "platform-integrations/claude/plugins/evolve-lite"
 
 
 class TestPluginManifest:
@@ -57,22 +54,23 @@ class TestHooksManifest:
                         py_tokens = [t for t in resolved.split() if t.endswith(".py")]
                         assert py_tokens, f"No .py script found in hook command: {cmd}"
                         script_path = Path(py_tokens[0])
-                        assert script_path.exists(), (
-                            f"Hook script missing: {script_path} (event: {event})"
-                        )
+                        assert script_path.exists(), f"Hook script missing: {script_path} (event: {event})"
 
 
 class TestSkillScripts:
     """Verify that every skill script referenced in the plugin exists on disk."""
 
-    @pytest.mark.parametrize("script_rel", [
-        "skills/publish/scripts/publish.py",
-        "skills/subscribe/scripts/subscribe.py",
-        "skills/unsubscribe/scripts/unsubscribe.py",
-        "skills/sync/scripts/sync.py",
-        "skills/recall/scripts/retrieve_entities.py",
-        "skills/learn/scripts/save_entities.py",
-    ])
+    @pytest.mark.parametrize(
+        "script_rel",
+        [
+            "skills/publish/scripts/publish.py",
+            "skills/subscribe/scripts/subscribe.py",
+            "skills/unsubscribe/scripts/unsubscribe.py",
+            "skills/sync/scripts/sync.py",
+            "skills/recall/scripts/retrieve_entities.py",
+            "skills/learn/scripts/save_entities.py",
+        ],
+    )
     def test_script_exists(self, script_rel):
         script = _PLUGIN_ROOT / script_rel
         assert script.exists(), f"Script not found: {script}"
@@ -81,10 +79,13 @@ class TestSkillScripts:
 class TestLibModules:
     """Verify that the shared lib modules the scripts depend on exist."""
 
-    @pytest.mark.parametrize("module", [
-        "lib/entity_io.py",
-        "lib/config.py",
-        "lib/audit.py",
-    ])
+    @pytest.mark.parametrize(
+        "module",
+        [
+            "lib/entity_io.py",
+            "lib/config.py",
+            "lib/audit.py",
+        ],
+    )
     def test_lib_module_exists(self, module):
         assert (_PLUGIN_ROOT / module).exists(), f"Lib module not found: {module}"

--- a/tests/platform_integrations/test_plugin_structure.py
+++ b/tests/platform_integrations/test_plugin_structure.py
@@ -1,0 +1,90 @@
+"""Tests for plugin manifest integrity and hook script references."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.platform_integrations
+
+_PLUGIN_ROOT = (
+    Path(__file__).parent.parent.parent
+    / "platform-integrations/claude/plugins/evolve-lite"
+)
+
+
+class TestPluginManifest:
+    def test_plugin_json_is_valid_json(self):
+        data = json.loads((_PLUGIN_ROOT / ".claude-plugin" / "plugin.json").read_text())
+        assert isinstance(data, dict)
+
+    def test_plugin_json_has_required_fields(self):
+        data = json.loads((_PLUGIN_ROOT / ".claude-plugin" / "plugin.json").read_text())
+        for field in ("name", "version", "description"):
+            assert field in data, f"plugin.json missing required field: {field}"
+
+    def test_plugin_json_skills_path_exists(self):
+        data = json.loads((_PLUGIN_ROOT / ".claude-plugin" / "plugin.json").read_text())
+        skills_path = (_PLUGIN_ROOT / data["skills"]).resolve()
+        assert skills_path.is_dir(), f"skills path does not exist: {skills_path}"
+
+
+class TestHooksManifest:
+    def test_hooks_json_is_valid_json(self):
+        data = json.loads((_PLUGIN_ROOT / "hooks" / "hooks.json").read_text())
+        assert isinstance(data, dict)
+
+    def test_hooks_json_has_hooks_key(self):
+        data = json.loads((_PLUGIN_ROOT / "hooks" / "hooks.json").read_text())
+        assert "hooks" in data
+
+    def test_known_lifecycle_events_present(self):
+        data = json.loads((_PLUGIN_ROOT / "hooks" / "hooks.json").read_text())
+        hooks = data["hooks"]
+        assert "UserPromptSubmit" in hooks
+        assert "SessionStart" in hooks
+        assert "Stop" in hooks
+
+    def test_command_hook_scripts_exist(self):
+        data = json.loads((_PLUGIN_ROOT / "hooks" / "hooks.json").read_text())
+        for event, groups in data["hooks"].items():
+            for group in groups:
+                for hook in group.get("hooks", []):
+                    if hook.get("type") == "command":
+                        cmd = hook["command"]
+                        resolved = cmd.replace("${CLAUDE_PLUGIN_ROOT}", str(_PLUGIN_ROOT))
+                        # Find the .py token — commands may have trailing flags
+                        py_tokens = [t for t in resolved.split() if t.endswith(".py")]
+                        assert py_tokens, f"No .py script found in hook command: {cmd}"
+                        script_path = Path(py_tokens[0])
+                        assert script_path.exists(), (
+                            f"Hook script missing: {script_path} (event: {event})"
+                        )
+
+
+class TestSkillScripts:
+    """Verify that every skill script referenced in the plugin exists on disk."""
+
+    @pytest.mark.parametrize("script_rel", [
+        "skills/publish/scripts/publish.py",
+        "skills/subscribe/scripts/subscribe.py",
+        "skills/unsubscribe/scripts/unsubscribe.py",
+        "skills/sync/scripts/sync.py",
+        "skills/recall/scripts/retrieve_entities.py",
+        "skills/learn/scripts/save_entities.py",
+    ])
+    def test_script_exists(self, script_rel):
+        script = _PLUGIN_ROOT / script_rel
+        assert script.exists(), f"Script not found: {script}"
+
+
+class TestLibModules:
+    """Verify that the shared lib modules the scripts depend on exist."""
+
+    @pytest.mark.parametrize("module", [
+        "lib/entity_io.py",
+        "lib/config.py",
+        "lib/audit.py",
+    ])
+    def test_lib_module_exists(self, module):
+        assert (_PLUGIN_ROOT / module).exists(), f"Lib module not found: {module}"

--- a/tests/platform_integrations/test_publish.py
+++ b/tests/platform_integrations/test_publish.py
@@ -1,0 +1,85 @@
+"""Tests for skills/publish/scripts/publish.py."""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.platform_integrations
+
+_PLUGIN_ROOT = (
+    Path(__file__).parent.parent.parent
+    / "platform-integrations/claude/plugins/evolve-lite"
+)
+PUBLISH_SCRIPT = _PLUGIN_ROOT / "skills/publish/scripts/publish.py"
+
+
+@pytest.fixture
+def project_dir(tmp_path):
+    """A temp project with one private guideline entity."""
+    guideline_dir = tmp_path / ".evolve" / "entities" / "guideline"
+    guideline_dir.mkdir(parents=True)
+    (guideline_dir / "my-tip.md").write_text(
+        "---\ntype: guideline\n---\n\nPrefer composition over inheritance.\n"
+    )
+    return tmp_path
+
+
+def run_publish(project_dir, args, expect_success=True):
+    env = {**os.environ, "EVOLVE_DIR": str(project_dir / ".evolve")}
+    return subprocess.run(
+        [sys.executable, str(PUBLISH_SCRIPT)] + args,
+        capture_output=True,
+        text=True,
+        cwd=str(project_dir),
+        env=env,
+        check=expect_success,
+    )
+
+
+class TestPublish:
+    def test_copies_entity_to_public_dir(self, project_dir):
+        run_publish(project_dir, ["--entity", "my-tip.md"])
+        assert (project_dir / ".evolve" / "public" / "guideline" / "my-tip.md").exists()
+
+    def test_sets_visibility_public(self, project_dir):
+        run_publish(project_dir, ["--entity", "my-tip.md"])
+        content = (project_dir / ".evolve" / "public" / "guideline" / "my-tip.md").read_text()
+        assert "visibility: public" in content
+
+    def test_stamps_published_at_timestamp(self, project_dir):
+        run_publish(project_dir, ["--entity", "my-tip.md"])
+        content = (project_dir / ".evolve" / "public" / "guideline" / "my-tip.md").read_text()
+        assert "published_at:" in content
+
+    def test_stamps_owner_when_user_flag_given(self, project_dir):
+        run_publish(project_dir, ["--entity", "my-tip.md", "--user", "alice"])
+        content = (project_dir / ".evolve" / "public" / "guideline" / "my-tip.md").read_text()
+        assert "owner: alice" in content
+
+    def test_preserves_original_content(self, project_dir):
+        run_publish(project_dir, ["--entity", "my-tip.md"])
+        content = (project_dir / ".evolve" / "public" / "guideline" / "my-tip.md").read_text()
+        assert "Prefer composition over inheritance." in content
+
+    def test_writes_audit_log(self, project_dir):
+        run_publish(project_dir, ["--entity", "my-tip.md", "--user", "alice"])
+        log_path = project_dir / ".evolve" / "audit.log"
+        assert log_path.exists()
+        entry = json.loads(log_path.read_text().strip())
+        assert entry["action"] == "publish"
+        assert entry["actor"] == "alice"
+        assert entry["entity"] == "my-tip.md"
+
+    def test_exits_nonzero_when_entity_not_found(self, project_dir):
+        result = run_publish(project_dir, ["--entity", "nonexistent.md"], expect_success=False)
+        assert result.returncode != 0
+        assert "not found" in result.stderr
+
+    def test_succeeds_without_user_flag(self, project_dir):
+        run_publish(project_dir, ["--entity", "my-tip.md"])
+        content = (project_dir / ".evolve" / "public" / "guideline" / "my-tip.md").read_text()
+        assert "visibility: public" in content

--- a/tests/platform_integrations/test_publish.py
+++ b/tests/platform_integrations/test_publish.py
@@ -83,3 +83,8 @@ class TestPublish:
         run_publish(project_dir, ["--entity", "my-tip.md"])
         content = (project_dir / ".evolve" / "public" / "guideline" / "my-tip.md").read_text()
         assert "visibility: public" in content
+
+    def test_rejects_path_traversal_in_entity_name(self, project_dir):
+        result = run_publish(project_dir, ["--entity", "../../etc/passwd"], expect_success=False)
+        assert result.returncode != 0
+        assert "invalid entity name" in result.stderr

--- a/tests/platform_integrations/test_publish.py
+++ b/tests/platform_integrations/test_publish.py
@@ -79,6 +79,18 @@ class TestPublish:
         content = (project_dir / ".evolve" / "public" / "guideline" / "my-tip.md").read_text()
         assert "visibility: public" in content
 
+    def test_exits_nonzero_when_public_entity_already_exists(self, project_dir):
+        public_path = project_dir / ".evolve" / "public" / "guideline" / "my-tip.md"
+        public_path.parent.mkdir(parents=True)
+        public_path.write_text("---\ntype: guideline\nvisibility: public\n---\n\nExisting public content.\n")
+
+        result = run_publish(project_dir, ["--entity", "my-tip.md"], expect_success=False)
+
+        assert result.returncode != 0
+        assert "already published" in result.stderr
+        assert public_path.read_text() == "---\ntype: guideline\nvisibility: public\n---\n\nExisting public content.\n"
+        assert (project_dir / ".evolve" / "entities" / "guideline" / "my-tip.md").exists()
+
     def test_rejects_path_traversal_in_entity_name(self, project_dir):
         result = run_publish(project_dir, ["--entity", "../../etc/passwd"], expect_success=False)
         assert result.returncode != 0

--- a/tests/platform_integrations/test_publish.py
+++ b/tests/platform_integrations/test_publish.py
@@ -10,22 +10,17 @@ import pytest
 
 pytestmark = pytest.mark.platform_integrations
 
-_PLUGIN_ROOT = (
-    Path(__file__).parent.parent.parent
-    / "platform-integrations/claude/plugins/evolve-lite"
-)
+_PLUGIN_ROOT = Path(__file__).parent.parent.parent / "platform-integrations/claude/plugins/evolve-lite"
 PUBLISH_SCRIPT = _PLUGIN_ROOT / "skills/publish/scripts/publish.py"
 
 
 @pytest.fixture
-def project_dir(tmp_path):
+def project_dir(temp_project_dir):
     """A temp project with one private guideline entity."""
-    guideline_dir = tmp_path / ".evolve" / "entities" / "guideline"
+    guideline_dir = temp_project_dir / ".evolve" / "entities" / "guideline"
     guideline_dir.mkdir(parents=True)
-    (guideline_dir / "my-tip.md").write_text(
-        "---\ntype: guideline\n---\n\nPrefer composition over inheritance.\n"
-    )
-    return tmp_path
+    (guideline_dir / "my-tip.md").write_text("---\ntype: guideline\n---\n\nPrefer composition over inheritance.\n")
+    return temp_project_dir
 
 
 def run_publish(project_dir, args, expect_success=True):

--- a/tests/platform_integrations/test_retrieve.py
+++ b/tests/platform_integrations/test_retrieve.py
@@ -67,9 +67,9 @@ class TestRetrieve:
 
     def test_owned_entities_not_annotated_with_from(self, evolve_dir):
         result = run_retrieve(evolve_dir=evolve_dir)
-        own_lines = [l for l in result.stdout.splitlines() if "Keep functions small." in l]
+        own_lines = [line for line in result.stdout.splitlines() if "Keep functions small." in line]
         assert own_lines
-        assert not any("[from:" in l for l in own_lines)
+        assert not any("[from:" in line for line in own_lines)
 
     def test_output_includes_type_annotation(self, evolve_dir):
         result = run_retrieve(evolve_dir=evolve_dir)

--- a/tests/platform_integrations/test_retrieve.py
+++ b/tests/platform_integrations/test_retrieve.py
@@ -1,0 +1,100 @@
+"""Tests for skills/recall/scripts/retrieve_entities.py."""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.platform_integrations
+
+_PLUGIN_ROOT = (
+    Path(__file__).parent.parent.parent
+    / "platform-integrations/claude/plugins/evolve-lite"
+)
+RETRIEVE_SCRIPT = _PLUGIN_ROOT / "skills/recall/scripts/retrieve_entities.py"
+
+# The hook pipes this JSON to the script on stdin
+HOOK_INPUT = json.dumps({"prompt": "How do I write clean code?"})
+
+
+def run_retrieve(evolve_dir=None, stdin_data=None):
+    env = {**os.environ}
+    if evolve_dir:
+        env["EVOLVE_DIR"] = str(evolve_dir)
+    return subprocess.run(
+        [sys.executable, str(RETRIEVE_SCRIPT)],
+        input=stdin_data or HOOK_INPUT,
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+
+@pytest.fixture
+def evolve_dir(tmp_path):
+    """An .evolve dir with one owned entity and one subscribed entity."""
+    d = tmp_path / ".evolve"
+
+    # Owned entity
+    own_dir = d / "entities" / "guideline"
+    own_dir.mkdir(parents=True)
+    (own_dir / "tip.md").write_text("---\ntype: guideline\n---\n\nKeep functions small.\n")
+
+    # Subscribed entity (lives under entities/subscribed/{name}/)
+    sub_dir = d / "entities" / "subscribed" / "alice" / "guideline"
+    sub_dir.mkdir(parents=True)
+    (sub_dir / "alice-tip.md").write_text(
+        "---\ntype: guideline\nowner: alice\nvisibility: public\n---\n\nAlways write tests.\n"
+    )
+
+    return d
+
+
+class TestRetrieve:
+    def test_exits_cleanly_with_no_output_when_no_entities_dir(self, tmp_path):
+        result = run_retrieve(evolve_dir=tmp_path / ".evolve")
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_outputs_owned_entities(self, evolve_dir):
+        result = run_retrieve(evolve_dir=evolve_dir)
+        assert result.returncode == 0
+        assert "Keep functions small." in result.stdout
+
+    def test_annotates_subscribed_entities_with_from_source(self, evolve_dir):
+        result = run_retrieve(evolve_dir=evolve_dir)
+        assert "[from: alice]" in result.stdout
+        assert "Always write tests." in result.stdout
+
+    def test_owned_entities_not_annotated_with_from(self, evolve_dir):
+        result = run_retrieve(evolve_dir=evolve_dir)
+        own_lines = [l for l in result.stdout.splitlines() if "Keep functions small." in l]
+        assert own_lines
+        assert not any("[from:" in l for l in own_lines)
+
+    def test_output_includes_type_annotation(self, evolve_dir):
+        result = run_retrieve(evolve_dir=evolve_dir)
+        assert "[guideline]" in result.stdout
+
+    def test_handles_invalid_json_stdin_gracefully(self, evolve_dir):
+        result = run_retrieve(evolve_dir=evolve_dir, stdin_data="not valid json")
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_output_has_header(self, evolve_dir):
+        result = run_retrieve(evolve_dir=evolve_dir)
+        assert "Entities for this task" in result.stdout
+
+    def test_entities_with_trigger_include_when_line(self, tmp_path):
+        d = tmp_path / ".evolve"
+        gdir = d / "entities" / "guideline"
+        gdir.mkdir(parents=True)
+        (gdir / "tip.md").write_text(
+            "---\ntype: guideline\ntrigger: when writing tests\n---\n\nAssert the important thing.\n"
+        )
+        result = run_retrieve(evolve_dir=d)
+        assert "when writing tests" in result.stdout

--- a/tests/platform_integrations/test_retrieve.py
+++ b/tests/platform_integrations/test_retrieve.py
@@ -101,9 +101,9 @@ class TestRetrieve:
             "---\ntype: guideline\nvisibility: public\n---\n\nPrefer immutable data structures.\n"
         )
         result = run_retrieve(evolve_dir=d)
-        pub_lines = [l for l in result.stdout.splitlines() if "Prefer immutable data structures." in l]
+        pub_lines = [line for line in result.stdout.splitlines() if "Prefer immutable data structures." in line]
         assert pub_lines
-        assert not any("[from:" in l for l in pub_lines)
+        assert not any("[from:" in line for line in pub_lines)
 
     def test_entities_with_trigger_include_when_line(self, temp_project_dir):
         d = temp_project_dir / ".evolve"

--- a/tests/platform_integrations/test_retrieve.py
+++ b/tests/platform_integrations/test_retrieve.py
@@ -10,10 +10,7 @@ import pytest
 
 pytestmark = pytest.mark.platform_integrations
 
-_PLUGIN_ROOT = (
-    Path(__file__).parent.parent.parent
-    / "platform-integrations/claude/plugins/evolve-lite"
-)
+_PLUGIN_ROOT = Path(__file__).parent.parent.parent / "platform-integrations/claude/plugins/evolve-lite"
 RETRIEVE_SCRIPT = _PLUGIN_ROOT / "skills/recall/scripts/retrieve_entities.py"
 
 # The hook pipes this JSON to the script on stdin
@@ -35,9 +32,9 @@ def run_retrieve(evolve_dir=None, stdin_data=None):
 
 
 @pytest.fixture
-def evolve_dir(tmp_path):
+def evolve_dir(temp_project_dir):
     """An .evolve dir with one owned entity and one subscribed entity."""
-    d = tmp_path / ".evolve"
+    d = temp_project_dir / ".evolve"
 
     # Owned entity
     own_dir = d / "entities" / "guideline"
@@ -47,16 +44,14 @@ def evolve_dir(tmp_path):
     # Subscribed entity (lives under entities/subscribed/{name}/)
     sub_dir = d / "entities" / "subscribed" / "alice" / "guideline"
     sub_dir.mkdir(parents=True)
-    (sub_dir / "alice-tip.md").write_text(
-        "---\ntype: guideline\nowner: alice\nvisibility: public\n---\n\nAlways write tests.\n"
-    )
+    (sub_dir / "alice-tip.md").write_text("---\ntype: guideline\nowner: alice\nvisibility: public\n---\n\nAlways write tests.\n")
 
     return d
 
 
 class TestRetrieve:
-    def test_exits_cleanly_with_no_output_when_no_entities_dir(self, tmp_path):
-        result = run_retrieve(evolve_dir=tmp_path / ".evolve")
+    def test_exits_cleanly_with_no_output_when_no_entities_dir(self, temp_project_dir):
+        result = run_retrieve(evolve_dir=temp_project_dir / ".evolve")
         assert result.returncode == 0
         assert result.stdout.strip() == ""
 
@@ -89,12 +84,10 @@ class TestRetrieve:
         result = run_retrieve(evolve_dir=evolve_dir)
         assert "Entities for this task" in result.stdout
 
-    def test_entities_with_trigger_include_when_line(self, tmp_path):
-        d = tmp_path / ".evolve"
+    def test_entities_with_trigger_include_when_line(self, temp_project_dir):
+        d = temp_project_dir / ".evolve"
         gdir = d / "entities" / "guideline"
         gdir.mkdir(parents=True)
-        (gdir / "tip.md").write_text(
-            "---\ntype: guideline\ntrigger: when writing tests\n---\n\nAssert the important thing.\n"
-        )
+        (gdir / "tip.md").write_text("---\ntype: guideline\ntrigger: when writing tests\n---\n\nAssert the important thing.\n")
         result = run_retrieve(evolve_dir=d)
         assert "when writing tests" in result.stdout

--- a/tests/platform_integrations/test_retrieve.py
+++ b/tests/platform_integrations/test_retrieve.py
@@ -84,6 +84,27 @@ class TestRetrieve:
         result = run_retrieve(evolve_dir=evolve_dir)
         assert "Entities for this task" in result.stdout
 
+    def test_public_entities_included_in_recall(self, temp_project_dir):
+        d = temp_project_dir / ".evolve"
+        (d / "public" / "guideline").mkdir(parents=True)
+        (d / "public" / "guideline" / "pub.md").write_text(
+            "---\ntype: guideline\nvisibility: public\n---\n\nPrefer immutable data structures.\n"
+        )
+        result = run_retrieve(evolve_dir=d)
+        assert result.returncode == 0
+        assert "Prefer immutable data structures." in result.stdout
+
+    def test_public_entities_not_annotated_with_from(self, temp_project_dir):
+        d = temp_project_dir / ".evolve"
+        (d / "public" / "guideline").mkdir(parents=True)
+        (d / "public" / "guideline" / "pub.md").write_text(
+            "---\ntype: guideline\nvisibility: public\n---\n\nPrefer immutable data structures.\n"
+        )
+        result = run_retrieve(evolve_dir=d)
+        pub_lines = [l for l in result.stdout.splitlines() if "Prefer immutable data structures." in l]
+        assert pub_lines
+        assert not any("[from:" in l for l in pub_lines)
+
     def test_entities_with_trigger_include_when_line(self, temp_project_dir):
         d = temp_project_dir / ".evolve"
         gdir = d / "entities" / "guideline"

--- a/tests/platform_integrations/test_save_entities.py
+++ b/tests/platform_integrations/test_save_entities.py
@@ -1,0 +1,102 @@
+"""Tests for skills/learn/scripts/save_entities.py."""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.platform_integrations
+
+_PLUGIN_ROOT = (
+    Path(__file__).parent.parent.parent
+    / "platform-integrations/claude/plugins/evolve-lite"
+)
+SAVE_SCRIPT = _PLUGIN_ROOT / "skills/learn/scripts/save_entities.py"
+
+
+def run_save(project_dir, entities, args=None, evolve_dir=None, expect_success=True):
+    env = {**os.environ}
+    if evolve_dir:
+        env["EVOLVE_DIR"] = str(evolve_dir)
+    return subprocess.run(
+        [sys.executable, str(SAVE_SCRIPT)] + (args or []),
+        input=json.dumps({"entities": entities}),
+        capture_output=True,
+        text=True,
+        cwd=str(project_dir),
+        env=env,
+        check=expect_success,
+    )
+
+
+class TestSaveEntities:
+    def test_writes_entity_file(self, tmp_path):
+        evolve_dir = tmp_path / ".evolve"
+        run_save(tmp_path, [{"type": "guideline", "content": "Use semantic versioning."}], evolve_dir=evolve_dir)
+        files = list((evolve_dir / "entities" / "guideline").glob("*.md"))
+        assert len(files) == 1
+        assert "Use semantic versioning." in files[0].read_text()
+
+    def test_sets_visibility_private_by_default(self, tmp_path):
+        evolve_dir = tmp_path / ".evolve"
+        run_save(tmp_path, [{"type": "guideline", "content": "Commit often."}], evolve_dir=evolve_dir)
+        files = list((evolve_dir / "entities" / "guideline").glob("*.md"))
+        assert "visibility: private" in files[0].read_text()
+
+    def test_user_flag_stamps_owner(self, tmp_path):
+        evolve_dir = tmp_path / ".evolve"
+        run_save(
+            tmp_path,
+            [{"type": "guideline", "content": "Write clear commit messages."}],
+            args=["--user", "alice"],
+            evolve_dir=evolve_dir,
+        )
+        files = list((evolve_dir / "entities" / "guideline").glob("*.md"))
+        assert "owner: alice" in files[0].read_text()
+
+    def test_deduplicates_exact_content(self, tmp_path):
+        evolve_dir = tmp_path / ".evolve"
+        entity = {"type": "guideline", "content": "No magic numbers."}
+        run_save(tmp_path, [entity], evolve_dir=evolve_dir)
+        run_save(tmp_path, [entity], evolve_dir=evolve_dir)
+        files = list((evolve_dir / "entities" / "guideline").glob("*.md"))
+        assert len(files) == 1
+
+    def test_dedup_is_case_and_whitespace_insensitive(self, tmp_path):
+        evolve_dir = tmp_path / ".evolve"
+        run_save(tmp_path, [{"type": "guideline", "content": "No magic numbers."}], evolve_dir=evolve_dir)
+        run_save(tmp_path, [{"type": "guideline", "content": "NO MAGIC  NUMBERS."}], evolve_dir=evolve_dir)
+        files = list((evolve_dir / "entities" / "guideline").glob("*.md"))
+        assert len(files) == 1
+
+    def test_multiple_entities_all_written(self, tmp_path):
+        evolve_dir = tmp_path / ".evolve"
+        run_save(tmp_path, [
+            {"type": "guideline", "content": "First tip."},
+            {"type": "guideline", "content": "Second tip."},
+        ], evolve_dir=evolve_dir)
+        files = list((evolve_dir / "entities" / "guideline").glob("*.md"))
+        assert len(files) == 2
+
+    def test_skips_entities_without_content(self, tmp_path):
+        evolve_dir = tmp_path / ".evolve"
+        run_save(tmp_path, [{"type": "guideline"}], evolve_dir=evolve_dir)
+        guideline_dir = evolve_dir / "entities" / "guideline"
+        if guideline_dir.exists():
+            assert list(guideline_dir.glob("*.md")) == []
+
+    def test_exits_cleanly_when_empty_entities_list(self, tmp_path):
+        evolve_dir = tmp_path / ".evolve"
+        result = run_save(tmp_path, [], evolve_dir=evolve_dir, expect_success=False)
+        assert result.returncode == 0
+
+    def test_output_reports_added_count(self, tmp_path):
+        evolve_dir = tmp_path / ".evolve"
+        result = run_save(tmp_path, [
+            {"type": "guideline", "content": "Tip A."},
+            {"type": "guideline", "content": "Tip B."},
+        ], evolve_dir=evolve_dir)
+        assert "Added 2" in result.stdout

--- a/tests/platform_integrations/test_save_entities.py
+++ b/tests/platform_integrations/test_save_entities.py
@@ -10,10 +10,7 @@ import pytest
 
 pytestmark = pytest.mark.platform_integrations
 
-_PLUGIN_ROOT = (
-    Path(__file__).parent.parent.parent
-    / "platform-integrations/claude/plugins/evolve-lite"
-)
+_PLUGIN_ROOT = Path(__file__).parent.parent.parent / "platform-integrations/claude/plugins/evolve-lite"
 SAVE_SCRIPT = _PLUGIN_ROOT / "skills/learn/scripts/save_entities.py"
 
 
@@ -33,23 +30,23 @@ def run_save(project_dir, entities, args=None, evolve_dir=None, expect_success=T
 
 
 class TestSaveEntities:
-    def test_writes_entity_file(self, tmp_path):
-        evolve_dir = tmp_path / ".evolve"
-        run_save(tmp_path, [{"type": "guideline", "content": "Use semantic versioning."}], evolve_dir=evolve_dir)
+    def test_writes_entity_file(self, temp_project_dir):
+        evolve_dir = temp_project_dir / ".evolve"
+        run_save(temp_project_dir, [{"type": "guideline", "content": "Use semantic versioning."}], evolve_dir=evolve_dir)
         files = list((evolve_dir / "entities" / "guideline").glob("*.md"))
         assert len(files) == 1
         assert "Use semantic versioning." in files[0].read_text()
 
-    def test_sets_visibility_private_by_default(self, tmp_path):
-        evolve_dir = tmp_path / ".evolve"
-        run_save(tmp_path, [{"type": "guideline", "content": "Commit often."}], evolve_dir=evolve_dir)
+    def test_sets_visibility_private_by_default(self, temp_project_dir):
+        evolve_dir = temp_project_dir / ".evolve"
+        run_save(temp_project_dir, [{"type": "guideline", "content": "Commit often."}], evolve_dir=evolve_dir)
         files = list((evolve_dir / "entities" / "guideline").glob("*.md"))
         assert "visibility: private" in files[0].read_text()
 
-    def test_user_flag_stamps_owner(self, tmp_path):
-        evolve_dir = tmp_path / ".evolve"
+    def test_user_flag_stamps_owner(self, temp_project_dir):
+        evolve_dir = temp_project_dir / ".evolve"
         run_save(
-            tmp_path,
+            temp_project_dir,
             [{"type": "guideline", "content": "Write clear commit messages."}],
             args=["--user", "alice"],
             evolve_dir=evolve_dir,
@@ -57,46 +54,54 @@ class TestSaveEntities:
         files = list((evolve_dir / "entities" / "guideline").glob("*.md"))
         assert "owner: alice" in files[0].read_text()
 
-    def test_deduplicates_exact_content(self, tmp_path):
-        evolve_dir = tmp_path / ".evolve"
+    def test_deduplicates_exact_content(self, temp_project_dir):
+        evolve_dir = temp_project_dir / ".evolve"
         entity = {"type": "guideline", "content": "No magic numbers."}
-        run_save(tmp_path, [entity], evolve_dir=evolve_dir)
-        run_save(tmp_path, [entity], evolve_dir=evolve_dir)
+        run_save(temp_project_dir, [entity], evolve_dir=evolve_dir)
+        run_save(temp_project_dir, [entity], evolve_dir=evolve_dir)
         files = list((evolve_dir / "entities" / "guideline").glob("*.md"))
         assert len(files) == 1
 
-    def test_dedup_is_case_and_whitespace_insensitive(self, tmp_path):
-        evolve_dir = tmp_path / ".evolve"
-        run_save(tmp_path, [{"type": "guideline", "content": "No magic numbers."}], evolve_dir=evolve_dir)
-        run_save(tmp_path, [{"type": "guideline", "content": "NO MAGIC  NUMBERS."}], evolve_dir=evolve_dir)
+    def test_dedup_is_case_and_whitespace_insensitive(self, temp_project_dir):
+        evolve_dir = temp_project_dir / ".evolve"
+        run_save(temp_project_dir, [{"type": "guideline", "content": "No magic numbers."}], evolve_dir=evolve_dir)
+        run_save(temp_project_dir, [{"type": "guideline", "content": "NO MAGIC  NUMBERS."}], evolve_dir=evolve_dir)
         files = list((evolve_dir / "entities" / "guideline").glob("*.md"))
         assert len(files) == 1
 
-    def test_multiple_entities_all_written(self, tmp_path):
-        evolve_dir = tmp_path / ".evolve"
-        run_save(tmp_path, [
-            {"type": "guideline", "content": "First tip."},
-            {"type": "guideline", "content": "Second tip."},
-        ], evolve_dir=evolve_dir)
+    def test_multiple_entities_all_written(self, temp_project_dir):
+        evolve_dir = temp_project_dir / ".evolve"
+        run_save(
+            temp_project_dir,
+            [
+                {"type": "guideline", "content": "First tip."},
+                {"type": "guideline", "content": "Second tip."},
+            ],
+            evolve_dir=evolve_dir,
+        )
         files = list((evolve_dir / "entities" / "guideline").glob("*.md"))
         assert len(files) == 2
 
-    def test_skips_entities_without_content(self, tmp_path):
-        evolve_dir = tmp_path / ".evolve"
-        run_save(tmp_path, [{"type": "guideline"}], evolve_dir=evolve_dir)
+    def test_skips_entities_without_content(self, temp_project_dir):
+        evolve_dir = temp_project_dir / ".evolve"
+        run_save(temp_project_dir, [{"type": "guideline"}], evolve_dir=evolve_dir)
         guideline_dir = evolve_dir / "entities" / "guideline"
         if guideline_dir.exists():
             assert list(guideline_dir.glob("*.md")) == []
 
-    def test_exits_cleanly_when_empty_entities_list(self, tmp_path):
-        evolve_dir = tmp_path / ".evolve"
-        result = run_save(tmp_path, [], evolve_dir=evolve_dir, expect_success=False)
+    def test_exits_cleanly_when_empty_entities_list(self, temp_project_dir):
+        evolve_dir = temp_project_dir / ".evolve"
+        result = run_save(temp_project_dir, [], evolve_dir=evolve_dir, expect_success=False)
         assert result.returncode == 0
 
-    def test_output_reports_added_count(self, tmp_path):
-        evolve_dir = tmp_path / ".evolve"
-        result = run_save(tmp_path, [
-            {"type": "guideline", "content": "Tip A."},
-            {"type": "guideline", "content": "Tip B."},
-        ], evolve_dir=evolve_dir)
+    def test_output_reports_added_count(self, temp_project_dir):
+        evolve_dir = temp_project_dir / ".evolve"
+        result = run_save(
+            temp_project_dir,
+            [
+                {"type": "guideline", "content": "Tip A."},
+                {"type": "guideline", "content": "Tip B."},
+            ],
+            evolve_dir=evolve_dir,
+        )
         assert "Added 2" in result.stdout

--- a/tests/platform_integrations/test_save_entities.py
+++ b/tests/platform_integrations/test_save_entities.py
@@ -84,10 +84,10 @@ class TestSaveEntities:
 
     def test_skips_entities_without_content(self, temp_project_dir):
         evolve_dir = temp_project_dir / ".evolve"
-        run_save(temp_project_dir, [{"type": "guideline"}], evolve_dir=evolve_dir)
+        result = run_save(temp_project_dir, [{"type": "guideline"}], evolve_dir=evolve_dir)
         guideline_dir = evolve_dir / "entities" / "guideline"
-        if guideline_dir.exists():
-            assert list(guideline_dir.glob("*.md")) == []
+        assert not guideline_dir.exists() or list(guideline_dir.glob("*.md")) == []
+        assert "Added 0" in result.stdout
 
     def test_exits_cleanly_when_empty_entities_list(self, temp_project_dir):
         evolve_dir = temp_project_dir / ".evolve"

--- a/tests/platform_integrations/test_subscribe.py
+++ b/tests/platform_integrations/test_subscribe.py
@@ -84,6 +84,16 @@ class TestSubscribe:
         assert result.returncode != 0
         assert "already exists" in result.stderr
 
+    def test_rejects_path_traversal_in_name(self, tmp_path, local_repo):
+        evolve_dir = tmp_path / ".evolve"
+        result = run_script(
+            SUBSCRIBE_SCRIPT, tmp_path,
+            ["--name", "../../evil", "--remote", str(local_repo["bare"]), "--branch", "main"],
+            evolve_dir=evolve_dir, expect_success=False,
+        )
+        assert result.returncode != 0
+        assert "invalid subscription name" in result.stderr
+
     def test_cloned_repo_contains_initial_entity(self, tmp_path, local_repo):
         evolve_dir = tmp_path / ".evolve"
         run_script(
@@ -148,3 +158,12 @@ class TestUnsubscribe:
         result = run_script(UNSUBSCRIBE_SCRIPT, tmp_path, ["--list"], evolve_dir=evolve_dir)
         data = json.loads(result.stdout)
         assert data == []
+
+    def test_rejects_path_traversal_in_name(self, tmp_path, local_repo):
+        evolve_dir = self._subscribe(tmp_path, local_repo)
+        result = run_script(
+            UNSUBSCRIBE_SCRIPT, tmp_path, ["--name", "../../evil"],
+            evolve_dir=evolve_dir, expect_success=False,
+        )
+        assert result.returncode != 0
+        assert "invalid subscription name" in result.stderr

--- a/tests/platform_integrations/test_subscribe.py
+++ b/tests/platform_integrations/test_subscribe.py
@@ -16,10 +16,7 @@ import config as cfg_module
 
 pytestmark = pytest.mark.platform_integrations
 
-_PLUGIN_ROOT = (
-    Path(__file__).parent.parent.parent
-    / "platform-integrations/claude/plugins/evolve-lite"
-)
+_PLUGIN_ROOT = Path(__file__).parent.parent.parent / "platform-integrations/claude/plugins/evolve-lite"
 SUBSCRIBE_SCRIPT = _PLUGIN_ROOT / "skills/subscribe/scripts/subscribe.py"
 UNSUBSCRIBE_SCRIPT = _PLUGIN_ROOT / "skills/unsubscribe/scripts/unsubscribe.py"
 
@@ -39,65 +36,71 @@ def run_script(script, project_dir, args, evolve_dir=None, expect_success=True):
 
 
 class TestSubscribe:
-    def test_clones_remote_into_subscribed_dir(self, tmp_path, local_repo):
-        evolve_dir = tmp_path / ".evolve"
+    def test_clones_remote_into_subscribed_dir(self, temp_project_dir, local_repo):
+        evolve_dir = temp_project_dir / ".evolve"
         run_script(
-            SUBSCRIBE_SCRIPT, tmp_path,
+            SUBSCRIBE_SCRIPT,
+            temp_project_dir,
             ["--name", "alice", "--remote", str(local_repo["bare"]), "--branch", "main"],
             evolve_dir=evolve_dir,
         )
         assert (evolve_dir / "subscribed" / "alice").is_dir()
         assert (evolve_dir / "subscribed" / "alice" / ".git").exists()
 
-    def test_updates_config_with_subscription(self, tmp_path, local_repo):
-        evolve_dir = tmp_path / ".evolve"
+    def test_updates_config_with_subscription(self, temp_project_dir, local_repo):
+        evolve_dir = temp_project_dir / ".evolve"
         run_script(
-            SUBSCRIBE_SCRIPT, tmp_path,
+            SUBSCRIBE_SCRIPT,
+            temp_project_dir,
             ["--name", "alice", "--remote", str(local_repo["bare"]), "--branch", "main"],
             evolve_dir=evolve_dir,
         )
-        cfg = cfg_module.load_config(str(tmp_path))
+        cfg = cfg_module.load_config(str(temp_project_dir))
         subs = cfg.get("subscriptions", [])
         assert len(subs) == 1
         assert subs[0]["name"] == "alice"
         assert subs[0]["branch"] == "main"
         assert str(local_repo["bare"]) in subs[0]["remote"]
 
-    def test_writes_audit_log(self, tmp_path, local_repo):
-        evolve_dir = tmp_path / ".evolve"
+    def test_writes_audit_log(self, temp_project_dir, local_repo):
+        evolve_dir = temp_project_dir / ".evolve"
         run_script(
-            SUBSCRIBE_SCRIPT, tmp_path,
+            SUBSCRIBE_SCRIPT,
+            temp_project_dir,
             ["--name", "alice", "--remote", str(local_repo["bare"]), "--branch", "main"],
             evolve_dir=evolve_dir,
         )
-        log_path = tmp_path / ".evolve" / "audit.log"
+        log_path = temp_project_dir / ".evolve" / "audit.log"
         assert log_path.exists()
         entry = json.loads(log_path.read_text().strip())
         assert entry["action"] == "subscribe"
         assert entry["name"] == "alice"
 
-    def test_fails_on_duplicate_name(self, tmp_path, local_repo):
-        evolve_dir = tmp_path / ".evolve"
+    def test_fails_on_duplicate_name(self, temp_project_dir, local_repo):
+        evolve_dir = temp_project_dir / ".evolve"
         args = ["--name", "alice", "--remote", str(local_repo["bare"]), "--branch", "main"]
-        run_script(SUBSCRIBE_SCRIPT, tmp_path, args, evolve_dir=evolve_dir)
-        result = run_script(SUBSCRIBE_SCRIPT, tmp_path, args, evolve_dir=evolve_dir, expect_success=False)
+        run_script(SUBSCRIBE_SCRIPT, temp_project_dir, args, evolve_dir=evolve_dir)
+        result = run_script(SUBSCRIBE_SCRIPT, temp_project_dir, args, evolve_dir=evolve_dir, expect_success=False)
         assert result.returncode != 0
         assert "already exists" in result.stderr
 
-    def test_rejects_path_traversal_in_name(self, tmp_path, local_repo):
-        evolve_dir = tmp_path / ".evolve"
+    def test_rejects_path_traversal_in_name(self, temp_project_dir, local_repo):
+        evolve_dir = temp_project_dir / ".evolve"
         result = run_script(
-            SUBSCRIBE_SCRIPT, tmp_path,
+            SUBSCRIBE_SCRIPT,
+            temp_project_dir,
             ["--name", "../../evil", "--remote", str(local_repo["bare"]), "--branch", "main"],
-            evolve_dir=evolve_dir, expect_success=False,
+            evolve_dir=evolve_dir,
+            expect_success=False,
         )
         assert result.returncode != 0
         assert "invalid subscription name" in result.stderr
 
-    def test_cloned_repo_contains_initial_entity(self, tmp_path, local_repo):
-        evolve_dir = tmp_path / ".evolve"
+    def test_cloned_repo_contains_initial_entity(self, temp_project_dir, local_repo):
+        evolve_dir = temp_project_dir / ".evolve"
         run_script(
-            SUBSCRIBE_SCRIPT, tmp_path,
+            SUBSCRIBE_SCRIPT,
+            temp_project_dir,
             ["--name", "alice", "--remote", str(local_repo["bare"]), "--branch", "main"],
             evolve_dir=evolve_dir,
         )
@@ -107,63 +110,70 @@ class TestSubscribe:
 
 
 class TestUnsubscribe:
-    def _subscribe(self, tmp_path, local_repo, name="alice"):
-        evolve_dir = tmp_path / ".evolve"
+    def _subscribe(self, temp_project_dir, local_repo, name="alice"):
+        evolve_dir = temp_project_dir / ".evolve"
         run_script(
-            SUBSCRIBE_SCRIPT, tmp_path,
+            SUBSCRIBE_SCRIPT,
+            temp_project_dir,
             ["--name", name, "--remote", str(local_repo["bare"]), "--branch", "main"],
             evolve_dir=evolve_dir,
         )
         return evolve_dir
 
-    def test_removes_local_clone(self, tmp_path, local_repo):
-        evolve_dir = self._subscribe(tmp_path, local_repo)
-        run_script(UNSUBSCRIBE_SCRIPT, tmp_path, ["--name", "alice"], evolve_dir=evolve_dir)
+    def test_removes_local_clone(self, temp_project_dir, local_repo):
+        evolve_dir = self._subscribe(temp_project_dir, local_repo)
+        run_script(UNSUBSCRIBE_SCRIPT, temp_project_dir, ["--name", "alice"], evolve_dir=evolve_dir)
         assert not (evolve_dir / "subscribed" / "alice").exists()
 
-    def test_removes_subscription_from_config(self, tmp_path, local_repo):
-        evolve_dir = self._subscribe(tmp_path, local_repo)
-        run_script(UNSUBSCRIBE_SCRIPT, tmp_path, ["--name", "alice"], evolve_dir=evolve_dir)
-        cfg = cfg_module.load_config(str(tmp_path))
+    def test_removes_subscription_from_config(self, temp_project_dir, local_repo):
+        evolve_dir = self._subscribe(temp_project_dir, local_repo)
+        run_script(UNSUBSCRIBE_SCRIPT, temp_project_dir, ["--name", "alice"], evolve_dir=evolve_dir)
+        cfg = cfg_module.load_config(str(temp_project_dir))
         assert cfg.get("subscriptions", []) == []
 
-    def test_list_flag_prints_subscriptions_as_json(self, tmp_path, local_repo):
-        evolve_dir = self._subscribe(tmp_path, local_repo)
-        result = run_script(UNSUBSCRIBE_SCRIPT, tmp_path, ["--list"], evolve_dir=evolve_dir)
+    def test_list_flag_prints_subscriptions_as_json(self, temp_project_dir, local_repo):
+        evolve_dir = self._subscribe(temp_project_dir, local_repo)
+        result = run_script(UNSUBSCRIBE_SCRIPT, temp_project_dir, ["--list"], evolve_dir=evolve_dir)
         data = json.loads(result.stdout)
         assert isinstance(data, list)
         assert data[0]["name"] == "alice"
 
-    def test_fails_when_name_not_found(self, tmp_path, local_repo):
-        evolve_dir = self._subscribe(tmp_path, local_repo)
+    def test_fails_when_name_not_found(self, temp_project_dir, local_repo):
+        evolve_dir = self._subscribe(temp_project_dir, local_repo)
         result = run_script(
-            UNSUBSCRIBE_SCRIPT, tmp_path, ["--name", "nonexistent"],
-            evolve_dir=evolve_dir, expect_success=False,
+            UNSUBSCRIBE_SCRIPT,
+            temp_project_dir,
+            ["--name", "nonexistent"],
+            evolve_dir=evolve_dir,
+            expect_success=False,
         )
         assert result.returncode != 0
         assert "not found" in result.stderr
 
-    def test_removes_mirrored_entities(self, tmp_path, local_repo):
-        evolve_dir = self._subscribe(tmp_path, local_repo)
+    def test_removes_mirrored_entities(self, temp_project_dir, local_repo):
+        evolve_dir = self._subscribe(temp_project_dir, local_repo)
         # Simulate mirrored entities (sync would create these)
         mirrored = evolve_dir / "entities" / "subscribed" / "alice"
         mirrored.mkdir(parents=True)
         (mirrored / "tip.md").write_text("---\ntype: guideline\n---\n\nA tip.\n")
 
-        run_script(UNSUBSCRIBE_SCRIPT, tmp_path, ["--name", "alice"], evolve_dir=evolve_dir)
+        run_script(UNSUBSCRIBE_SCRIPT, temp_project_dir, ["--name", "alice"], evolve_dir=evolve_dir)
         assert not mirrored.exists()
 
-    def test_list_empty_when_no_subscriptions(self, tmp_path):
-        evolve_dir = tmp_path / ".evolve"
-        result = run_script(UNSUBSCRIBE_SCRIPT, tmp_path, ["--list"], evolve_dir=evolve_dir)
+    def test_list_empty_when_no_subscriptions(self, temp_project_dir):
+        evolve_dir = temp_project_dir / ".evolve"
+        result = run_script(UNSUBSCRIBE_SCRIPT, temp_project_dir, ["--list"], evolve_dir=evolve_dir)
         data = json.loads(result.stdout)
         assert data == []
 
-    def test_rejects_path_traversal_in_name(self, tmp_path, local_repo):
-        evolve_dir = self._subscribe(tmp_path, local_repo)
+    def test_rejects_path_traversal_in_name(self, temp_project_dir, local_repo):
+        evolve_dir = self._subscribe(temp_project_dir, local_repo)
         result = run_script(
-            UNSUBSCRIBE_SCRIPT, tmp_path, ["--name", "../../evil"],
-            evolve_dir=evolve_dir, expect_success=False,
+            UNSUBSCRIBE_SCRIPT,
+            temp_project_dir,
+            ["--name", "../../evil"],
+            evolve_dir=evolve_dir,
+            expect_success=False,
         )
         assert result.returncode != 0
         assert "invalid subscription name" in result.stderr

--- a/tests/platform_integrations/test_subscribe.py
+++ b/tests/platform_integrations/test_subscribe.py
@@ -96,6 +96,35 @@ class TestSubscribe:
         assert result.returncode != 0
         assert "invalid subscription name" in result.stderr
 
+    def test_fails_when_dest_already_exists(self, temp_project_dir, local_repo):
+        evolve_dir = temp_project_dir / ".evolve"
+        dest = evolve_dir / "subscribed" / "alice"
+        dest.mkdir(parents=True)
+        result = run_script(
+            SUBSCRIBE_SCRIPT,
+            temp_project_dir,
+            ["--name", "alice", "--remote", str(local_repo["bare"]), "--branch", "main"],
+            evolve_dir=evolve_dir,
+            expect_success=False,
+        )
+        assert result.returncode != 0
+        assert "already exists" in result.stderr
+        cfg = cfg_module.load_config(str(temp_project_dir))
+        assert cfg.get("subscriptions", []) == []
+
+    def test_rejects_empty_or_dot_name(self, temp_project_dir, local_repo):
+        evolve_dir = temp_project_dir / ".evolve"
+        for bad_name in [".", ""]:
+            result = run_script(
+                SUBSCRIBE_SCRIPT,
+                temp_project_dir,
+                ["--name", bad_name, "--remote", str(local_repo["bare"]), "--branch", "main"],
+                evolve_dir=evolve_dir,
+                expect_success=False,
+            )
+            assert result.returncode != 0, f"Expected failure for name={bad_name!r}"
+            assert "invalid subscription name" in result.stderr
+
     def test_cloned_repo_contains_initial_entity(self, temp_project_dir, local_repo):
         evolve_dir = temp_project_dir / ".evolve"
         run_script(

--- a/tests/platform_integrations/test_subscribe.py
+++ b/tests/platform_integrations/test_subscribe.py
@@ -1,0 +1,150 @@
+"""Tests for subscribe.py and unsubscribe.py."""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(
+    0,
+    str(Path(__file__).parent.parent.parent / "platform-integrations/claude/plugins/evolve-lite/lib"),
+)
+import config as cfg_module
+
+pytestmark = pytest.mark.platform_integrations
+
+_PLUGIN_ROOT = (
+    Path(__file__).parent.parent.parent
+    / "platform-integrations/claude/plugins/evolve-lite"
+)
+SUBSCRIBE_SCRIPT = _PLUGIN_ROOT / "skills/subscribe/scripts/subscribe.py"
+UNSUBSCRIBE_SCRIPT = _PLUGIN_ROOT / "skills/unsubscribe/scripts/unsubscribe.py"
+
+
+def run_script(script, project_dir, args, evolve_dir=None, expect_success=True):
+    env = {**os.environ}
+    if evolve_dir:
+        env["EVOLVE_DIR"] = str(evolve_dir)
+    return subprocess.run(
+        [sys.executable, str(script)] + args,
+        capture_output=True,
+        text=True,
+        cwd=str(project_dir),
+        env=env,
+        check=expect_success,
+    )
+
+
+class TestSubscribe:
+    def test_clones_remote_into_subscribed_dir(self, tmp_path, local_repo):
+        evolve_dir = tmp_path / ".evolve"
+        run_script(
+            SUBSCRIBE_SCRIPT, tmp_path,
+            ["--name", "alice", "--remote", str(local_repo["bare"]), "--branch", "main"],
+            evolve_dir=evolve_dir,
+        )
+        assert (evolve_dir / "subscribed" / "alice").is_dir()
+        assert (evolve_dir / "subscribed" / "alice" / ".git").exists()
+
+    def test_updates_config_with_subscription(self, tmp_path, local_repo):
+        evolve_dir = tmp_path / ".evolve"
+        run_script(
+            SUBSCRIBE_SCRIPT, tmp_path,
+            ["--name", "alice", "--remote", str(local_repo["bare"]), "--branch", "main"],
+            evolve_dir=evolve_dir,
+        )
+        cfg = cfg_module.load_config(str(tmp_path))
+        subs = cfg.get("subscriptions", [])
+        assert len(subs) == 1
+        assert subs[0]["name"] == "alice"
+        assert subs[0]["branch"] == "main"
+        assert str(local_repo["bare"]) in subs[0]["remote"]
+
+    def test_writes_audit_log(self, tmp_path, local_repo):
+        evolve_dir = tmp_path / ".evolve"
+        run_script(
+            SUBSCRIBE_SCRIPT, tmp_path,
+            ["--name", "alice", "--remote", str(local_repo["bare"]), "--branch", "main"],
+            evolve_dir=evolve_dir,
+        )
+        log_path = tmp_path / ".evolve" / "audit.log"
+        assert log_path.exists()
+        entry = json.loads(log_path.read_text().strip())
+        assert entry["action"] == "subscribe"
+        assert entry["name"] == "alice"
+
+    def test_fails_on_duplicate_name(self, tmp_path, local_repo):
+        evolve_dir = tmp_path / ".evolve"
+        args = ["--name", "alice", "--remote", str(local_repo["bare"]), "--branch", "main"]
+        run_script(SUBSCRIBE_SCRIPT, tmp_path, args, evolve_dir=evolve_dir)
+        result = run_script(SUBSCRIBE_SCRIPT, tmp_path, args, evolve_dir=evolve_dir, expect_success=False)
+        assert result.returncode != 0
+        assert "already exists" in result.stderr
+
+    def test_cloned_repo_contains_initial_entity(self, tmp_path, local_repo):
+        evolve_dir = tmp_path / ".evolve"
+        run_script(
+            SUBSCRIBE_SCRIPT, tmp_path,
+            ["--name", "alice", "--remote", str(local_repo["bare"]), "--branch", "main"],
+            evolve_dir=evolve_dir,
+        )
+        cloned = evolve_dir / "subscribed" / "alice" / "guideline" / "tip-one.md"
+        assert cloned.exists()
+        assert "Always write tests." in cloned.read_text()
+
+
+class TestUnsubscribe:
+    def _subscribe(self, tmp_path, local_repo, name="alice"):
+        evolve_dir = tmp_path / ".evolve"
+        run_script(
+            SUBSCRIBE_SCRIPT, tmp_path,
+            ["--name", name, "--remote", str(local_repo["bare"]), "--branch", "main"],
+            evolve_dir=evolve_dir,
+        )
+        return evolve_dir
+
+    def test_removes_local_clone(self, tmp_path, local_repo):
+        evolve_dir = self._subscribe(tmp_path, local_repo)
+        run_script(UNSUBSCRIBE_SCRIPT, tmp_path, ["--name", "alice"], evolve_dir=evolve_dir)
+        assert not (evolve_dir / "subscribed" / "alice").exists()
+
+    def test_removes_subscription_from_config(self, tmp_path, local_repo):
+        evolve_dir = self._subscribe(tmp_path, local_repo)
+        run_script(UNSUBSCRIBE_SCRIPT, tmp_path, ["--name", "alice"], evolve_dir=evolve_dir)
+        cfg = cfg_module.load_config(str(tmp_path))
+        assert cfg.get("subscriptions", []) == []
+
+    def test_list_flag_prints_subscriptions_as_json(self, tmp_path, local_repo):
+        evolve_dir = self._subscribe(tmp_path, local_repo)
+        result = run_script(UNSUBSCRIBE_SCRIPT, tmp_path, ["--list"], evolve_dir=evolve_dir)
+        data = json.loads(result.stdout)
+        assert isinstance(data, list)
+        assert data[0]["name"] == "alice"
+
+    def test_fails_when_name_not_found(self, tmp_path, local_repo):
+        evolve_dir = self._subscribe(tmp_path, local_repo)
+        result = run_script(
+            UNSUBSCRIBE_SCRIPT, tmp_path, ["--name", "nonexistent"],
+            evolve_dir=evolve_dir, expect_success=False,
+        )
+        assert result.returncode != 0
+        assert "not found" in result.stderr
+
+    def test_removes_mirrored_entities(self, tmp_path, local_repo):
+        evolve_dir = self._subscribe(tmp_path, local_repo)
+        # Simulate mirrored entities (sync would create these)
+        mirrored = evolve_dir / "entities" / "subscribed" / "alice"
+        mirrored.mkdir(parents=True)
+        (mirrored / "tip.md").write_text("---\ntype: guideline\n---\n\nA tip.\n")
+
+        run_script(UNSUBSCRIBE_SCRIPT, tmp_path, ["--name", "alice"], evolve_dir=evolve_dir)
+        assert not mirrored.exists()
+
+    def test_list_empty_when_no_subscriptions(self, tmp_path):
+        evolve_dir = tmp_path / ".evolve"
+        result = run_script(UNSUBSCRIBE_SCRIPT, tmp_path, ["--list"], evolve_dir=evolve_dir)
+        data = json.loads(result.stdout)
+        assert data == []

--- a/tests/platform_integrations/test_subscribe.py
+++ b/tests/platform_integrations/test_subscribe.py
@@ -44,8 +44,8 @@ class TestSubscribe:
             ["--name", "alice", "--remote", str(local_repo["bare"]), "--branch", "main"],
             evolve_dir=evolve_dir,
         )
-        assert (evolve_dir / "subscribed" / "alice").is_dir()
-        assert (evolve_dir / "subscribed" / "alice" / ".git").exists()
+        assert (evolve_dir / "entities" / "subscribed" / "alice").is_dir()
+        assert (evolve_dir / "entities" / "subscribed" / "alice" / ".git").exists()
 
     def test_updates_config_with_subscription(self, temp_project_dir, local_repo):
         evolve_dir = temp_project_dir / ".evolve"
@@ -98,7 +98,7 @@ class TestSubscribe:
 
     def test_fails_when_dest_already_exists(self, temp_project_dir, local_repo):
         evolve_dir = temp_project_dir / ".evolve"
-        dest = evolve_dir / "subscribed" / "alice"
+        dest = evolve_dir / "entities" / "subscribed" / "alice"
         dest.mkdir(parents=True)
         result = run_script(
             SUBSCRIBE_SCRIPT,
@@ -133,7 +133,7 @@ class TestSubscribe:
             ["--name", "alice", "--remote", str(local_repo["bare"]), "--branch", "main"],
             evolve_dir=evolve_dir,
         )
-        cloned = evolve_dir / "subscribed" / "alice" / "guideline" / "tip-one.md"
+        cloned = evolve_dir / "entities" / "subscribed" / "alice" / "guideline" / "tip-one.md"
         assert cloned.exists()
         assert "Always write tests." in cloned.read_text()
 
@@ -152,7 +152,7 @@ class TestUnsubscribe:
     def test_removes_local_clone(self, temp_project_dir, local_repo):
         evolve_dir = self._subscribe(temp_project_dir, local_repo)
         run_script(UNSUBSCRIBE_SCRIPT, temp_project_dir, ["--name", "alice"], evolve_dir=evolve_dir)
-        assert not (evolve_dir / "subscribed" / "alice").exists()
+        assert not (evolve_dir / "entities" / "subscribed" / "alice").exists()
 
     def test_removes_subscription_from_config(self, temp_project_dir, local_repo):
         evolve_dir = self._subscribe(temp_project_dir, local_repo)
@@ -181,13 +181,11 @@ class TestUnsubscribe:
 
     def test_removes_mirrored_entities(self, temp_project_dir, local_repo):
         evolve_dir = self._subscribe(temp_project_dir, local_repo)
-        # Simulate mirrored entities (sync would create these)
-        mirrored = evolve_dir / "entities" / "subscribed" / "alice"
-        mirrored.mkdir(parents=True)
-        (mirrored / "tip.md").write_text("---\ntype: guideline\n---\n\nA tip.\n")
+        cloned = evolve_dir / "entities" / "subscribed" / "alice"
+        assert cloned.is_dir()
 
         run_script(UNSUBSCRIBE_SCRIPT, temp_project_dir, ["--name", "alice"], evolve_dir=evolve_dir)
-        assert not mirrored.exists()
+        assert not cloned.exists()
 
     def test_list_empty_when_no_subscriptions(self, temp_project_dir):
         evolve_dir = temp_project_dir / ".evolve"

--- a/tests/platform_integrations/test_sync.py
+++ b/tests/platform_integrations/test_sync.py
@@ -107,7 +107,7 @@ class TestSync:
         run_script(SYNC_SCRIPT, p["project_dir"], evolve_dir=p["evolve_dir"])
         log_path = p["project_dir"] / ".evolve" / "audit.log"
         assert log_path.exists()
-        actions = [json.loads(l)["action"] for l in log_path.read_text().splitlines() if l.strip()]
+        actions = [json.loads(line)["action"] for line in log_path.read_text().splitlines() if line.strip()]
         assert "sync" in actions
 
     def test_removed_entity_disappears_after_sync(self, subscribed_project):

--- a/tests/platform_integrations/test_sync.py
+++ b/tests/platform_integrations/test_sync.py
@@ -1,0 +1,146 @@
+"""Tests for skills/sync/scripts/sync.py."""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.platform_integrations
+
+_PLUGIN_ROOT = (
+    Path(__file__).parent.parent.parent
+    / "platform-integrations/claude/plugins/evolve-lite"
+)
+SUBSCRIBE_SCRIPT = _PLUGIN_ROOT / "skills/subscribe/scripts/subscribe.py"
+SYNC_SCRIPT = _PLUGIN_ROOT / "skills/sync/scripts/sync.py"
+
+
+def run_script(script, project_dir, args=None, evolve_dir=None, expect_success=True):
+    env = {**os.environ}
+    if evolve_dir:
+        env["EVOLVE_DIR"] = str(evolve_dir)
+    return subprocess.run(
+        [sys.executable, str(script)] + (args or []),
+        capture_output=True,
+        text=True,
+        cwd=str(project_dir),
+        env=env,
+        check=expect_success,
+    )
+
+
+@pytest.fixture
+def subscribed_project(tmp_path, local_repo):
+    """A project already subscribed to local_repo."""
+    evolve_dir = tmp_path / ".evolve"
+    run_script(
+        SUBSCRIBE_SCRIPT, tmp_path,
+        ["--name", "alice", "--remote", str(local_repo["bare"]), "--branch", "main"],
+        evolve_dir=evolve_dir,
+    )
+    return {"project_dir": tmp_path, "evolve_dir": evolve_dir, "local_repo": local_repo}
+
+
+class TestSync:
+    def test_mirrors_entities_into_subscribed_dir(self, subscribed_project):
+        p = subscribed_project
+        run_script(SYNC_SCRIPT, p["project_dir"], evolve_dir=p["evolve_dir"])
+        mirrored = p["evolve_dir"] / "entities" / "subscribed" / "alice"
+        assert mirrored.is_dir()
+        assert any(mirrored.rglob("*.md"))
+
+    def test_mirrors_initial_entity_content(self, subscribed_project):
+        p = subscribed_project
+        run_script(SYNC_SCRIPT, p["project_dir"], evolve_dir=p["evolve_dir"])
+        tip = p["evolve_dir"] / "entities" / "subscribed" / "alice" / "guideline" / "tip-one.md"
+        assert tip.exists()
+        assert "Always write tests." in tip.read_text()
+
+    def test_picks_up_new_entity_after_push(self, subscribed_project):
+        """After a new entity is pushed to the remote, a second sync picks it up."""
+        p = subscribed_project
+        lr = p["local_repo"]
+        git_env = lr["env"]
+
+        # First sync — brings down the initial entity
+        run_script(SYNC_SCRIPT, p["project_dir"], evolve_dir=p["evolve_dir"])
+
+        # Push a new entity to the remote via the working clone
+        new_entity = lr["work"] / "guideline" / "tip-two.md"
+        new_entity.write_text("---\ntype: guideline\n---\n\nDelete dead code promptly.\n")
+        subprocess.run(["git", "-C", str(lr["work"]), "add", "."], check=True, env=git_env)
+        subprocess.run(
+            ["git", "-C", str(lr["work"]), "commit", "-m", "add tip-two"],
+            check=True, env=git_env,
+        )
+        subprocess.run(
+            ["git", "-C", str(lr["work"]), "push", "origin", "main"],
+            check=True, env=git_env,
+        )
+
+        # Second sync — should pick up tip-two
+        run_script(SYNC_SCRIPT, p["project_dir"], evolve_dir=p["evolve_dir"])
+
+        mirrored = (
+            p["evolve_dir"] / "entities" / "subscribed" / "alice" / "guideline" / "tip-two.md"
+        )
+        assert mirrored.exists()
+        assert "Delete dead code promptly." in mirrored.read_text()
+
+    def test_quiet_flag_suppresses_output_when_no_changes(self, subscribed_project):
+        p = subscribed_project
+        # First sync to reach a clean state
+        run_script(SYNC_SCRIPT, p["project_dir"], evolve_dir=p["evolve_dir"])
+        # Second sync with --quiet: nothing changed, no output expected
+        result = run_script(SYNC_SCRIPT, p["project_dir"], ["--quiet"], evolve_dir=p["evolve_dir"])
+        assert result.stdout.strip() == ""
+
+    def test_no_subscriptions_exits_cleanly(self, tmp_path):
+        evolve_dir = tmp_path / ".evolve"
+        result = run_script(SYNC_SCRIPT, tmp_path, evolve_dir=evolve_dir)
+        assert result.returncode == 0
+        assert "No subscriptions" in result.stdout
+
+    def test_writes_audit_log(self, subscribed_project):
+        p = subscribed_project
+        run_script(SYNC_SCRIPT, p["project_dir"], evolve_dir=p["evolve_dir"])
+        log_path = p["project_dir"] / ".evolve" / "audit.log"
+        assert log_path.exists()
+        actions = [
+            json.loads(l)["action"]
+            for l in log_path.read_text().splitlines()
+            if l.strip()
+        ]
+        assert "sync" in actions
+
+    def test_removed_entity_disappears_after_sync(self, subscribed_project):
+        """Entities deleted from the remote are removed from the mirror on next sync."""
+        p = subscribed_project
+        lr = p["local_repo"]
+        git_env = lr["env"]
+
+        # First sync
+        run_script(SYNC_SCRIPT, p["project_dir"], evolve_dir=p["evolve_dir"])
+        tip_one = p["evolve_dir"] / "entities" / "subscribed" / "alice" / "guideline" / "tip-one.md"
+        assert tip_one.exists()
+
+        # Delete tip-one from remote
+        subprocess.run(
+            ["git", "-C", str(lr["work"]), "rm", "guideline/tip-one.md"],
+            check=True, env=git_env,
+        )
+        subprocess.run(
+            ["git", "-C", str(lr["work"]), "commit", "-m", "remove tip-one"],
+            check=True, env=git_env,
+        )
+        subprocess.run(
+            ["git", "-C", str(lr["work"]), "push", "origin", "main"],
+            check=True, env=git_env,
+        )
+
+        # Second sync — mirror is cleared and re-copied without tip-one
+        run_script(SYNC_SCRIPT, p["project_dir"], evolve_dir=p["evolve_dir"])
+        assert not tip_one.exists()

--- a/tests/platform_integrations/test_sync.py
+++ b/tests/platform_integrations/test_sync.py
@@ -126,9 +126,7 @@ class TestSync:
         evolve_dir = temp_project_dir / ".evolve"
         # Write config manually with an unsafe name
         cfg_path = temp_project_dir / "evolve.config.yaml"
-        cfg_path.write_text(
-            "subscriptions:\n  - name: ../evil\n    remote: git@github.com:x/y.git\n    branch: main\n"
-        )
+        cfg_path.write_text("subscriptions:\n  - name: ../evil\n    remote: git@github.com:x/y.git\n    branch: main\n")
         result = run_script(SYNC_SCRIPT, temp_project_dir, evolve_dir=evolve_dir)
         assert result.returncode == 0
         assert "invalid subscription name" in result.stdout
@@ -137,9 +135,7 @@ class TestSync:
     def test_manual_run_ignores_on_session_start_false(self, subscribed_project):
         p = subscribed_project
         cfg_path = p["project_dir"] / "evolve.config.yaml"
-        cfg_path.write_text(
-            "sync:\n  on_session_start: false\nsubscriptions:\n  - name: alice\n    remote: x\n    branch: main\n"
-        )
+        cfg_path.write_text("sync:\n  on_session_start: false\nsubscriptions:\n  - name: alice\n    remote: x\n    branch: main\n")
         # Manual run (no --quiet) must still execute even with on_session_start: false
         result = run_script(SYNC_SCRIPT, p["project_dir"], evolve_dir=p["evolve_dir"])
         assert result.returncode == 0

--- a/tests/platform_integrations/test_sync.py
+++ b/tests/platform_integrations/test_sync.py
@@ -110,6 +110,41 @@ class TestSync:
         actions = [json.loads(line)["action"] for line in log_path.read_text().splitlines() if line.strip()]
         assert "sync" in actions
 
+    def test_skips_symlinked_entities(self, subscribed_project):
+        p = subscribed_project
+        lr = p["local_repo"]
+        # Create a real file and a symlink pointing at it in the subscribed clone
+        real_file = lr["work"] / "guideline" / "real.md"
+        real_file.write_text("---\ntype: guideline\n---\n\nReal content.\n")
+        symlink_file = lr["work"] / "guideline" / "link.md"
+        symlink_file.symlink_to(real_file)
+        run_script(SYNC_SCRIPT, p["project_dir"], evolve_dir=p["evolve_dir"])
+        mirrored = p["evolve_dir"] / "entities" / "subscribed" / "alice" / "guideline"
+        assert not (mirrored / "link.md").exists()
+
+    def test_skips_invalid_subscription_name(self, temp_project_dir):
+        evolve_dir = temp_project_dir / ".evolve"
+        # Write config manually with an unsafe name
+        cfg_path = temp_project_dir / "evolve.config.yaml"
+        cfg_path.write_text(
+            "subscriptions:\n  - name: ../evil\n    remote: git@github.com:x/y.git\n    branch: main\n"
+        )
+        result = run_script(SYNC_SCRIPT, temp_project_dir, evolve_dir=evolve_dir)
+        assert result.returncode == 0
+        assert "invalid subscription name" in result.stdout
+        assert not (evolve_dir / "subscribed" / ".." / "evil").exists()
+
+    def test_manual_run_ignores_on_session_start_false(self, subscribed_project):
+        p = subscribed_project
+        cfg_path = p["project_dir"] / "evolve.config.yaml"
+        cfg_path.write_text(
+            "sync:\n  on_session_start: false\nsubscriptions:\n  - name: alice\n    remote: x\n    branch: main\n"
+        )
+        # Manual run (no --quiet) must still execute even with on_session_start: false
+        result = run_script(SYNC_SCRIPT, p["project_dir"], evolve_dir=p["evolve_dir"])
+        assert result.returncode == 0
+        assert "Synced" in result.stdout
+
     def test_removed_entity_disappears_after_sync(self, subscribed_project):
         """Entities deleted from the remote are removed from the mirror on next sync."""
         p = subscribed_project

--- a/tests/platform_integrations/test_sync.py
+++ b/tests/platform_integrations/test_sync.py
@@ -10,10 +10,7 @@ import pytest
 
 pytestmark = pytest.mark.platform_integrations
 
-_PLUGIN_ROOT = (
-    Path(__file__).parent.parent.parent
-    / "platform-integrations/claude/plugins/evolve-lite"
-)
+_PLUGIN_ROOT = Path(__file__).parent.parent.parent / "platform-integrations/claude/plugins/evolve-lite"
 SUBSCRIBE_SCRIPT = _PLUGIN_ROOT / "skills/subscribe/scripts/subscribe.py"
 SYNC_SCRIPT = _PLUGIN_ROOT / "skills/sync/scripts/sync.py"
 
@@ -33,15 +30,16 @@ def run_script(script, project_dir, args=None, evolve_dir=None, expect_success=T
 
 
 @pytest.fixture
-def subscribed_project(tmp_path, local_repo):
+def subscribed_project(temp_project_dir, local_repo):
     """A project already subscribed to local_repo."""
-    evolve_dir = tmp_path / ".evolve"
+    evolve_dir = temp_project_dir / ".evolve"
     run_script(
-        SUBSCRIBE_SCRIPT, tmp_path,
+        SUBSCRIBE_SCRIPT,
+        temp_project_dir,
         ["--name", "alice", "--remote", str(local_repo["bare"]), "--branch", "main"],
         evolve_dir=evolve_dir,
     )
-    return {"project_dir": tmp_path, "evolve_dir": evolve_dir, "local_repo": local_repo}
+    return {"project_dir": temp_project_dir, "evolve_dir": evolve_dir, "local_repo": local_repo}
 
 
 class TestSync:
@@ -74,19 +72,19 @@ class TestSync:
         subprocess.run(["git", "-C", str(lr["work"]), "add", "."], check=True, env=git_env)
         subprocess.run(
             ["git", "-C", str(lr["work"]), "commit", "-m", "add tip-two"],
-            check=True, env=git_env,
+            check=True,
+            env=git_env,
         )
         subprocess.run(
             ["git", "-C", str(lr["work"]), "push", "origin", "main"],
-            check=True, env=git_env,
+            check=True,
+            env=git_env,
         )
 
         # Second sync — should pick up tip-two
         run_script(SYNC_SCRIPT, p["project_dir"], evolve_dir=p["evolve_dir"])
 
-        mirrored = (
-            p["evolve_dir"] / "entities" / "subscribed" / "alice" / "guideline" / "tip-two.md"
-        )
+        mirrored = p["evolve_dir"] / "entities" / "subscribed" / "alice" / "guideline" / "tip-two.md"
         assert mirrored.exists()
         assert "Delete dead code promptly." in mirrored.read_text()
 
@@ -98,9 +96,9 @@ class TestSync:
         result = run_script(SYNC_SCRIPT, p["project_dir"], ["--quiet"], evolve_dir=p["evolve_dir"])
         assert result.stdout.strip() == ""
 
-    def test_no_subscriptions_exits_cleanly(self, tmp_path):
-        evolve_dir = tmp_path / ".evolve"
-        result = run_script(SYNC_SCRIPT, tmp_path, evolve_dir=evolve_dir)
+    def test_no_subscriptions_exits_cleanly(self, temp_project_dir):
+        evolve_dir = temp_project_dir / ".evolve"
+        result = run_script(SYNC_SCRIPT, temp_project_dir, evolve_dir=evolve_dir)
         assert result.returncode == 0
         assert "No subscriptions" in result.stdout
 
@@ -109,11 +107,7 @@ class TestSync:
         run_script(SYNC_SCRIPT, p["project_dir"], evolve_dir=p["evolve_dir"])
         log_path = p["project_dir"] / ".evolve" / "audit.log"
         assert log_path.exists()
-        actions = [
-            json.loads(l)["action"]
-            for l in log_path.read_text().splitlines()
-            if l.strip()
-        ]
+        actions = [json.loads(l)["action"] for l in log_path.read_text().splitlines() if l.strip()]
         assert "sync" in actions
 
     def test_removed_entity_disappears_after_sync(self, subscribed_project):
@@ -130,15 +124,18 @@ class TestSync:
         # Delete tip-one from remote
         subprocess.run(
             ["git", "-C", str(lr["work"]), "rm", "guideline/tip-one.md"],
-            check=True, env=git_env,
+            check=True,
+            env=git_env,
         )
         subprocess.run(
             ["git", "-C", str(lr["work"]), "commit", "-m", "remove tip-one"],
-            check=True, env=git_env,
+            check=True,
+            env=git_env,
         )
         subprocess.run(
             ["git", "-C", str(lr["work"]), "push", "origin", "main"],
-            check=True, env=git_env,
+            check=True,
+            env=git_env,
         )
 
         # Second sync — mirror is cleared and re-copied without tip-one


### PR DESCRIPTION
Starts addressing Issue #182 
New skills: publish, subscribe, unsubscribe, sync
New lib modules: config.py, audit.py
Updated: plugin.json, hooks.json, entity_io.py, save_entities.py, retrieve_entities.py

CI test suite (110 tests in tests/platform_integrations/):
- test_config.py, test_audit.py, test_entity_io_core.py
- test_publish.py, test_subscribe.py, test_sync.py
- test_retrieve.py, test_save_entities.py, test_plugin_structure.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Publish private guidelines to a public repo (marked public, timestamped, optional owner).
  * Subscribe/unsubscribe workflows and on-demand/automatic sync of subscribed guidelines (session-start hook).
  * Save flow stamps owner/visibility; recall annotates subscribed sources; append-only audit logging.
* **Documentation**
  * Interactive skill docs for publish, subscribe, sync, unsubscribe; README expanded.
* **Tests**
  * Extensive integration/e2e tests for publish, subscribe/unsubscribe, sync, save, retrieve, config, and audit.
* **Chores**
  * Plugin version bumped to 1.1.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->