### PR TITLE
fix: release artifact versioning

### DIFF
--- a/.github/workflows/release-github.yaml
+++ b/.github/workflows/release-github.yaml
@@ -116,3 +116,14 @@ jobs:
         with:
           github_token: ${{ secrets.CI_PUSH_TOKEN }}
           tag: ${{ steps.release.outputs.tag }}
+
+      - name: Upload install.sh to GitHub release assets
+        if: steps.release.outputs.released == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.CI_PUSH_TOKEN }}
+        run: |
+          sed 's/^SCRIPT_VERSION="main"/SCRIPT_VERSION="${{ steps.release.outputs.tag }}"/' \
+            platform-integrations/install.sh > /tmp/install.sh
+          gh release upload ${{ steps.release.outputs.tag }} \
+            /tmp/install.sh#install.sh \
+            --clobber

--- a/platform-integrations/install.sh
+++ b/platform-integrations/install.sh
@@ -11,8 +11,7 @@
 #   curl -fsSL https://raw.githubusercontent.com/AgentToolkit/altk-evolve/main/platform-integrations/install.sh | bash
 #   curl -fsSL https://raw.githubusercontent.com/AgentToolkit/altk-evolve/main/platform-integrations/install.sh | bash -s -- install --platform bob
 #
-# Pinned version (SCRIPT_VERSION is substituted by the release process, so the
-# script fetched from a tag already knows its own version — no env var needed):
+# Pinned version:
 #   curl -fsSL https://raw.githubusercontent.com/AgentToolkit/altk-evolve/v1.2.0/platform-integrations/install.sh | bash
 
 set -euo pipefail
@@ -21,9 +20,11 @@ set -euo pipefail
 EVOLVE_REPO="${EVOLVE_REPO:-AgentToolkit/altk-evolve}"
 EVOLVE_DEBUG="${EVOLVE_DEBUG:-0}"
 
-# Default to "main" so the installer always pulls the latest source.
-# Callers can still pin a specific tag: EVOLVE_VERSION=v1.0.6 bash install.sh ...
-SCRIPT_VERSION="v1.0.8"
+# SCRIPT_VERSION refers to a branch or a version tag. This value is substituted
+# during the release process, so that a script always knows it's own version,
+# and downloads the correct artifact bundle.
+# Callers can manually override: EVOLVE_VERSION=v1.0.6 bash install.sh ...
+SCRIPT_VERSION="main"
 EVOLVE_VERSION="${EVOLVE_VERSION:-${SCRIPT_VERSION}}"
 
 # ─── Colours ──────────────────────────────────────────────────────────────────

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,8 +116,8 @@ build_command = '''
     perl -i -pe "s|\]\(([A-Z_]*\.md)\)|](https://github.com/AgentToolkit/altk-evolve/blob/v$NEW_VERSION/\$1)|g" README.md
     perl -i -pe "s|\]\(docs/([^)]*)\)|](https://github.com/AgentToolkit/altk-evolve/blob/v$NEW_VERSION/docs/\$1)|g" README.md
     sed -i 's/^SCRIPT_VERSION="main"/SCRIPT_VERSION="v'"$NEW_VERSION"'"/' platform-integrations/install.sh
-    git add platform-integrations/install.sh
     uv build
+    git checkout platform-integrations/install.sh
     mv README.md.bak README.md
 '''
 tag_format = "v{version}"


### PR DESCRIPTION
Previously, PSR committed the version-stamped install.sh back to main, leaving the branch permanently at the last release version rather than "main". The build_command now restores the file with git checkout after uv build, so built artifacts (wheel, sdist) get the correct version while main always stays at SCRIPT_VERSION="main".

Adds platform-integrations/install.sh to GitHub release assets, with SCRIPT_VERSION stamped to the release tag at upload time via sed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release automation to ensure installation scripts in GitHub releases include correct version information.
  * Updated installer script version defaults for better out-of-the-box behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->