### PR TITLE
fix(install): default to main branch instead of pinned tag

### DIFF
--- a/platform-integrations/install.sh
+++ b/platform-integrations/install.sh
@@ -23,8 +23,8 @@ EVOLVE_DEBUG="${EVOLVE_DEBUG:-0}"
 
 # Default to "main" so the installer always pulls the latest source.
 # Callers can still pin a specific tag: EVOLVE_VERSION=v1.0.6 bash install.sh ...
-SCRIPT_VERSION="v1.0.8"
-EVOLVE_VERSION="${EVOLVE_VERSION:-${SCRIPT_VERSION}}"
+SCRIPT_VERSION="v1.0.9"
+EVOLVE_VERSION="${EVOLVE_VERSION:-main}"
 
 # ─── Colours ──────────────────────────────────────────────────────────────────
 if [ -t 1 ]; then


### PR DESCRIPTION
## Summary
- The installer defaulted to downloading the `v1.0.8` tag, which predates the `evolve-save-trajectory` skill added in #184
- Remote installs via `curl | bash` failed with `FileNotFoundError` because the skill directory didn't exist in the v1.0.8 tarball
- Changed `EVOLVE_VERSION` default from `${SCRIPT_VERSION}` to `main` so remote installs always pull the latest source tree

## Test plan
- [ ] Run `curl -fsSL https://raw.githubusercontent.com/AgentToolkit/altk-evolve/main/platform-integrations/install.sh | bash -s -- install --platform bob --mode lite` in a target project and verify all three skills install
- [ ] Verify `EVOLVE_VERSION=v1.0.8 bash install.sh install --platform bob --mode lite` still allows pinning to a specific tag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated installer to version v1.0.9
  * Modified default installation source behavior when no specific version is provided

<!-- end of auto-generated comment: release notes by coderabbit.ai -->