### PR TITLE
feat(altk_evolve): entity sharing — public/private visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,10 +106,12 @@ npx @modelcontextprotocol/inspector@latest http://127.0.0.1:8201/sse --cli --met
 ```
 
 **Available tools:**
-- `get_entities(task: str, entity_type: str)`: Get relevant entities for a specific task, filtered by type (e.g., 'guideline', 'policy').
-- `get_guidelines(task: str)`: Get relevant guidelines for a specific task (backward compatibility alias).
-- `save_trajectory(trajectory_data: str, task_id: str | None)`: Save a conversation trajectory and generate new guidelines.
-- `create_entity(content: str, entity_type: str, metadata: str | None, enable_conflict_resolution: bool)`: Create a single entity in the namespace.
+- `get_entities(task: str, entity_type: str = "guideline", include_public: bool = False)`: Get relevant entities for a specific task. Set `include_public=True` to merge in public entities from all other namespaces; those results are annotated with `[public: {owner_id}]`.
+- `get_guidelines(task: str)`: Get relevant guidelines for a specific task (backward compatibility alias for `get_entities`).
+- `save_trajectory(trajectory_data: str, task_id: str | None, owner_id: str | None)`: Save a conversation trajectory and generate new guidelines.
+- `create_entity(content: str, entity_type: str, metadata: str | None, enable_conflict_resolution: bool, owner_id: str | None, visibility: str = "private")`: Create a single entity. Pass `visibility="public"` and `owner_id` to make it immediately discoverable by other namespaces.
+- `publish_entity(entity_id: str, user_id: str | None)`: Make an entity publicly visible to all namespaces. Records the caller as owner and stamps `published_at`.
+- `unpublish_entity(entity_id: str)`: Revert an entity to private visibility.
 - `delete_entity(entity_id: str)`: Delete a specific entity by its ID.
 
 ### Filter Migration Note

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ npx @modelcontextprotocol/inspector@latest http://127.0.0.1:8201/sse --cli --met
 - `save_trajectory(trajectory_data: str, task_id: str | None, owner_id: str | None)`: Save a conversation trajectory and generate new guidelines.
 - `create_entity(content: str, entity_type: str, metadata: str | None, enable_conflict_resolution: bool, owner_id: str | None, visibility: str = "private")`: Create a single entity. Pass `visibility="public"` and `owner_id` to make it immediately discoverable by other namespaces.
 - `publish_entity(entity_id: str, user_id: str | None)`: Make an entity publicly visible to all namespaces. Records the caller as owner and stamps `published_at`.
-- `unpublish_entity(entity_id: str)`: Revert an entity to private visibility.
+- `unpublish_entity(entity_id: str, user_id: str | None = None)`: Revert an entity to private visibility. Ownership is enforced server-side: if the entity has an `owner_id`, `user_id` must match it.
 - `delete_entity(entity_id: str)`: Delete a specific entity by its ID.
 
 ### Filter Migration Note
@@ -158,7 +158,7 @@ Sets `visibility=public` and records the owner and publish timestamp.
 
 **Unpublishing:**
 ```python
-unpublish_entity(entity_id="42")
+unpublish_entity(entity_id="42", user_id="alice")
 ```
 Reverts the entity to private. The entity stays in its namespace — only its visibility changes.
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Existing integrations that stored custom fields in entity metadata should update
 - **Proactive**: Learns how to recognize problems and their solutions, and generates guidelines that get automatically applied to new tasks.
 - **Conflict Resolution**: Update existing guidelines when new information contradicts them.
 - **On Command**: An array of tools to manage guidelines whether in the agent or through a CLI
+- **Sharing**: Publish individual entities so other agents can discover and retrieve them across namespaces.
 
 ## Architecture
 Evolve is built on a modular architecture which forms a feedback loop, taking conversation traces (trajectories) from an agent, extracting key insights into a database, feeding it back into the agent.
@@ -132,6 +133,46 @@ _Lite Mode omits the Interaction layer. All activity is performed in-agent_
   <source media="(prefers-color-scheme: dark)" srcset="docs/assets/architecture-wide-dark.svg">
   <img src="docs/assets/architecture-wide-light.svg" alt="Architecture" width="480">
 </picture>
+
+## Entity Sharing
+
+Evolve supports sharing entities across namespaces using a simple public/private visibility model.
+
+**Visibility** is stored in each entity's metadata and is private by default. Existing entities without a `visibility` field are unaffected.
+
+| Metadata field | Description |
+|---|---|
+| `owner_id` | User ID who created or last published the entity |
+| `visibility` | `"private"` (default) or `"public"` |
+| `published_at` | ISO-8601 timestamp of the most recent publish |
+
+### MCP Tools
+
+**Publishing an entity:**
+```
+publish_entity(entity_id="42", user_id="alice")
+```
+Sets `visibility=public` and records the owner and publish timestamp.
+
+**Unpublishing:**
+```
+unpublish_entity(entity_id="42")
+```
+Reverts the entity to private. The entity stays in its namespace — only its visibility changes.
+
+**Retrieving public entities from all namespaces:**
+```
+get_entities(task="write safer code", include_public=True)
+```
+Merges results from the caller's namespace with public entities from all other namespaces. Public results are annotated with `[public: {owner_id}]`.
+
+**Creating an entity with visibility:**
+```
+create_entity(content="...", entity_type="guideline", visibility="public", owner_id="alice")
+```
+
+### What's deferred (Phase 1C)
+REST API endpoints (`GET /api/entities/public`, publish/unpublish routes) and UI controls are not yet implemented.
 
 ## Guideline Provenance
 Evolve automatically tracks the origin of every guideline it generates or stores. Every guideline entity contains `metadata` identifying its source:

--- a/README.md
+++ b/README.md
@@ -149,25 +149,25 @@ Evolve supports sharing entities across namespaces using a simple public/private
 ### MCP Tools
 
 **Publishing an entity:**
-```
+```python
 publish_entity(entity_id="42", user_id="alice")
 ```
 Sets `visibility=public` and records the owner and publish timestamp.
 
 **Unpublishing:**
-```
+```python
 unpublish_entity(entity_id="42")
 ```
 Reverts the entity to private. The entity stays in its namespace — only its visibility changes.
 
 **Retrieving public entities from all namespaces:**
-```
+```python
 get_entities(task="write safer code", include_public=True)
 ```
 Merges results from the caller's namespace with public entities from all other namespaces. Public results are annotated with `[public: {owner_id}]`.
 
 **Creating an entity with visibility:**
-```
+```python
 create_entity(content="...", entity_type="guideline", visibility="public", owner_id="alice")
 ```
 

--- a/altk_evolve/backend/base.py
+++ b/altk_evolve/backend/base.py
@@ -99,10 +99,11 @@ class BaseEntityBackend(ABC):
         results = self.search_entities(namespace_id, filters={"id": entity_id}, limit=1)
         if not results:
             from altk_evolve.schema.exceptions import EvolveException
+
             raise EvolveException(f"Entity '{entity_id}' not found in namespace '{namespace_id}'")
         entity = results[0]
         merged = {**(entity.metadata or {}), **metadata_patch}
-        timestamp = int(datetime.datetime.now(datetime.UTC).timestamp())
+        timestamp = int(entity.created_at.timestamp())
         self.patch_entity(namespace_id, entity_id, entity.type, serialize_content(entity.content), timestamp, merged)
         return RecordedEntity(**{**entity.model_dump(), "metadata": merged})
 

--- a/altk_evolve/backend/base.py
+++ b/altk_evolve/backend/base.py
@@ -88,6 +88,24 @@ class BaseEntityBackend(ABC):
         """
         self._update_entity(namespace_id, entity_id, entity_type, content_str, timestamp, metadata)
 
+    def update_entity_metadata(self, namespace_id: str, entity_id: str, metadata_patch: dict) -> RecordedEntity:
+        """Merge metadata_patch into an entity's metadata without touching content.
+
+        The default implementation fetches via search_entities, merges, then calls patch_entity.
+        DB-backed backends should override with a native atomic update.
+        """
+        from altk_evolve.utils.utils import serialize_content
+
+        results = self.search_entities(namespace_id, filters={"id": entity_id}, limit=1)
+        if not results:
+            from altk_evolve.schema.exceptions import EvolveException
+            raise EvolveException(f"Entity '{entity_id}' not found in namespace '{namespace_id}'")
+        entity = results[0]
+        merged = {**(entity.metadata or {}), **metadata_patch}
+        timestamp = int(datetime.datetime.now(datetime.UTC).timestamp())
+        self.patch_entity(namespace_id, entity_id, entity.type, serialize_content(entity.content), timestamp, merged)
+        return RecordedEntity(**{**entity.model_dump(), "metadata": merged})
+
     def update_entities(
         self,
         namespace_id: str,

--- a/altk_evolve/backend/base.py
+++ b/altk_evolve/backend/base.py
@@ -80,6 +80,14 @@ class BaseEntityBackend(ABC):
         """Hook called after all entity mutations are complete. No-op by default."""
         pass
 
+    def patch_entity(self, namespace_id: str, entity_id: str, entity_type: str, content_str: str, timestamp: int, metadata: dict) -> None:
+        """Update an existing entity in-place (fetch-merge-write helper).
+
+        Backends that require pre-loaded state before calling _update_entity
+        (e.g. filesystem) must override this method.
+        """
+        self._update_entity(namespace_id, entity_id, entity_type, content_str, timestamp, metadata)
+
     def update_entities(
         self,
         namespace_id: str,

--- a/altk_evolve/backend/filesystem.py
+++ b/altk_evolve/backend/filesystem.py
@@ -170,10 +170,16 @@ class FilesystemEntityBackend(BaseEntityBackend):
 
     def patch_entity(self, namespace_id: str, entity_id: str, entity_type: str, content_str: str, timestamp: int, metadata: dict) -> None:
         """Override to load namespace data, call _update_entity, then persist."""
+        if not entity_id:
+            raise ValueError(f"entity_id must be a non-empty string, got {entity_id!r}")
         with self._lock:
             self._active_data = self._load_namespace_data(namespace_id)
-            self._update_entity(namespace_id, entity_id, entity_type, content_str, timestamp, metadata)
-            self._post_update(namespace_id)
+            try:
+                self._update_entity(namespace_id, entity_id, entity_type, content_str, timestamp, metadata)
+                self._post_update(namespace_id)
+            except Exception:
+                self._active_data = None
+                raise
 
     def update_entities(
         self,

--- a/altk_evolve/backend/filesystem.py
+++ b/altk_evolve/backend/filesystem.py
@@ -168,6 +168,13 @@ class FilesystemEntityBackend(BaseEntityBackend):
         self._save_namespace_data(namespace_id, self._active_data)
         self._active_data = None
 
+    def patch_entity(self, namespace_id: str, entity_id: str, entity_type: str, content_str: str, timestamp: int, metadata: dict) -> None:
+        """Override to load namespace data, call _update_entity, then persist."""
+        with self._lock:
+            self._active_data = self._load_namespace_data(namespace_id)
+            self._update_entity(namespace_id, entity_id, entity_type, content_str, timestamp, metadata)
+            self._post_update(namespace_id)
+
     def update_entities(
         self,
         namespace_id: str,

--- a/altk_evolve/backend/milvus.py
+++ b/altk_evolve/backend/milvus.py
@@ -290,6 +290,28 @@ class MilvusEntityBackend(BaseEntityBackend):
     def _delete_entity(self, namespace_id: str, entity_id: str) -> None:
         self.delete_entity_by_id(namespace_id=namespace_id, entity_id=entity_id)
 
+    def update_entity_metadata(self, namespace_id: str, entity_id: str, metadata_patch: dict) -> RecordedEntity:
+        try:
+            entity_id_int = int(entity_id)
+        except ValueError:
+            raise EvolveException(f"Invalid entity ID '{entity_id}': must be numeric.")
+        self._validate_namespace(namespace_id)
+        results = self.milvus.query(
+            collection_name=namespace_id,
+            filter=f"id == {entity_id_int}",
+            output_fields=["id", "type", "content", "created_at", "metadata"],
+            limit=1,
+        )
+        if not results:
+            raise EvolveException(f"Entity '{entity_id}' not found in namespace '{namespace_id}'")
+        entity = parse_milvus_entity(results[0])
+        merged = {**(entity.metadata or {}), **metadata_patch}
+        timestamp = int(datetime.datetime.now(datetime.UTC).timestamp())
+        from altk_evolve.utils.utils import serialize_content
+        self._update_entity(namespace_id, entity_id, entity.type, serialize_content(entity.content), timestamp, merged)
+        self._post_update(namespace_id)
+        return RecordedEntity(**{**entity.model_dump(), "metadata": merged})
+
     def _post_update(self, namespace_id: str) -> None:
         self.milvus.flush(namespace_id)
         self.milvus.load_collection(namespace_id)

--- a/altk_evolve/backend/milvus.py
+++ b/altk_evolve/backend/milvus.py
@@ -306,8 +306,9 @@ class MilvusEntityBackend(BaseEntityBackend):
             raise EvolveException(f"Entity '{entity_id}' not found in namespace '{namespace_id}'")
         entity = parse_milvus_entity(results[0])
         merged = {**(entity.metadata or {}), **metadata_patch}
-        timestamp = int(datetime.datetime.now(datetime.UTC).timestamp())
+        timestamp = int(entity.created_at.timestamp())
         from altk_evolve.utils.utils import serialize_content
+
         self._update_entity(namespace_id, entity_id, entity.type, serialize_content(entity.content), timestamp, merged)
         self._post_update(namespace_id)
         return RecordedEntity(**{**entity.model_dump(), "metadata": merged})

--- a/altk_evolve/backend/postgres.py
+++ b/altk_evolve/backend/postgres.py
@@ -277,6 +277,26 @@ class PostgresEntityBackend(BaseEntityBackend):
     def _delete_entity(self, namespace_id: str, entity_id: str) -> None:
         self.delete_entity_by_id(namespace_id=namespace_id, entity_id=entity_id)
 
+    def update_entity_metadata(self, namespace_id: str, entity_id: str, metadata_patch: dict) -> RecordedEntity:
+        try:
+            entity_id_int = int(entity_id)
+        except ValueError:
+            raise EvolveException(f"Invalid entity ID '{entity_id}': must be numeric.")
+        self._validate_namespace(namespace_id)
+        table = self._table_name(namespace_id)
+        with self.conn.cursor(row_factory=_entity_row_factory) as cur:
+            cur.execute(
+                sql.SQL(
+                    "UPDATE {table} SET metadata = metadata || %s::jsonb WHERE id = %s "
+                    "RETURNING id, type, content, created_at, metadata"
+                ).format(table=sql.Identifier(table)),
+                (json.dumps(metadata_patch), entity_id_int),
+            )
+            results = cur.fetchall()
+        if not results:
+            raise EvolveException(f"Entity '{entity_id}' not found in namespace '{namespace_id}'")
+        return results[0]
+
     # ── search / delete ──────────────────────────────────────────────
 
     def search_entities(

--- a/altk_evolve/backend/postgres.py
+++ b/altk_evolve/backend/postgres.py
@@ -287,8 +287,7 @@ class PostgresEntityBackend(BaseEntityBackend):
         with self.conn.cursor(row_factory=_entity_row_factory) as cur:
             cur.execute(
                 sql.SQL(
-                    "UPDATE {table} SET metadata = metadata || %s::jsonb WHERE id = %s "
-                    "RETURNING id, type, content, created_at, metadata"
+                    "UPDATE {table} SET metadata = metadata || %s::jsonb WHERE id = %s RETURNING id, type, content, created_at, metadata"
                 ).format(table=sql.Identifier(table)),
                 (json.dumps(metadata_patch), entity_id_int),
             )

--- a/altk_evolve/frontend/client/evolve_client.py
+++ b/altk_evolve/frontend/client/evolve_client.py
@@ -6,9 +6,8 @@ from altk_evolve.config.evolve import EvolveConfig
 from altk_evolve.llm.fact_extraction.fact_extraction import ExtractedFact, extract_facts_from_messages
 from altk_evolve.schema.conflict_resolution import EntityUpdate
 from altk_evolve.schema.core import Entity, Namespace, RecordedEntity
-from altk_evolve.schema.exceptions import EvolveException, NamespaceAlreadyExistsException, NamespaceNotFoundException
+from altk_evolve.schema.exceptions import NamespaceAlreadyExistsException, NamespaceNotFoundException
 from altk_evolve.schema.guidelines import ConsolidationResult
-from altk_evolve.utils.utils import serialize_content
 
 logger = logging.getLogger(__name__)
 

--- a/altk_evolve/frontend/client/evolve_client.py
+++ b/altk_evolve/frontend/client/evolve_client.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 from typing import Any
 
@@ -6,8 +7,9 @@ from altk_evolve.config.evolve import EvolveConfig
 from altk_evolve.llm.fact_extraction.fact_extraction import ExtractedFact, extract_facts_from_messages
 from altk_evolve.schema.conflict_resolution import EntityUpdate
 from altk_evolve.schema.core import Entity, Namespace, RecordedEntity
-from altk_evolve.schema.exceptions import NamespaceAlreadyExistsException, NamespaceNotFoundException
+from altk_evolve.schema.exceptions import EvolveException, NamespaceAlreadyExistsException, NamespaceNotFoundException
 from altk_evolve.schema.guidelines import ConsolidationResult
+from altk_evolve.utils.utils import serialize_content
 
 logger = logging.getLogger(__name__)
 
@@ -85,6 +87,31 @@ class EvolveClient:
     def delete_entity_by_id(self, namespace_id: str, entity_id: str) -> None:
         """Delete a specific entity by its ID."""
         self.backend.delete_entity_by_id(namespace_id, entity_id)
+
+    def get_entity_by_id(self, namespace_id: str, entity_id: str) -> RecordedEntity | None:
+        """Fetch a single entity by its ID. Returns None if not found."""
+        results = self.search_entities(namespace_id, filters={"id": entity_id}, limit=1)
+        return results[0] if results else None
+
+    def patch_entity_metadata(self, namespace_id: str, entity_id: str, metadata_updates: dict) -> RecordedEntity:
+        """Fetch entity, merge metadata_updates, and write back without changing content or ID."""
+        entity = self.get_entity_by_id(namespace_id, entity_id)
+        if entity is None:
+            raise EvolveException(f"Entity '{entity_id}' not found in namespace '{namespace_id}'")
+        merged_metadata = {**entity.metadata, **metadata_updates}
+        timestamp = int(datetime.datetime.now(datetime.UTC).timestamp())
+        self.backend.patch_entity(namespace_id, entity_id, entity.type, serialize_content(entity.content), timestamp, merged_metadata)
+        return RecordedEntity(**{**entity.model_dump(), "metadata": merged_metadata})
+
+    def get_public_entities(self, query: str | None = None, entity_type: str | None = None, limit: int = 100) -> list[RecordedEntity]:
+        """Search for public entities across all namespaces."""
+        all_results: list[RecordedEntity] = []
+        for ns in self.search_namespaces(limit=1000):
+            filters: dict = {"metadata.visibility": "public"}
+            if entity_type:
+                filters["type"] = entity_type
+            all_results.extend(self.search_entities(ns.id, query=query, filters=filters, limit=limit))
+        return all_results
 
     def cluster_guidelines(self, namespace_id: str, threshold: float | None = None, limit: int = 10000) -> list[list[RecordedEntity]]:
         """Cluster guideline entities by task description similarity.

--- a/altk_evolve/frontend/client/evolve_client.py
+++ b/altk_evolve/frontend/client/evolve_client.py
@@ -1,4 +1,3 @@
-import datetime
 import logging
 from typing import Any
 
@@ -94,14 +93,8 @@ class EvolveClient:
         return results[0] if results else None
 
     def patch_entity_metadata(self, namespace_id: str, entity_id: str, metadata_updates: dict) -> RecordedEntity:
-        """Fetch entity, merge metadata_updates, and write back without changing content or ID."""
-        entity = self.get_entity_by_id(namespace_id, entity_id)
-        if entity is None:
-            raise EvolveException(f"Entity '{entity_id}' not found in namespace '{namespace_id}'")
-        merged_metadata = {**entity.metadata, **metadata_updates}
-        timestamp = int(datetime.datetime.now(datetime.UTC).timestamp())
-        self.backend.patch_entity(namespace_id, entity_id, entity.type, serialize_content(entity.content), timestamp, merged_metadata)
-        return RecordedEntity(**{**entity.model_dump(), "metadata": merged_metadata})
+        """Merge metadata_updates into an entity without touching content or ID."""
+        return self.backend.update_entity_metadata(namespace_id, entity_id, metadata_updates)
 
     def get_public_entities(self, query: str | None = None, entity_type: str | None = None, limit: int = 100) -> list[RecordedEntity]:
         """Search for public entities across all namespaces."""

--- a/altk_evolve/frontend/client/evolve_client.py
+++ b/altk_evolve/frontend/client/evolve_client.py
@@ -98,12 +98,18 @@ class EvolveClient:
 
     def get_public_entities(self, query: str | None = None, entity_type: str | None = None, limit: int = 100) -> list[RecordedEntity]:
         """Search for public entities across all namespaces."""
+        if limit <= 0:
+            return []
+
         all_results: list[RecordedEntity] = []
         for ns in self.search_namespaces(limit=1000):
+            remaining = limit - len(all_results)
+            if remaining <= 0:
+                break
             filters: dict = {"metadata.visibility": "public"}
             if entity_type:
                 filters["type"] = entity_type
-            all_results.extend(self.search_entities(ns.id, query=query, filters=filters, limit=limit))
+            all_results.extend(self.search_entities(ns.id, query=query, filters=filters, limit=remaining))
         return all_results
 
     def cluster_guidelines(self, namespace_id: str, threshold: float | None = None, limit: int = 10000) -> list[list[RecordedEntity]]:

--- a/altk_evolve/frontend/client/evolve_client.py
+++ b/altk_evolve/frontend/client/evolve_client.py
@@ -96,13 +96,30 @@ class EvolveClient:
         """Merge metadata_updates into an entity without touching content or ID."""
         return self.backend.update_entity_metadata(namespace_id, entity_id, metadata_updates)
 
-    def get_public_entities(self, query: str | None = None, entity_type: str | None = None, limit: int = 100) -> list[RecordedEntity]:
-        """Search for public entities across all namespaces."""
+    def get_public_entities(
+        self,
+        query: str | None = None,
+        entity_type: str | None = None,
+        limit: int = 100,
+        exclude_namespace_ids: list[str] | None = None,
+    ) -> list[RecordedEntity]:
+        """Search for public entities across all namespaces.
+
+        Args:
+            query: Optional semantic search query.
+            entity_type: Optional type filter (e.g. 'guideline').
+            limit: Maximum total results to return.
+            exclude_namespace_ids: Namespace IDs to skip (e.g. the caller's own
+                namespace whose entities are already returned via a private search).
+        """
         if limit <= 0:
             return []
 
+        excluded = set(exclude_namespace_ids or [])
         all_results: list[RecordedEntity] = []
         for ns in self.search_namespaces(limit=1000):
+            if ns.id in excluded:
+                continue
             remaining = limit - len(all_results)
             if remaining <= 0:
                 break

--- a/altk_evolve/frontend/mcp/mcp_server.py
+++ b/altk_evolve/frontend/mcp/mcp_server.py
@@ -323,6 +323,7 @@ def publish_entity(entity_id: str, user_id: str | None = None) -> str:
     logger.info(f"publish entity={entity_id} owner={user_id} namespace={evolve_config.namespace_id}")
     try:
         from datetime import datetime, UTC
+
         updated = get_client().patch_entity_metadata(
             namespace_id=evolve_config.namespace_id,
             entity_id=entity_id,

--- a/altk_evolve/frontend/mcp/mcp_server.py
+++ b/altk_evolve/frontend/mcp/mcp_server.py
@@ -132,17 +132,24 @@ def get_entities_logic(task: str, entity_type: str = "guideline", include_public
     header = f"# {entity_type.capitalize()}s for: {task}"
     response_lines = [f"{header}\n"]
 
-    seen_ids = {e.id for e in private_results}
     for i, entity in enumerate(private_results, 1):
         response_lines.append(f"{i}. {entity.content}")
 
     if include_public:
-        public_results = client.get_public_entities(query=task, entity_type=entity_type)
+        # Exclude the caller's own namespace: those entities are already in private_results,
+        # and using a bare entity ID for cross-namespace dedup risks false-positives when
+        # different namespaces share the same auto-assigned numeric IDs.
+        public_results = client.get_public_entities(
+            query=task,
+            entity_type=entity_type,
+            exclude_namespace_ids=[evolve_config.namespace_id],
+        )
+        seen_public_ids: set[str] = set()
         idx = len(private_results) + 1
         for entity in public_results:
-            if entity.id in seen_ids:
+            if entity.id in seen_public_ids:
                 continue
-            seen_ids.add(entity.id)
+            seen_public_ids.add(entity.id)
             owner = (entity.metadata or {}).get("owner_id", "unknown")
             response_lines.append(f"{idx}. [public: {owner}] {entity.content}")
             idx += 1

--- a/altk_evolve/frontend/mcp/mcp_server.py
+++ b/altk_evolve/frontend/mcp/mcp_server.py
@@ -138,13 +138,14 @@ def get_entities_logic(task: str, entity_type: str = "guideline", include_public
 
     if include_public:
         public_results = client.get_public_entities(query=task, entity_type=entity_type)
-        offset = len(private_results) + 1
-        for i, entity in enumerate(public_results, offset):
+        idx = len(private_results) + 1
+        for entity in public_results:
             if entity.id in seen_ids:
                 continue
             seen_ids.add(entity.id)
             owner = (entity.metadata or {}).get("owner_id", "unknown")
-            response_lines.append(f"{i}. [public: {owner}] {entity.content}")
+            response_lines.append(f"{idx}. [public: {owner}] {entity.content}")
+            idx += 1
 
     return "\n".join(response_lines)
 
@@ -271,6 +272,8 @@ def create_entity(
         if visibility not in ("private", "public"):
             return json.dumps({"error": f"Invalid visibility '{visibility}': must be 'private' or 'public'"})
 
+        _RESERVED_KEYS = {"owner_id", "visibility", "published_at", "creation_mode"}
+
         metadata_dict = {}
         if metadata:
             try:
@@ -282,6 +285,8 @@ def create_entity(
                 return json.dumps(
                     {"error": "Invalid metadata type", "message": "metadata must be a JSON object", "invalid_metadata": metadata}
                 )
+            for key in _RESERVED_KEYS:
+                metadata_dict.pop(key, None)
 
         if entity_type in ("guideline", "policy"):
             metadata_dict.setdefault("creation_mode", "manual")
@@ -324,7 +329,7 @@ def publish_entity(entity_id: str, user_id: str | None = None) -> str:
     Returns:
         JSON string with the updated entity, or an error message
     """
-    logger.info(f"publish entity={entity_id} owner={user_id} namespace={evolve_config.namespace_id}")
+    logger.info(f"publish entity={entity_id} owner_present={user_id is not None} namespace={evolve_config.namespace_id}")
     try:
         from datetime import datetime, UTC
 

--- a/altk_evolve/frontend/mcp/mcp_server.py
+++ b/altk_evolve/frontend/mcp/mcp_server.py
@@ -118,7 +118,7 @@ def get_client() -> EvolveClient:
         return _client
 
 
-def get_entities_logic(task: str, entity_type: str = "guideline", include_public: bool = False) -> str:
+def get_entities_logic(task: str, entity_type: str = "guideline", include_public: bool = False, limit: int = 10) -> str:
     """Implementation logic for get_entities tool."""
     logger.info(f"Getting entities of type '{entity_type}' for task: {task} (include_public={include_public})")
     client = get_client()
@@ -127,6 +127,7 @@ def get_entities_logic(task: str, entity_type: str = "guideline", include_public
         namespace_id=evolve_config.namespace_id,
         query=task,
         filters={"type": entity_type},
+        limit=limit,
     )
 
     header = f"# {entity_type.capitalize()}s for: {task}"
@@ -143,6 +144,7 @@ def get_entities_logic(task: str, entity_type: str = "guideline", include_public
             query=task,
             entity_type=entity_type,
             exclude_namespace_ids=[evolve_config.namespace_id],
+            limit=limit,
         )
         private_ids: set[str] = {e.id for e in private_results}
         seen_public_ids: set[str] = set()
@@ -159,7 +161,7 @@ def get_entities_logic(task: str, entity_type: str = "guideline", include_public
 
 
 @mcp.tool()
-def get_entities(task: str, entity_type: str = "guideline", include_public: bool = False) -> str:
+def get_entities(task: str, entity_type: str = "guideline", include_public: bool = False, limit: int = 10) -> str:
     """
     Get relevant entities for a given task, filtered by type.
     Provide a task description and receive applicable best practices, guidelines, or policies.
@@ -168,8 +170,9 @@ def get_entities(task: str, entity_type: str = "guideline", include_public: bool
         task: A description of the task you want entities for
         entity_type: The type of entities to retrieve (e.g., 'guideline', 'policy'). Defaults to 'guideline'.
         include_public: If True, also include public entities from all namespaces. Defaults to False.
+        limit: Maximum number of results to return from each source (private and public). Defaults to 10.
     """
-    return get_entities_logic(task, entity_type, include_public)
+    return get_entities_logic(task, entity_type, include_public, limit)
 
 
 @mcp.tool()
@@ -279,6 +282,8 @@ def create_entity(
     try:
         if visibility not in ("private", "public"):
             return json.dumps({"error": f"Invalid visibility '{visibility}': must be 'private' or 'public'"})
+        if visibility == "public" and not owner_id:
+            return json.dumps({"error": "Missing owner_id", "message": "public entities must have an owner_id"})
 
         _RESERVED_KEYS = {"owner_id", "visibility", "published_at", "creation_mode"}
 

--- a/altk_evolve/frontend/mcp/mcp_server.py
+++ b/altk_evolve/frontend/mcp/mcp_server.py
@@ -118,28 +118,39 @@ def get_client() -> EvolveClient:
         return _client
 
 
-def get_entities_logic(task: str, entity_type: str = "guideline") -> str:
+def get_entities_logic(task: str, entity_type: str = "guideline", include_public: bool = False) -> str:
     """Implementation logic for get_entities tool."""
-    logger.info(f"Getting entities of type '{entity_type}' for task: {task}")
-    # Get relevant entities
-    results = get_client().search_entities(
+    logger.info(f"Getting entities of type '{entity_type}' for task: {task} (include_public={include_public})")
+    client = get_client()
+
+    private_results = client.search_entities(
         namespace_id=evolve_config.namespace_id,
         query=task,
         filters={"type": entity_type},
     )
 
-    # Format the response
     header = f"# {entity_type.capitalize()}s for: {task}"
     response_lines = [f"{header}\n"]
 
-    for i, entity in enumerate(results, 1):
+    seen_ids = {e.id for e in private_results}
+    for i, entity in enumerate(private_results, 1):
         response_lines.append(f"{i}. {entity.content}")
+
+    if include_public:
+        public_results = client.get_public_entities(query=task, entity_type=entity_type)
+        offset = len(private_results) + 1
+        for i, entity in enumerate(public_results, offset):
+            if entity.id in seen_ids:
+                continue
+            seen_ids.add(entity.id)
+            owner = (entity.metadata or {}).get("owner_id", "unknown")
+            response_lines.append(f"{i}. [public: {owner}] {entity.content}")
 
     return "\n".join(response_lines)
 
 
 @mcp.tool()
-def get_entities(task: str, entity_type: str = "guideline") -> str:
+def get_entities(task: str, entity_type: str = "guideline", include_public: bool = False) -> str:
     """
     Get relevant entities for a given task, filtered by type.
     Provide a task description and receive applicable best practices, guidelines, or policies.
@@ -147,8 +158,9 @@ def get_entities(task: str, entity_type: str = "guideline") -> str:
     Args:
         task: A description of the task you want entities for
         entity_type: The type of entities to retrieve (e.g., 'guideline', 'policy'). Defaults to 'guideline'.
+        include_public: If True, also include public entities from all namespaces. Defaults to False.
     """
-    return get_entities_logic(task, entity_type)
+    return get_entities_logic(task, entity_type, include_public)
 
 
 @mcp.tool()
@@ -165,13 +177,14 @@ def get_guidelines(task: str) -> str:
 
 
 @mcp.tool()
-def save_trajectory(trajectory_data: str, task_id: str | None = None) -> list[RecordedEntity]:
+def save_trajectory(trajectory_data: str, task_id: str | None = None, owner_id: str | None = None) -> list[RecordedEntity]:
     """
     Save the full agent trajectory to the Entity DB and generate guidelines
 
     Args:
         trajectory_data: A JSON formatted OpenAI conversation.
         task_id: Optional identifier for the task.
+        owner_id: Optional user ID to record as the owner of generated guidelines.
     """
     task_id = task_id or str(uuid.uuid4())
     entities = []
@@ -183,7 +196,7 @@ def save_trajectory(trajectory_data: str, task_id: str | None = None) -> list[Re
                 content=message["content"] if isinstance(message["content"], str) else str(message["content"]),
                 metadata={
                     "task_id": task_id,
-                    "message": message,  # store the original message for reference
+                    "message": message,
                 },
             )
         )
@@ -196,6 +209,14 @@ def save_trajectory(trajectory_data: str, task_id: str | None = None) -> list[Re
     result = generate_guidelines(messages)
 
     if result.guidelines:
+        guideline_metadata_base = {
+            "task_description": result.task_description,
+            "source_task_id": task_id,
+            "creation_mode": "auto-mcp",
+        }
+        if owner_id:
+            guideline_metadata_base["owner_id"] = owner_id
+
         get_client().update_entities(
             namespace_id=evolve_config.namespace_id,
             entities=[
@@ -203,13 +224,11 @@ def save_trajectory(trajectory_data: str, task_id: str | None = None) -> list[Re
                     type="guideline",
                     content=guideline.content,
                     metadata={
+                        **guideline_metadata_base,
                         "category": guideline.category,
                         "rationale": guideline.rationale,
                         "trigger": guideline.trigger,
                         "implementation_steps": guideline.implementation_steps,
-                        "task_description": result.task_description,
-                        "source_task_id": task_id,
-                        "creation_mode": "auto-mcp",
                     },
                 )
                 for guideline in result.guidelines
@@ -225,7 +244,14 @@ def save_trajectory(trajectory_data: str, task_id: str | None = None) -> list[Re
 
 
 @mcp.tool()
-def create_entity(content: str, entity_type: str, metadata: str | None = None, enable_conflict_resolution: bool = False) -> str:
+def create_entity(
+    content: str,
+    entity_type: str,
+    metadata: str | None = None,
+    enable_conflict_resolution: bool = False,
+    owner_id: str | None = None,
+    visibility: str = "private",
+) -> str:
     """
     Create a single entity in the namespace.
 
@@ -234,13 +260,17 @@ def create_entity(content: str, entity_type: str, metadata: str | None = None, e
         entity_type: The type/category of the entity (e.g., 'guideline', 'note', 'fact')
         metadata: Optional JSON string containing arbitrary metadata related to the entity
         enable_conflict_resolution: If True, uses LLM to check for conflicts with existing entities
+        owner_id: Optional user ID to record as the owner of this entity
+        visibility: Visibility of the entity — 'private' (default) or 'public'
 
     Returns:
         JSON string with the entity update details (ADD/UPDATE/DELETE/NONE) and entity ID
     """
     logger.info(f"Creating entity of type: {entity_type}")
     try:
-        # Parse metadata if provided
+        if visibility not in ("private", "public"):
+            return json.dumps({"error": f"Invalid visibility '{visibility}': must be 'private' or 'public'"})
+
         metadata_dict = {}
         if metadata:
             try:
@@ -249,19 +279,19 @@ def create_entity(content: str, entity_type: str, metadata: str | None = None, e
                 logger.exception(f"Invalid JSON in metadata parameter: {str(e)}")
                 return json.dumps({"error": "Invalid JSON", "message": f"Failed to parse metadata: {str(e)}", "invalid_metadata": metadata})
 
-        # Inject creation mode for manually created guidelines/policies if not present
         if entity_type in ("guideline", "policy"):
             metadata_dict.setdefault("creation_mode", "manual")
 
-        # Create the entity using the Entity schema
+        metadata_dict["visibility"] = visibility
+        if owner_id:
+            metadata_dict["owner_id"] = owner_id
+
         entity = Entity(type=entity_type, content=content, metadata=metadata_dict)
 
-        # Use EvolveClient.update_entities() to create the entity
         updates = get_client().update_entities(
             namespace_id=evolve_config.namespace_id, entities=[entity], enable_conflict_resolution=enable_conflict_resolution
         )
 
-        # Return the first (and only) update result
         if updates:
             update = updates[0]
             return json.dumps(
@@ -276,6 +306,58 @@ def create_entity(content: str, entity_type: str, metadata: str | None = None, e
         traceback.print_exc()
         logger.exception(f"CRASH IN CREATE_ENTITY: {e}")
         return json.dumps({"error": f"Server Error: {str(e)}"})
+
+
+@mcp.tool()
+def publish_entity(entity_id: str, user_id: str | None = None) -> str:
+    """
+    Make an entity publicly visible to all users.
+
+    Args:
+        entity_id: The ID of the entity to publish
+        user_id: Optional caller identity to record as owner
+
+    Returns:
+        JSON string with the updated entity, or an error message
+    """
+    logger.info(f"publish entity={entity_id} owner={user_id} namespace={evolve_config.namespace_id}")
+    try:
+        from datetime import datetime, UTC
+        updated = get_client().patch_entity_metadata(
+            namespace_id=evolve_config.namespace_id,
+            entity_id=entity_id,
+            metadata_updates={
+                "visibility": "public",
+                "owner_id": user_id,
+                "published_at": datetime.now(UTC).isoformat(),
+            },
+        )
+        return json.dumps({"id": updated.id, "type": updated.type, "content": updated.content, "metadata": updated.metadata})
+    except EvolveException as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+def unpublish_entity(entity_id: str) -> str:
+    """
+    Revert an entity to private visibility.
+
+    Args:
+        entity_id: The ID of the entity to unpublish
+
+    Returns:
+        JSON string with the updated entity, or an error message
+    """
+    logger.info(f"unpublish entity={entity_id} namespace={evolve_config.namespace_id}")
+    try:
+        updated = get_client().patch_entity_metadata(
+            namespace_id=evolve_config.namespace_id,
+            entity_id=entity_id,
+            metadata_updates={"visibility": "private", "published_at": None},
+        )
+        return json.dumps({"id": updated.id, "type": updated.type, "content": updated.content, "metadata": updated.metadata})
+    except EvolveException as e:
+        return json.dumps({"error": str(e)})
 
 
 @mcp.tool()

--- a/altk_evolve/frontend/mcp/mcp_server.py
+++ b/altk_evolve/frontend/mcp/mcp_server.py
@@ -335,7 +335,7 @@ def publish_entity(entity_id: str, user_id: str | None = None) -> str:
 
     Args:
         entity_id: The ID of the entity to publish
-        user_id: Optional caller identity to record as owner
+        user_id: Caller identity; must match the entity's owner_id if one is set
 
     Returns:
         JSON string with the updated entity, or an error message
@@ -344,11 +344,19 @@ def publish_entity(entity_id: str, user_id: str | None = None) -> str:
     try:
         from datetime import datetime, UTC
 
+        entity = get_client().get_entity_by_id(namespace_id=evolve_config.namespace_id, entity_id=entity_id)
+        if entity is None:
+            return json.dumps({"error": f"Entity {entity_id} not found"})
+
+        existing_owner = (entity.metadata or {}).get("owner_id")
+        if existing_owner is not None and user_id != existing_owner:
+            return json.dumps({"error": "Permission denied: caller is not the owner of this entity"})
+
         metadata_updates: dict = {
             "visibility": "public",
             "published_at": datetime.now(UTC).isoformat(),
         }
-        if user_id is not None:
+        if user_id is not None and existing_owner is None:
             metadata_updates["owner_id"] = user_id
         updated = get_client().patch_entity_metadata(
             namespace_id=evolve_config.namespace_id,
@@ -361,18 +369,27 @@ def publish_entity(entity_id: str, user_id: str | None = None) -> str:
 
 
 @mcp.tool()
-def unpublish_entity(entity_id: str) -> str:
+def unpublish_entity(entity_id: str, user_id: str | None = None) -> str:
     """
     Revert an entity to private visibility.
 
     Args:
         entity_id: The ID of the entity to unpublish
+        user_id: Caller identity; must match the entity's owner_id if one is set
 
     Returns:
         JSON string with the updated entity, or an error message
     """
     logger.info(f"unpublish entity={entity_id} namespace={evolve_config.namespace_id}")
     try:
+        entity = get_client().get_entity_by_id(namespace_id=evolve_config.namespace_id, entity_id=entity_id)
+        if entity is None:
+            return json.dumps({"error": f"Entity {entity_id} not found"})
+
+        existing_owner = (entity.metadata or {}).get("owner_id")
+        if existing_owner is not None and user_id != existing_owner:
+            return json.dumps({"error": "Permission denied: caller is not the owner of this entity"})
+
         updated = get_client().patch_entity_metadata(
             namespace_id=evolve_config.namespace_id,
             entity_id=entity_id,

--- a/altk_evolve/frontend/mcp/mcp_server.py
+++ b/altk_evolve/frontend/mcp/mcp_server.py
@@ -144,10 +144,11 @@ def get_entities_logic(task: str, entity_type: str = "guideline", include_public
             entity_type=entity_type,
             exclude_namespace_ids=[evolve_config.namespace_id],
         )
+        private_ids: set[str] = {e.id for e in private_results}
         seen_public_ids: set[str] = set()
         idx = len(private_results) + 1
         for entity in public_results:
-            if entity.id in seen_public_ids:
+            if entity.id in private_ids or entity.id in seen_public_ids:
                 continue
             seen_public_ids.add(entity.id)
             owner = (entity.metadata or {}).get("owner_id", "unknown")
@@ -356,7 +357,7 @@ def publish_entity(entity_id: str, user_id: str | None = None) -> str:
             "visibility": "public",
             "published_at": datetime.now(UTC).isoformat(),
         }
-        if user_id is not None and existing_owner is None:
+        if user_id is not None:
             metadata_updates["owner_id"] = user_id
         updated = get_client().patch_entity_metadata(
             namespace_id=evolve_config.namespace_id,

--- a/altk_evolve/frontend/mcp/mcp_server.py
+++ b/altk_evolve/frontend/mcp/mcp_server.py
@@ -292,6 +292,10 @@ def create_entity(
             metadata_dict.setdefault("creation_mode", "manual")
 
         metadata_dict["visibility"] = visibility
+        if visibility == "public":
+            from datetime import UTC, datetime
+
+            metadata_dict.setdefault("published_at", datetime.now(UTC).isoformat())
         if owner_id:
             metadata_dict["owner_id"] = owner_id
 

--- a/altk_evolve/frontend/mcp/mcp_server.py
+++ b/altk_evolve/frontend/mcp/mcp_server.py
@@ -278,6 +278,8 @@ def create_entity(
             except json.JSONDecodeError as e:
                 logger.exception(f"Invalid JSON in metadata parameter: {str(e)}")
                 return json.dumps({"error": "Invalid JSON", "message": f"Failed to parse metadata: {str(e)}", "invalid_metadata": metadata})
+            if not isinstance(metadata_dict, dict):
+                return json.dumps({"error": "Invalid metadata type", "message": "metadata must be a JSON object", "invalid_metadata": metadata})
 
         if entity_type in ("guideline", "policy"):
             metadata_dict.setdefault("creation_mode", "manual")
@@ -324,14 +326,16 @@ def publish_entity(entity_id: str, user_id: str | None = None) -> str:
     try:
         from datetime import datetime, UTC
 
+        metadata_updates: dict = {
+            "visibility": "public",
+            "published_at": datetime.now(UTC).isoformat(),
+        }
+        if user_id is not None:
+            metadata_updates["owner_id"] = user_id
         updated = get_client().patch_entity_metadata(
             namespace_id=evolve_config.namespace_id,
             entity_id=entity_id,
-            metadata_updates={
-                "visibility": "public",
-                "owner_id": user_id,
-                "published_at": datetime.now(UTC).isoformat(),
-            },
+            metadata_updates=metadata_updates,
         )
         return json.dumps({"id": updated.id, "type": updated.type, "content": updated.content, "metadata": updated.metadata})
     except EvolveException as e:

--- a/altk_evolve/frontend/mcp/mcp_server.py
+++ b/altk_evolve/frontend/mcp/mcp_server.py
@@ -279,7 +279,9 @@ def create_entity(
                 logger.exception(f"Invalid JSON in metadata parameter: {str(e)}")
                 return json.dumps({"error": "Invalid JSON", "message": f"Failed to parse metadata: {str(e)}", "invalid_metadata": metadata})
             if not isinstance(metadata_dict, dict):
-                return json.dumps({"error": "Invalid metadata type", "message": "metadata must be a JSON object", "invalid_metadata": metadata})
+                return json.dumps(
+                    {"error": "Invalid metadata type", "message": "metadata must be a JSON object", "invalid_metadata": metadata}
+                )
 
         if entity_type in ("guideline", "policy"):
             metadata_dict.setdefault("creation_mode", "manual")

--- a/altk_evolve/schema/core.py
+++ b/altk_evolve/schema/core.py
@@ -17,7 +17,13 @@ class Namespace(BaseModel):
 
 
 class Entity(BaseModel):
-    """Basic data stored in the DB"""
+    """Basic data stored in the DB.
+
+    Sharing metadata conventions (all optional; existing entities without them are unaffected):
+      - owner_id (str | None): User ID who created or last published the entity.
+      - visibility ("private" | "public"): Controls cross-namespace access. Defaults to "private".
+      - published_at (ISO-8601 str | None): Timestamp of the most recent publish_entity call.
+    """
 
     content: str | list | dict = Field(description="Searchable text or structured data.")
     type: str = Field(description="The type of the entity.")

--- a/platform-integrations/install.sh
+++ b/platform-integrations/install.sh
@@ -872,7 +872,7 @@ class CodexInstaller:
         # Prune empty groups (groups with no hooks left)
         hooks["UserPromptSubmit"] = [
             group for group in hooks["UserPromptSubmit"]
-            if not isinstance(group, dict) or len(self._iter_group_hooks(group)) > 0
+            if not isinstance(group, dict) or self._iter_group_hooks(group)
         ]
         if not hooks["UserPromptSubmit"]:
             hooks.pop("UserPromptSubmit", None)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -51,6 +51,7 @@ def mcp(request, tmp_path):
     if backend_type == "milvus":
         try:
             from pymilvus import connections
+
             for alias, _ in connections.list_connections():
                 try:
                     connections.disconnect(alias)
@@ -61,6 +62,7 @@ def mcp(request, tmp_path):
 
         try:
             from milvus_lite.server_manager import server_manager_instance
+
             server_manager_instance.release_all()
         except Exception:
             pass

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,4 +1,3 @@
-import importlib
 import os
 import uuid
 import pytest

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -3,19 +3,24 @@ import uuid
 import pytest
 from altk_evolve.config.milvus import milvus_client_settings
 
+_EVOLVE_ENV_KEYS = ("EVOLVE_NAMESPACE_ID", "EVOLVE_BACKEND", "EVOLVE_SQLITE_PATH", "EVOLVE_DATA_DIR")
+
 
 @pytest.fixture(params=["filesystem", "milvus"])
 def mcp(request, tmp_path):
     backend_type = request.param
+
+    # Snapshot env before mutating so teardown can restore exactly
+    original_env = {key: os.environ.get(key) for key in _EVOLVE_ENV_KEYS}
+    original_milvus_uri = milvus_client_settings.uri
+
     os.environ["EVOLVE_NAMESPACE_ID"] = "test"
     os.environ["EVOLVE_BACKEND"] = backend_type
     os.environ["EVOLVE_SQLITE_PATH"] = str(tmp_path / f"test_{backend_type}.sqlite.db")
 
     milvus_db_file = None
-    original_milvus_uri = None
 
     if backend_type == "milvus":
-        original_milvus_uri = milvus_client_settings.uri
         _env_uri = os.getenv("EVOLVE_URI", "")
         if _env_uri.startswith("http"):
             milvus_client_settings.uri = _env_uri
@@ -43,6 +48,13 @@ def mcp(request, tmp_path):
 
     yield mcp_server_module.mcp
 
+    # Close the MCP singleton backend before NoneOut
+    if mcp_server_module._client is not None:
+        try:
+            mcp_server_module._client.backend.close()
+        except Exception:
+            pass
+
     try:
         evolve_client.backend.close()
     except Exception:
@@ -67,8 +79,7 @@ def mcp(request, tmp_path):
         except Exception:
             pass
 
-        if original_milvus_uri:
-            milvus_client_settings.uri = original_milvus_uri
+        milvus_client_settings.uri = original_milvus_uri
 
         for path in [milvus_db_file, f"{milvus_db_file}.lock"] if milvus_db_file else []:
             if path and os.path.exists(path):
@@ -76,6 +87,13 @@ def mcp(request, tmp_path):
                     os.remove(path)
                 except Exception:
                     pass
+
+    # Restore env vars to their pre-test state
+    for key, original_value in original_env.items():
+        if original_value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = original_value
 
     mcp_server_module._client = None
     mcp_server_module._namespace_initialized = False

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,79 @@
+import os
+import uuid
+import pytest
+from altk_evolve.config.milvus import milvus_client_settings
+
+
+@pytest.fixture(params=["filesystem", "milvus"])
+def mcp(request, tmp_path):
+    backend_type = request.param
+    os.environ["EVOLVE_NAMESPACE_ID"] = "test"
+    os.environ["EVOLVE_BACKEND"] = backend_type
+    os.environ["EVOLVE_SQLITE_PATH"] = str(tmp_path / f"test_{backend_type}.sqlite.db")
+
+    milvus_db_file = None
+    original_milvus_uri = None
+
+    if backend_type == "milvus":
+        original_milvus_uri = milvus_client_settings.uri
+        _env_uri = os.getenv("EVOLVE_URI", "")
+        if _env_uri.startswith("http"):
+            milvus_client_settings.uri = _env_uri
+        else:
+            milvus_db_file = str(tmp_path / f"test_{uuid.uuid4().hex[:8]}.db")
+            milvus_client_settings.uri = milvus_db_file
+    elif backend_type == "filesystem":
+        os.environ["EVOLVE_DATA_DIR"] = str(tmp_path)
+
+    from altk_evolve.frontend.client.evolve_client import EvolveClient
+    from altk_evolve.config.evolve import evolve_config
+
+    evolve_config.__init__()
+
+    import altk_evolve.frontend.mcp.mcp_server as mcp_server_module
+
+    mcp_server_module._client = None
+    mcp_server_module._namespace_initialized = False
+
+    evolve_client = EvolveClient()
+    try:
+        evolve_client.create_namespace("test")
+    except Exception:
+        pass
+
+    yield mcp_server_module.mcp
+
+    try:
+        evolve_client.backend.close()
+    except Exception:
+        pass
+
+    if backend_type == "milvus":
+        try:
+            from pymilvus import connections
+            for alias, _ in connections.list_connections():
+                try:
+                    connections.disconnect(alias)
+                except Exception:
+                    pass
+        except Exception:
+            pass
+
+        try:
+            from milvus_lite.server_manager import server_manager_instance
+            server_manager_instance.release_all()
+        except Exception:
+            pass
+
+        if original_milvus_uri:
+            milvus_client_settings.uri = original_milvus_uri
+
+        for path in [milvus_db_file, f"{milvus_db_file}.lock"] if milvus_db_file else []:
+            if path and os.path.exists(path):
+                try:
+                    os.remove(path)
+                except Exception:
+                    pass
+
+    mcp_server_module._client = None
+    mcp_server_module._namespace_initialized = False

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -15,7 +15,7 @@ def mcp(request, tmp_path):
     original_milvus_uri = milvus_client_settings.uri
 
     # Use a per-run namespace to avoid collisions on shared remote backends
-    namespace_id = f"test-{uuid.uuid4().hex[:8]}"
+    namespace_id = f"test_{uuid.uuid4().hex[:8]}"
 
     milvus_db_file = None
     evolve_client_ref = [None]
@@ -105,9 +105,6 @@ def mcp(request, tmp_path):
 
     evolve_client = EvolveClient()
     evolve_client_ref[0] = evolve_client
-    try:
-        evolve_client.create_namespace(namespace_id)
-    except Exception:
-        pass
+    evolve_client.ensure_namespace(namespace_id)
 
     yield mcp_server_module.mcp

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,3 +1,4 @@
+import importlib
 import os
 import uuid
 import pytest
@@ -10,15 +11,78 @@ _EVOLVE_ENV_KEYS = ("EVOLVE_NAMESPACE_ID", "EVOLVE_BACKEND", "EVOLVE_SQLITE_PATH
 def mcp(request, tmp_path):
     backend_type = request.param
 
-    # Snapshot env before mutating so teardown can restore exactly
+    # Snapshot state before mutating so the finalizer can always restore it
     original_env = {key: os.environ.get(key) for key in _EVOLVE_ENV_KEYS}
     original_milvus_uri = milvus_client_settings.uri
 
-    os.environ["EVOLVE_NAMESPACE_ID"] = "test"
-    os.environ["EVOLVE_BACKEND"] = backend_type
-    os.environ["EVOLVE_SQLITE_PATH"] = str(tmp_path / f"test_{backend_type}.sqlite.db")
+    # Use a per-run namespace to avoid collisions on shared remote backends
+    namespace_id = f"test-{uuid.uuid4().hex[:8]}"
 
     milvus_db_file = None
+    evolve_client_ref = [None]
+
+    def _restore():
+        import altk_evolve.frontend.mcp.mcp_server as mcp_server_module
+        from altk_evolve.config.evolve import evolve_config
+
+        if mcp_server_module._client is not None:
+            try:
+                mcp_server_module._client.backend.close()
+            except Exception:
+                pass
+
+        if evolve_client_ref[0] is not None:
+            try:
+                evolve_client_ref[0].backend.close()
+            except Exception:
+                pass
+
+        if backend_type == "milvus":
+            try:
+                from pymilvus import connections
+
+                for alias, _ in connections.list_connections():
+                    try:
+                        connections.disconnect(alias)
+                    except Exception:
+                        pass
+            except Exception:
+                pass
+
+            try:
+                from milvus_lite.server_manager import server_manager_instance
+
+                server_manager_instance.release_all()
+            except Exception:
+                pass
+
+            milvus_client_settings.uri = original_milvus_uri
+
+            for path in [milvus_db_file, f"{milvus_db_file}.lock"] if milvus_db_file else []:
+                if path and os.path.exists(path):
+                    try:
+                        os.remove(path)
+                    except Exception:
+                        pass
+
+        for key, original_value in original_env.items():
+            if original_value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = original_value
+
+        # Reset evolve_config singleton to pick up the restored env
+        evolve_config.__init__()
+
+        mcp_server_module._client = None
+        mcp_server_module._namespace_initialized = False
+
+    # Register finalizer immediately so cleanup runs even if setup raises
+    request.addfinalizer(_restore)
+
+    os.environ["EVOLVE_NAMESPACE_ID"] = namespace_id
+    os.environ["EVOLVE_BACKEND"] = backend_type
+    os.environ["EVOLVE_SQLITE_PATH"] = str(tmp_path / f"test_{backend_type}.sqlite.db")
 
     if backend_type == "milvus":
         _env_uri = os.getenv("EVOLVE_URI", "")
@@ -41,59 +105,10 @@ def mcp(request, tmp_path):
     mcp_server_module._namespace_initialized = False
 
     evolve_client = EvolveClient()
+    evolve_client_ref[0] = evolve_client
     try:
-        evolve_client.create_namespace("test")
+        evolve_client.create_namespace(namespace_id)
     except Exception:
         pass
 
     yield mcp_server_module.mcp
-
-    # Close the MCP singleton backend before NoneOut
-    if mcp_server_module._client is not None:
-        try:
-            mcp_server_module._client.backend.close()
-        except Exception:
-            pass
-
-    try:
-        evolve_client.backend.close()
-    except Exception:
-        pass
-
-    if backend_type == "milvus":
-        try:
-            from pymilvus import connections
-
-            for alias, _ in connections.list_connections():
-                try:
-                    connections.disconnect(alias)
-                except Exception:
-                    pass
-        except Exception:
-            pass
-
-        try:
-            from milvus_lite.server_manager import server_manager_instance
-
-            server_manager_instance.release_all()
-        except Exception:
-            pass
-
-        milvus_client_settings.uri = original_milvus_uri
-
-        for path in [milvus_db_file, f"{milvus_db_file}.lock"] if milvus_db_file else []:
-            if path and os.path.exists(path):
-                try:
-                    os.remove(path)
-                except Exception:
-                    pass
-
-    # Restore env vars to their pre-test state
-    for key, original_value in original_env.items():
-        if original_value is None:
-            os.environ.pop(key, None)
-        else:
-            os.environ[key] = original_value
-
-    mcp_server_module._client = None
-    mcp_server_module._namespace_initialized = False

--- a/tests/e2e/test_mcp.py
+++ b/tests/e2e/test_mcp.py
@@ -1,113 +1,11 @@
-import os
 import pytest
 import json
 from fastmcp.client import Client
 from pathlib import Path
 from dotenv import load_dotenv
 
-import uuid
-from altk_evolve.config.milvus import milvus_client_settings
-
 __data__ = Path(__file__).parent.parent / "data"
 load_dotenv()
-
-
-@pytest.fixture(params=["filesystem"])
-def mcp(request, tmp_path):
-    backend_type = request.param
-    os.environ["EVOLVE_NAMESPACE_ID"] = "test"
-    os.environ["EVOLVE_BACKEND"] = backend_type
-
-    # Common SQLite setup
-    os.environ["EVOLVE_SQLITE_PATH"] = str(tmp_path / f"test_{backend_type}.sqlite.db")
-
-    # Backend-specific setup
-    milvus_db_file = None
-    original_milvus_uri = None
-
-    if backend_type == "milvus":
-        original_milvus_uri = milvus_client_settings.uri
-        _env_uri = os.getenv("EVOLVE_URI", "")
-        if _env_uri.startswith("http"):
-            # Running against a real Milvus server (e.g. in CI via Docker sidecar).
-            # Use the server URI directly; skip milvus-lite local file creation.
-            milvus_db_file = None
-            milvus_client_settings.uri = _env_uri
-        else:
-            # Local dev: use a unique milvus-lite DB file per test run.
-            milvus_db_file = str(tmp_path / f"test_{uuid.uuid4().hex[:8]}.db")
-            milvus_client_settings.uri = milvus_db_file
-            # Note: currently milvus-lite creates a file, not a dir for the uri
-    elif backend_type == "filesystem":
-        os.environ["EVOLVE_DATA_DIR"] = str(tmp_path)
-
-    from altk_evolve.frontend.client.evolve_client import EvolveClient
-    from altk_evolve.config.evolve import evolve_config
-
-    # Reset loaded settings to pick up new env vars
-    evolve_config.__init__()
-
-    # Reset the MCP server client
-    import altk_evolve.frontend.mcp.mcp_server as mcp_server_module
-
-    mcp_server_module._client = None
-    mcp_server_module._namespace_initialized = False
-
-    evolve_client = EvolveClient()
-    # Create the test namespace
-    try:
-        evolve_client.create_namespace("test")
-    except Exception:
-        pass
-
-    yield mcp_server_module.mcp
-
-    # Cleanup
-    try:
-        evolve_client.backend.close()
-    except Exception:
-        pass
-
-    if backend_type == "milvus":
-        # Disconnect all pymilvus connections
-        try:
-            from pymilvus import connections
-
-            for alias, _ in connections.list_connections():
-                try:
-                    connections.disconnect(alias)
-                except Exception:
-                    pass
-        except Exception:
-            pass
-
-        # Release all Milvus Lite servers
-        try:
-            from milvus_lite.server_manager import server_manager_instance
-
-            server_manager_instance.release_all()
-        except Exception:
-            pass
-
-        # Restore original URI
-        if original_milvus_uri:
-            milvus_client_settings.uri = original_milvus_uri
-
-        # Clean up temp DB files
-        if milvus_db_file and os.path.exists(milvus_db_file):
-            try:
-                os.remove(milvus_db_file)
-            except Exception:
-                pass
-        if milvus_db_file and os.path.exists(f"{milvus_db_file}.lock"):
-            try:
-                os.remove(f"{milvus_db_file}.lock")
-            except Exception:
-                pass
-
-    # Reset the MCP server client
-    mcp_server_module._client = None
-    mcp_server_module._namespace_initialized = False
 
 
 @pytest.mark.e2e

--- a/tests/e2e/test_sharing.py
+++ b/tests/e2e/test_sharing.py
@@ -42,19 +42,27 @@ async def test_publish_entity_makes_it_retrievable_publicly(mcp):
 
 @pytest.mark.e2e
 async def test_unpublish_entity_removes_it_from_public_results(mcp):
-    """unpublish_entity reverts visibility to private."""
+    """unpublish_entity reverts visibility to private and removes the entity from public results."""
     async with Client(transport=mcp) as client:
         create_resp = await client.call_tool_mcp(
             "create_entity",
-            {"content": "prefer list comprehensions", "entity_type": "guideline", "enable_conflict_resolution": False},
+            {"content": "prefer list comprehensions", "entity_type": "guideline", "enable_conflict_resolution": False, "owner_id": "alice"},
         )
         entity_id = json.loads(create_resp.content[0].text)["id"]
 
-        await client.call_tool_mcp("publish_entity", {"entity_id": entity_id})
+        await client.call_tool_mcp("publish_entity", {"entity_id": entity_id, "user_id": "alice"})
 
-        unpub_resp = await client.call_tool_mcp("unpublish_entity", {"entity_id": entity_id})
+        unpub_resp = await client.call_tool_mcp("unpublish_entity", {"entity_id": entity_id, "user_id": "alice"})
         unpublished = json.loads(unpub_resp.content[0].text)
         assert unpublished["metadata"]["visibility"] == "private"
+
+        get_resp = await client.call_tool_mcp(
+            "get_entities",
+            {"task": "list comprehensions", "entity_type": "guideline", "include_public": True},
+        )
+        public_output = get_resp.content[0].text
+        entity_lines = [line for line in public_output.splitlines() if "list comprehensions" in line]
+        assert not any("[public:" in line for line in entity_lines)
 
 
 @pytest.mark.e2e

--- a/tests/e2e/test_sharing.py
+++ b/tests/e2e/test_sharing.py
@@ -6,6 +6,8 @@ The `mcp` fixture is parameterized in conftest.py — every test here runs twice
 """
 
 import json
+import uuid
+
 import pytest
 from fastmcp.client import Client
 
@@ -81,6 +83,55 @@ async def test_create_entity_with_visibility_public(mcp):
         result = json.loads(resp.content[0].text)
         assert result["metadata"]["visibility"] == "public"
         assert result["metadata"]["owner_id"] == "bob"
+
+
+@pytest.mark.e2e
+async def test_cross_namespace_public_discovery(mcp):
+    """Entities published in a second namespace appear only when include_public=True."""
+    from altk_evolve.frontend.client.evolve_client import EvolveClient
+    from altk_evolve.schema.core import Entity
+
+    second_ns = f"test_x_{uuid.uuid4().hex[:6]}"
+    second_client = EvolveClient()
+    second_client.create_namespace(second_ns)
+
+    try:
+        second_client.update_entities(
+            second_ns,
+            [
+                Entity(
+                    type="guideline",
+                    content="use dependency injection for testability",
+                    metadata={"visibility": "public", "owner_id": "alice"},
+                )
+            ],
+            enable_conflict_resolution=False,
+        )
+
+        async with Client(transport=mcp) as client:
+            # With include_public=True the cross-namespace entity should surface
+            with_public = await client.call_tool_mcp(
+                "get_entities",
+                {"task": "dependency injection", "entity_type": "guideline", "include_public": True},
+            )
+            assert "dependency injection" in with_public.content[0].text
+            assert "[public: alice]" in with_public.content[0].text
+
+            # Without include_public it must NOT appear (it lives in a different namespace)
+            without_public = await client.call_tool_mcp(
+                "get_entities",
+                {"task": "dependency injection", "entity_type": "guideline", "include_public": False},
+            )
+            assert "dependency injection" not in without_public.content[0].text
+    finally:
+        try:
+            second_client.delete_namespace(second_ns)
+        except Exception:
+            pass
+        try:
+            second_client.backend.close()
+        except Exception:
+            pass
 
 
 @pytest.mark.e2e

--- a/tests/e2e/test_sharing.py
+++ b/tests/e2e/test_sharing.py
@@ -1,0 +1,102 @@
+"""
+E2E tests for Phase 1B entity sharing: publish, unpublish, cross-namespace public recall.
+
+Exercises the full MCP tool stack against real backends (filesystem + milvus-lite).
+The `mcp` fixture is parameterized in conftest.py — every test here runs twice.
+"""
+
+import json
+import pytest
+from fastmcp.client import Client
+
+
+@pytest.mark.e2e
+async def test_publish_entity_makes_it_retrievable_publicly(mcp):
+    """publish_entity sets visibility=public; get_entities(include_public=True) finds it."""
+    async with Client(transport=mcp) as client:
+        # Create a private entity first
+        create_resp = await client.call_tool_mcp(
+            "create_entity",
+            {"content": "always use type hints", "entity_type": "guideline", "enable_conflict_resolution": False},
+        )
+        entity = json.loads(create_resp.content[0].text)
+        entity_id = entity["id"]
+
+        # Publish it
+        pub_resp = await client.call_tool_mcp(
+            "publish_entity", {"entity_id": entity_id, "user_id": "alice"}
+        )
+        published = json.loads(pub_resp.content[0].text)
+        assert published["metadata"]["visibility"] == "public"
+        assert published["metadata"]["owner_id"] == "alice"
+        assert "published_at" in published["metadata"]
+
+        # Should appear in a public search
+        get_resp = await client.call_tool_mcp(
+            "get_entities",
+            {"task": "type hints python", "entity_type": "guideline", "include_public": True},
+        )
+        output = get_resp.content[0].text
+        assert "type hints" in output
+
+
+@pytest.mark.e2e
+async def test_unpublish_entity_removes_it_from_public_results(mcp):
+    """unpublish_entity reverts visibility to private."""
+    async with Client(transport=mcp) as client:
+        create_resp = await client.call_tool_mcp(
+            "create_entity",
+            {"content": "prefer list comprehensions", "entity_type": "guideline", "enable_conflict_resolution": False},
+        )
+        entity_id = json.loads(create_resp.content[0].text)["id"]
+
+        await client.call_tool_mcp("publish_entity", {"entity_id": entity_id})
+
+        unpub_resp = await client.call_tool_mcp("unpublish_entity", {"entity_id": entity_id})
+        unpublished = json.loads(unpub_resp.content[0].text)
+        assert unpublished["metadata"]["visibility"] == "private"
+
+
+@pytest.mark.e2e
+async def test_publish_entity_not_found_returns_error(mcp):
+    """publish_entity on a missing entity returns an error, not a 500."""
+    async with Client(transport=mcp) as client:
+        resp = await client.call_tool_mcp("publish_entity", {"entity_id": "99999"})
+        result = json.loads(resp.content[0].text)
+        assert "error" in result
+
+
+@pytest.mark.e2e
+async def test_create_entity_with_visibility_public(mcp):
+    """create_entity(visibility=public) stores the visibility flag immediately."""
+    async with Client(transport=mcp) as client:
+        resp = await client.call_tool_mcp(
+            "create_entity",
+            {
+                "content": "document all public functions",
+                "entity_type": "guideline",
+                "visibility": "public",
+                "owner_id": "bob",
+                "enable_conflict_resolution": False,
+            },
+        )
+        result = json.loads(resp.content[0].text)
+        assert result["metadata"]["visibility"] == "public"
+        assert result["metadata"]["owner_id"] == "bob"
+
+
+@pytest.mark.e2e
+async def test_patch_metadata_preserves_content(mcp):
+    """publish_entity must not alter entity content — only metadata."""
+    original_content = "avoid mutable default arguments"
+    async with Client(transport=mcp) as client:
+        create_resp = await client.call_tool_mcp(
+            "create_entity",
+            {"content": original_content, "entity_type": "guideline", "enable_conflict_resolution": False},
+        )
+        entity_id = json.loads(create_resp.content[0].text)["id"]
+
+        pub_resp = await client.call_tool_mcp("publish_entity", {"entity_id": entity_id, "user_id": "carol"})
+        published = json.loads(pub_resp.content[0].text)
+
+        assert published["content"] == original_content

--- a/tests/e2e/test_sharing.py
+++ b/tests/e2e/test_sharing.py
@@ -23,9 +23,7 @@ async def test_publish_entity_makes_it_retrievable_publicly(mcp):
         entity_id = entity["id"]
 
         # Publish it
-        pub_resp = await client.call_tool_mcp(
-            "publish_entity", {"entity_id": entity_id, "user_id": "alice"}
-        )
+        pub_resp = await client.call_tool_mcp("publish_entity", {"entity_id": entity_id, "user_id": "alice"})
         published = json.loads(pub_resp.content[0].text)
         assert published["metadata"]["visibility"] == "public"
         assert published["metadata"]["owner_id"] == "alice"

--- a/tests/unit/test_entity_sharing.py
+++ b/tests/unit/test_entity_sharing.py
@@ -67,6 +67,7 @@ def _make_entity(entity_id="42", visibility="private", owner_id=None):
 
 def test_publish_entity_sets_public(mock_get_client):
     updated = _make_entity(visibility="public", owner_id="alice")
+    mock_get_client.get_entity_by_id.return_value = _make_entity(owner_id="alice")
     mock_get_client.patch_entity_metadata.return_value = updated
 
     result = json.loads(publish_entity(entity_id="42", user_id="alice"))
@@ -82,6 +83,7 @@ def test_publish_entity_sets_public(mock_get_client):
 
 def test_publish_entity_no_user_id(mock_get_client):
     updated = _make_entity(visibility="public")
+    mock_get_client.get_entity_by_id.return_value = _make_entity()
     mock_get_client.patch_entity_metadata.return_value = updated
 
     publish_entity(entity_id="42")
@@ -91,9 +93,7 @@ def test_publish_entity_no_user_id(mock_get_client):
 
 
 def test_publish_entity_not_found(mock_get_client):
-    from altk_evolve.schema.exceptions import EvolveException
-
-    mock_get_client.patch_entity_metadata.side_effect = EvolveException("Entity '99' not found")
+    mock_get_client.get_entity_by_id.return_value = None
 
     result = json.loads(publish_entity(entity_id="99", user_id="alice"))
     assert "error" in result
@@ -104,6 +104,7 @@ def test_publish_entity_not_found(mock_get_client):
 
 def test_unpublish_entity_reverts_to_private(mock_get_client):
     updated = _make_entity(visibility="private")
+    mock_get_client.get_entity_by_id.return_value = _make_entity()
     mock_get_client.patch_entity_metadata.return_value = updated
 
     result = json.loads(unpublish_entity(entity_id="42"))

--- a/tests/unit/test_entity_sharing.py
+++ b/tests/unit/test_entity_sharing.py
@@ -22,6 +22,7 @@ def mock_get_client():
 
 # ── create_entity ─────────────────────────────────────────────────────────────
 
+
 def test_create_entity_stores_visibility(mock_get_client):
     mock_get_client.update_entities.return_value = [
         EntityUpdate(id="1", type="guideline", content="test", event="ADD", metadata={"visibility": "private"})
@@ -48,15 +49,14 @@ def test_create_entity_invalid_visibility(mock_get_client):
 
 
 def test_create_entity_no_owner_id_omitted(mock_get_client):
-    mock_get_client.update_entities.return_value = [
-        EntityUpdate(id="1", type="note", content="x", event="ADD", metadata={})
-    ]
+    mock_get_client.update_entities.return_value = [EntityUpdate(id="1", type="note", content="x", event="ADD", metadata={})]
     create_entity(content="x", entity_type="note")
     entities = mock_get_client.update_entities.call_args[1]["entities"]
     assert "owner_id" not in entities[0].metadata
 
 
 # ── publish_entity ─────────────────────────────────────────────────────────────
+
 
 def _make_entity(entity_id="42", visibility="private", owner_id=None):
     meta = {"visibility": visibility}
@@ -92,6 +92,7 @@ def test_publish_entity_no_user_id(mock_get_client):
 
 def test_publish_entity_not_found(mock_get_client):
     from altk_evolve.schema.exceptions import EvolveException
+
     mock_get_client.patch_entity_metadata.side_effect = EvolveException("Entity '99' not found")
 
     result = json.loads(publish_entity(entity_id="99", user_id="alice"))
@@ -99,6 +100,7 @@ def test_publish_entity_not_found(mock_get_client):
 
 
 # ── unpublish_entity ───────────────────────────────────────────────────────────
+
 
 def test_unpublish_entity_reverts_to_private(mock_get_client):
     updated = _make_entity(visibility="private")
@@ -113,6 +115,7 @@ def test_unpublish_entity_reverts_to_private(mock_get_client):
 
 
 # ── get_entities with include_public ──────────────────────────────────────────
+
 
 def test_get_entities_include_public_annotates_results(mock_get_client):
     private = _make_entity(entity_id="1", visibility="private")
@@ -149,11 +152,10 @@ def test_get_entities_deduplicates_public_already_in_private(mock_get_client):
 
 # ── backward compatibility ─────────────────────────────────────────────────────
 
+
 def test_create_entity_backward_compat_no_visibility_args(mock_get_client):
     """Calling create_entity without new args should still work and default to private."""
-    mock_get_client.update_entities.return_value = [
-        EntityUpdate(id="1", type="fact", content="x", event="ADD", metadata={})
-    ]
+    mock_get_client.update_entities.return_value = [EntityUpdate(id="1", type="fact", content="x", event="ADD", metadata={})]
     result = json.loads(create_entity(content="x", entity_type="fact"))
     assert "error" not in result
     entities = mock_get_client.update_entities.call_args[1]["entities"]

--- a/tests/unit/test_entity_sharing.py
+++ b/tests/unit/test_entity_sharing.py
@@ -87,7 +87,7 @@ def test_publish_entity_no_user_id(mock_get_client):
     publish_entity(entity_id="42")
 
     call_kwargs = mock_get_client.patch_entity_metadata.call_args[1]
-    assert call_kwargs["metadata_updates"]["owner_id"] is None
+    assert "owner_id" not in call_kwargs["metadata_updates"]
 
 
 def test_publish_entity_not_found(mock_get_client):

--- a/tests/unit/test_entity_sharing.py
+++ b/tests/unit/test_entity_sharing.py
@@ -1,0 +1,160 @@
+"""Tests for Phase 1A + 1B entity sharing: visibility, publish, unpublish, get_public."""
+
+import json
+import pytest
+from unittest.mock import patch
+
+from altk_evolve.frontend.mcp.mcp_server import create_entity, publish_entity, unpublish_entity, get_entities
+from altk_evolve.schema.conflict_resolution import EntityUpdate
+from altk_evolve.schema.core import RecordedEntity
+import datetime
+
+pytestmark = pytest.mark.unit
+
+NOW = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
+
+
+@pytest.fixture
+def mock_get_client():
+    with patch("altk_evolve.frontend.mcp.mcp_server.get_client") as mock:
+        yield mock.return_value
+
+
+# ── create_entity ─────────────────────────────────────────────────────────────
+
+def test_create_entity_stores_visibility(mock_get_client):
+    mock_get_client.update_entities.return_value = [
+        EntityUpdate(id="1", type="guideline", content="test", event="ADD", metadata={"visibility": "private"})
+    ]
+    create_entity(content="test", entity_type="guideline")
+    entities = mock_get_client.update_entities.call_args[1]["entities"]
+    assert entities[0].metadata["visibility"] == "private"
+
+
+def test_create_entity_public_visibility(mock_get_client):
+    mock_get_client.update_entities.return_value = [
+        EntityUpdate(id="1", type="guideline", content="test", event="ADD", metadata={"visibility": "public", "owner_id": "alice"})
+    ]
+    create_entity(content="test", entity_type="guideline", visibility="public", owner_id="alice")
+    entities = mock_get_client.update_entities.call_args[1]["entities"]
+    assert entities[0].metadata["visibility"] == "public"
+    assert entities[0].metadata["owner_id"] == "alice"
+
+
+def test_create_entity_invalid_visibility(mock_get_client):
+    result = json.loads(create_entity(content="test", entity_type="guideline", visibility="team"))
+    assert "error" in result
+    mock_get_client.update_entities.assert_not_called()
+
+
+def test_create_entity_no_owner_id_omitted(mock_get_client):
+    mock_get_client.update_entities.return_value = [
+        EntityUpdate(id="1", type="note", content="x", event="ADD", metadata={})
+    ]
+    create_entity(content="x", entity_type="note")
+    entities = mock_get_client.update_entities.call_args[1]["entities"]
+    assert "owner_id" not in entities[0].metadata
+
+
+# ── publish_entity ─────────────────────────────────────────────────────────────
+
+def _make_entity(entity_id="42", visibility="private", owner_id=None):
+    meta = {"visibility": visibility}
+    if owner_id:
+        meta["owner_id"] = owner_id
+    return RecordedEntity(id=entity_id, type="guideline", content="tip content", created_at=NOW, metadata=meta)
+
+
+def test_publish_entity_sets_public(mock_get_client):
+    updated = _make_entity(visibility="public", owner_id="alice")
+    mock_get_client.patch_entity_metadata.return_value = updated
+
+    result = json.loads(publish_entity(entity_id="42", user_id="alice"))
+
+    mock_get_client.patch_entity_metadata.assert_called_once()
+    call_kwargs = mock_get_client.patch_entity_metadata.call_args[1]
+    assert call_kwargs["entity_id"] == "42"
+    assert call_kwargs["metadata_updates"]["visibility"] == "public"
+    assert call_kwargs["metadata_updates"]["owner_id"] == "alice"
+    assert "published_at" in call_kwargs["metadata_updates"]
+    assert result["metadata"]["visibility"] == "public"
+
+
+def test_publish_entity_no_user_id(mock_get_client):
+    updated = _make_entity(visibility="public")
+    mock_get_client.patch_entity_metadata.return_value = updated
+
+    publish_entity(entity_id="42")
+
+    call_kwargs = mock_get_client.patch_entity_metadata.call_args[1]
+    assert call_kwargs["metadata_updates"]["owner_id"] is None
+
+
+def test_publish_entity_not_found(mock_get_client):
+    from altk_evolve.schema.exceptions import EvolveException
+    mock_get_client.patch_entity_metadata.side_effect = EvolveException("Entity '99' not found")
+
+    result = json.loads(publish_entity(entity_id="99", user_id="alice"))
+    assert "error" in result
+
+
+# ── unpublish_entity ───────────────────────────────────────────────────────────
+
+def test_unpublish_entity_reverts_to_private(mock_get_client):
+    updated = _make_entity(visibility="private")
+    mock_get_client.patch_entity_metadata.return_value = updated
+
+    result = json.loads(unpublish_entity(entity_id="42"))
+
+    call_kwargs = mock_get_client.patch_entity_metadata.call_args[1]
+    assert call_kwargs["metadata_updates"]["visibility"] == "private"
+    assert call_kwargs["metadata_updates"]["published_at"] is None
+    assert result["metadata"]["visibility"] == "private"
+
+
+# ── get_entities with include_public ──────────────────────────────────────────
+
+def test_get_entities_include_public_annotates_results(mock_get_client):
+    private = _make_entity(entity_id="1", visibility="private")
+    public = _make_entity(entity_id="2", visibility="public", owner_id="bob")
+
+    mock_get_client.search_entities.return_value = [private]
+    mock_get_client.get_public_entities.return_value = [public]
+
+    result = get_entities(task="some task", include_public=True)
+
+    assert "[public: bob]" in result
+    mock_get_client.get_public_entities.assert_called_once()
+
+
+def test_get_entities_no_include_public_skips_cross_namespace(mock_get_client):
+    mock_get_client.search_entities.return_value = []
+
+    get_entities(task="some task", include_public=False)
+
+    mock_get_client.get_public_entities.assert_not_called()
+
+
+def test_get_entities_deduplicates_public_already_in_private(mock_get_client):
+    """Entity returned by both private search and public search should appear only once."""
+    entity = _make_entity(entity_id="1", visibility="public", owner_id="alice")
+    mock_get_client.search_entities.return_value = [entity]
+    mock_get_client.get_public_entities.return_value = [entity]
+
+    result = get_entities(task="some task", include_public=True)
+
+    # Should appear exactly once (no duplicate)
+    assert result.count("tip content") == 1
+
+
+# ── backward compatibility ─────────────────────────────────────────────────────
+
+def test_create_entity_backward_compat_no_visibility_args(mock_get_client):
+    """Calling create_entity without new args should still work and default to private."""
+    mock_get_client.update_entities.return_value = [
+        EntityUpdate(id="1", type="fact", content="x", event="ADD", metadata={})
+    ]
+    result = json.loads(create_entity(content="x", entity_type="fact"))
+    assert "error" not in result
+    entities = mock_get_client.update_entities.call_args[1]["entities"]
+    assert entities[0].metadata.get("visibility") == "private"

--- a/tests/unit/test_entity_sharing.py
+++ b/tests/unit/test_entity_sharing.py
@@ -115,6 +115,26 @@ def test_unpublish_entity_reverts_to_private(mock_get_client):
     assert result["metadata"]["visibility"] == "private"
 
 
+def test_publish_entity_ownership_mismatch_denied(mock_get_client):
+    mock_get_client.get_entity_by_id.return_value = _make_entity(owner_id="bob")
+
+    result = json.loads(publish_entity(entity_id="42", user_id="alice"))
+
+    assert "error" in result
+    assert "Permission denied" in result["error"]
+    mock_get_client.patch_entity_metadata.assert_not_called()
+
+
+def test_unpublish_entity_ownership_mismatch_denied(mock_get_client):
+    mock_get_client.get_entity_by_id.return_value = _make_entity(owner_id="bob")
+
+    result = json.loads(unpublish_entity(entity_id="42", user_id="alice"))
+
+    assert "error" in result
+    assert "Permission denied" in result["error"]
+    mock_get_client.patch_entity_metadata.assert_not_called()
+
+
 # ── get_entities with include_public ──────────────────────────────────────────
 
 

--- a/tests/unit/test_entity_sharing_e2e.py
+++ b/tests/unit/test_entity_sharing_e2e.py
@@ -27,6 +27,7 @@ def ns(client):
 
 # ── get_entity_by_id ──────────────────────────────────────────────────────────
 
+
 def test_get_entity_by_id_returns_entity(client, ns):
     updates = client.update_entities(ns, [Entity(type="guideline", content="be concise")], enable_conflict_resolution=False)
     entity_id = updates[0].id
@@ -43,9 +44,11 @@ def test_get_entity_by_id_missing_returns_none(client, ns):
 
 # ── patch_entity_metadata ─────────────────────────────────────────────────────
 
+
 def test_patch_entity_metadata_merges_without_touching_content(client, ns):
     updates = client.update_entities(
-        ns, [Entity(type="guideline", content="original content", metadata={"creation_mode": "manual"})],
+        ns,
+        [Entity(type="guideline", content="original content", metadata={"creation_mode": "manual"})],
         enable_conflict_resolution=False,
     )
     entity_id = updates[0].id
@@ -75,6 +78,7 @@ def test_patch_entity_metadata_raises_for_missing_entity(client, ns):
 
 
 # ── publish / unpublish round-trip ────────────────────────────────────────────
+
 
 def test_publish_makes_entity_appear_in_public_search(client, ns):
     updates = client.update_entities(ns, [Entity(type="guideline", content="use context managers")], enable_conflict_resolution=False)
@@ -106,13 +110,12 @@ def test_private_entities_not_returned_by_get_public(client, ns):
 
 # ── cross-namespace public discovery ──────────────────────────────────────────
 
+
 def test_public_entity_in_one_namespace_visible_from_another(client):
     ns_a = client.create_namespace("user_a").id
     ns_b = client.create_namespace("user_b").id
 
-    updates = client.update_entities(
-        ns_a, [Entity(type="guideline", content="always write tests")], enable_conflict_resolution=False
-    )
+    updates = client.update_entities(ns_a, [Entity(type="guideline", content="always write tests")], enable_conflict_resolution=False)
     entity_id = updates[0].id
     client.patch_entity_metadata(ns_a, entity_id, {"visibility": "public", "owner_id": "alice"})
 

--- a/tests/unit/test_entity_sharing_e2e.py
+++ b/tests/unit/test_entity_sharing_e2e.py
@@ -1,0 +1,139 @@
+"""
+E2E tests for entity sharing using the real FilesystemEntityBackend.
+
+No mocks — exercises EvolveClient + FilesystemEntityBackend + file I/O end-to-end.
+"""
+
+import pytest
+from altk_evolve.config.evolve import EvolveConfig
+from altk_evolve.config.filesystem import FilesystemSettings
+from altk_evolve.frontend.client.evolve_client import EvolveClient
+from altk_evolve.schema.core import Entity
+from altk_evolve.schema.exceptions import EvolveException
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def client(tmp_path):
+    config = EvolveConfig(backend="filesystem", settings=FilesystemSettings(data_dir=str(tmp_path)))
+    return EvolveClient(config=config)
+
+
+@pytest.fixture
+def ns(client):
+    return client.create_namespace("main").id
+
+
+# ── get_entity_by_id ──────────────────────────────────────────────────────────
+
+def test_get_entity_by_id_returns_entity(client, ns):
+    updates = client.update_entities(ns, [Entity(type="guideline", content="be concise")], enable_conflict_resolution=False)
+    entity_id = updates[0].id
+
+    found = client.get_entity_by_id(ns, entity_id)
+    assert found is not None
+    assert found.content == "be concise"
+    assert found.id == entity_id
+
+
+def test_get_entity_by_id_missing_returns_none(client, ns):
+    assert client.get_entity_by_id(ns, "99999") is None
+
+
+# ── patch_entity_metadata ─────────────────────────────────────────────────────
+
+def test_patch_entity_metadata_merges_without_touching_content(client, ns):
+    updates = client.update_entities(
+        ns, [Entity(type="guideline", content="original content", metadata={"creation_mode": "manual"})],
+        enable_conflict_resolution=False,
+    )
+    entity_id = updates[0].id
+
+    updated = client.patch_entity_metadata(ns, entity_id, {"visibility": "public", "owner_id": "alice"})
+
+    assert updated.content == "original content"
+    assert updated.metadata["creation_mode"] == "manual"
+    assert updated.metadata["visibility"] == "public"
+    assert updated.metadata["owner_id"] == "alice"
+
+
+def test_patch_entity_metadata_persists_to_disk(client, ns):
+    updates = client.update_entities(ns, [Entity(type="guideline", content="tip")], enable_conflict_resolution=False)
+    entity_id = updates[0].id
+
+    client.patch_entity_metadata(ns, entity_id, {"visibility": "public"})
+
+    # Re-fetch from disk to confirm persistence
+    reloaded = client.get_entity_by_id(ns, entity_id)
+    assert reloaded.metadata["visibility"] == "public"
+
+
+def test_patch_entity_metadata_raises_for_missing_entity(client, ns):
+    with pytest.raises(EvolveException, match="not found"):
+        client.patch_entity_metadata(ns, "99999", {"visibility": "public"})
+
+
+# ── publish / unpublish round-trip ────────────────────────────────────────────
+
+def test_publish_makes_entity_appear_in_public_search(client, ns):
+    updates = client.update_entities(ns, [Entity(type="guideline", content="use context managers")], enable_conflict_resolution=False)
+    entity_id = updates[0].id
+
+    client.patch_entity_metadata(ns, entity_id, {"visibility": "public", "owner_id": "alice"})
+
+    public = client.get_public_entities(entity_type="guideline")
+    assert any(e.id == entity_id for e in public)
+
+
+def test_unpublish_removes_entity_from_public_search(client, ns):
+    updates = client.update_entities(ns, [Entity(type="guideline", content="use context managers")], enable_conflict_resolution=False)
+    entity_id = updates[0].id
+
+    client.patch_entity_metadata(ns, entity_id, {"visibility": "public"})
+    client.patch_entity_metadata(ns, entity_id, {"visibility": "private", "published_at": None})
+
+    public = client.get_public_entities(entity_type="guideline")
+    assert not any(e.id == entity_id for e in public)
+
+
+def test_private_entities_not_returned_by_get_public(client, ns):
+    client.update_entities(ns, [Entity(type="guideline", content="private tip")], enable_conflict_resolution=False)
+
+    public = client.get_public_entities(entity_type="guideline")
+    assert all(e.metadata.get("visibility") == "public" for e in public)
+
+
+# ── cross-namespace public discovery ──────────────────────────────────────────
+
+def test_public_entity_in_one_namespace_visible_from_another(client):
+    ns_a = client.create_namespace("user_a").id
+    ns_b = client.create_namespace("user_b").id
+
+    updates = client.update_entities(
+        ns_a, [Entity(type="guideline", content="always write tests")], enable_conflict_resolution=False
+    )
+    entity_id = updates[0].id
+    client.patch_entity_metadata(ns_a, entity_id, {"visibility": "public", "owner_id": "alice"})
+
+    # Private entity in ns_b — should not appear in public results
+    client.update_entities(ns_b, [Entity(type="guideline", content="private note")], enable_conflict_resolution=False)
+
+    public = client.get_public_entities(entity_type="guideline")
+    contents = [e.content for e in public]
+    assert "always write tests" in contents
+    assert "private note" not in contents
+
+
+def test_get_public_entities_filters_by_type(client):
+    ns = client.create_namespace("mixed").id
+
+    g_updates = client.update_entities(ns, [Entity(type="guideline", content="guideline text")], enable_conflict_resolution=False)
+    client.patch_entity_metadata(ns, g_updates[0].id, {"visibility": "public"})
+
+    f_updates = client.update_entities(ns, [Entity(type="fact", content="fact text")], enable_conflict_resolution=False)
+    client.patch_entity_metadata(ns, f_updates[0].id, {"visibility": "public"})
+
+    public_guidelines = client.get_public_entities(entity_type="guideline")
+    assert all(e.type == "guideline" for e in public_guidelines)
+    assert any(e.content == "guideline text" for e in public_guidelines)

--- a/tests/unit/test_entity_sharing_e2e.py
+++ b/tests/unit/test_entity_sharing_e2e.py
@@ -11,7 +11,7 @@ from altk_evolve.frontend.client.evolve_client import EvolveClient
 from altk_evolve.schema.core import Entity
 from altk_evolve.schema.exceptions import EvolveException
 
-pytestmark = pytest.mark.unit
+pytestmark = pytest.mark.e2e
 
 
 @pytest.fixture

--- a/tests/unit/test_milvus_backend.py
+++ b/tests/unit/test_milvus_backend.py
@@ -409,6 +409,72 @@ def test_delete_entity_nonexistent_namespace(milvus_backend: MilvusEntityBackend
         milvus_backend.delete_entity_by_id(namespace_id="nonexistent_namespace", entity_id="12345")
 
 
+# ── update_entity_metadata ────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_update_entity_metadata_merges_and_returns(milvus_backend: MilvusEntityBackend, monkeypatch):
+    """Fetches via milvus.query, merges patch, upserts with partial_update, returns updated entity."""
+    now_ts = int(datetime.datetime.now(datetime.UTC).timestamp())
+    raw_entity = {
+        "id": 42,
+        "type": "guideline",
+        "content": "be concise",
+        "created_at": now_ts,
+        "metadata": {"creation_mode": "manual"},
+    }
+
+    query = Mock(return_value=[raw_entity])
+    upsert = Mock(return_value={"ids": [42]})
+    flush = Mock()
+    load = Mock()
+
+    monkeypatch.setattr(milvus_backend.milvus, "has_collection", always_has_collection)
+    monkeypatch.setattr(milvus_backend.milvus, "query", query)
+    monkeypatch.setattr(milvus_backend.milvus, "upsert", upsert)
+    monkeypatch.setattr(milvus_backend.milvus, "flush", flush)
+    monkeypatch.setattr(milvus_backend.milvus, "load_collection", load)
+    monkeypatch.setattr(milvus_backend.embedding_model, "encode", arbitrary_embedding)
+
+    result = milvus_backend.update_entity_metadata(
+        "test_namespace", "42", {"visibility": "public", "owner_id": "alice"}
+    )
+
+    # query must use direct id filter, not search_entities fan-out
+    query.assert_called_once_with(
+        collection_name="test_namespace",
+        filter="id == 42",
+        output_fields=["id", "type", "content", "created_at", "metadata"],
+        limit=1,
+    )
+
+    # upsert must carry merged metadata
+    upserted_data = upsert.call_args[1]["data"]
+    assert upserted_data["metadata"]["creation_mode"] == "manual"
+    assert upserted_data["metadata"]["visibility"] == "public"
+    assert upserted_data["metadata"]["owner_id"] == "alice"
+
+    assert result.metadata["visibility"] == "public"
+    assert result.metadata["creation_mode"] == "manual"
+
+
+@pytest.mark.unit
+def test_update_entity_metadata_raises_for_missing_entity(milvus_backend: MilvusEntityBackend, monkeypatch):
+    """Raises EvolveException when milvus.query returns no results."""
+    monkeypatch.setattr(milvus_backend.milvus, "has_collection", always_has_collection)
+    monkeypatch.setattr(milvus_backend.milvus, "query", Mock(return_value=[]))
+
+    with pytest.raises(EvolveException, match="not found"):
+        milvus_backend.update_entity_metadata("test_namespace", "99", {"visibility": "public"})
+
+
+@pytest.mark.unit
+def test_update_entity_metadata_rejects_non_numeric_id(milvus_backend: MilvusEntityBackend):
+    """Raises EvolveException immediately for non-numeric entity IDs."""
+    with pytest.raises(EvolveException, match="must be numeric"):
+        milvus_backend.update_entity_metadata("test_namespace", "not-an-id", {"visibility": "public"})
+
+
 @pytest.mark.unit
 def test_parse_milvus_entity_accepts_epoch_zero_created_at():
     parsed = parse_milvus_entity(

--- a/tests/unit/test_milvus_backend.py
+++ b/tests/unit/test_milvus_backend.py
@@ -436,9 +436,7 @@ def test_update_entity_metadata_merges_and_returns(milvus_backend: MilvusEntityB
     monkeypatch.setattr(milvus_backend.milvus, "load_collection", load)
     monkeypatch.setattr(milvus_backend.embedding_model, "encode", arbitrary_embedding)
 
-    result = milvus_backend.update_entity_metadata(
-        "test_namespace", "42", {"visibility": "public", "owner_id": "alice"}
-    )
+    result = milvus_backend.update_entity_metadata("test_namespace", "42", {"visibility": "public", "owner_id": "alice"})
 
     # query must use direct id filter, not search_entities fan-out
     query.assert_called_once_with(

--- a/tests/unit/test_postgres_backend.py
+++ b/tests/unit/test_postgres_backend.py
@@ -679,9 +679,7 @@ def test_update_entity_metadata_merges_and_returns(postgres_backend: PostgresEnt
     mock_cursor_ctx.__exit__ = Mock(return_value=False)
 
     with patch.object(postgres_backend.conn, "cursor", return_value=mock_cursor_ctx):
-        result = postgres_backend.update_entity_metadata(
-            "test_namespace", "42", {"visibility": "public", "owner_id": "alice"}
-        )
+        result = postgres_backend.update_entity_metadata("test_namespace", "42", {"visibility": "public", "owner_id": "alice"})
 
     # Verify the SQL used the jsonb merge operator and RETURNING clause
     executed_sql = str(mock_cursor.execute.call_args[0][0])
@@ -692,6 +690,7 @@ def test_update_entity_metadata_merges_and_returns(postgres_backend: PostgresEnt
     call_params = mock_cursor.execute.call_args[0][1]
     assert call_params[1] == 42  # entity_id cast to int
     import json
+
     patch_dict = json.loads(call_params[0])
     assert patch_dict == {"visibility": "public", "owner_id": "alice"}
 

--- a/tests/unit/test_postgres_backend.py
+++ b/tests/unit/test_postgres_backend.py
@@ -653,3 +653,70 @@ def test_delete_entity_invalid_id(postgres_backend: PostgresEntityBackend, monke
     """Test deleting an entity with a non-numeric ID."""
     with pytest.raises(EvolveException, match="Invalid entity ID"):
         postgres_backend.delete_entity_by_id(namespace_id="test_namespace", entity_id="not_a_number")
+
+
+# ── update_entity_metadata ────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_update_entity_metadata_merges_and_returns(postgres_backend: PostgresEntityBackend, monkeypatch):
+    """Native metadata merge issues UPDATE ... metadata || jsonb and returns the updated entity."""
+    now_dt = datetime.datetime.now(datetime.UTC)
+    updated_row = RecordedEntity(
+        id="42",
+        type="guideline",
+        content="be concise",
+        created_at=now_dt,
+        metadata={"creation_mode": "manual", "visibility": "public", "owner_id": "alice"},
+    )
+
+    monkeypatch.setattr(postgres_backend, "_table_exists", make_table_exists(True))
+
+    mock_cursor = MagicMock()
+    mock_cursor.fetchall.return_value = [updated_row]
+    mock_cursor_ctx = MagicMock()
+    mock_cursor_ctx.__enter__ = Mock(return_value=mock_cursor)
+    mock_cursor_ctx.__exit__ = Mock(return_value=False)
+
+    with patch.object(postgres_backend.conn, "cursor", return_value=mock_cursor_ctx):
+        result = postgres_backend.update_entity_metadata(
+            "test_namespace", "42", {"visibility": "public", "owner_id": "alice"}
+        )
+
+    # Verify the SQL used the jsonb merge operator and RETURNING clause
+    executed_sql = str(mock_cursor.execute.call_args[0][0])
+    assert "metadata || %s" in executed_sql
+    assert "RETURNING" in executed_sql
+
+    # Verify the patch dict and numeric entity ID were passed as params
+    call_params = mock_cursor.execute.call_args[0][1]
+    assert call_params[1] == 42  # entity_id cast to int
+    import json
+    patch_dict = json.loads(call_params[0])
+    assert patch_dict == {"visibility": "public", "owner_id": "alice"}
+
+    assert result.metadata["visibility"] == "public"
+    assert result.metadata["owner_id"] == "alice"
+
+
+@pytest.mark.unit
+def test_update_entity_metadata_raises_for_missing_entity(postgres_backend: PostgresEntityBackend, monkeypatch):
+    """Raises EvolveException when RETURNING yields no rows (entity not found)."""
+    monkeypatch.setattr(postgres_backend, "_table_exists", make_table_exists(True))
+
+    mock_cursor = MagicMock()
+    mock_cursor.fetchall.return_value = []
+    mock_cursor_ctx = MagicMock()
+    mock_cursor_ctx.__enter__ = Mock(return_value=mock_cursor)
+    mock_cursor_ctx.__exit__ = Mock(return_value=False)
+
+    with patch.object(postgres_backend.conn, "cursor", return_value=mock_cursor_ctx):
+        with pytest.raises(EvolveException, match="not found"):
+            postgres_backend.update_entity_metadata("test_namespace", "99", {"visibility": "public"})
+
+
+@pytest.mark.unit
+def test_update_entity_metadata_rejects_non_numeric_id(postgres_backend: PostgresEntityBackend):
+    """Raises EvolveException immediately for non-numeric entity IDs."""
+    with pytest.raises(EvolveException, match="must be numeric"):
+        postgres_backend.update_entity_metadata("test_namespace", "not-an-id", {"visibility": "public"})


### PR DESCRIPTION
Addresses partly issue #182 in the mcp full version.

## Summary

- Adds public/private visibility to entities via metadata fields (`owner_id`, `visibility`, `published_at`) — no schema migration required, all backends unaffected
- New `publish_entity` and `unpublish_entity` MCP tools to control visibility per entity
- `get_entities` gains `include_public=True` to merge public entities from all namespaces, annotated with `[public: {owner_id}]`
- `create_entity` gains `owner_id` and `visibility` params; `save_trajectory` gains `owner_id`
- New `get_public_entities`, `get_entity_by_id`, `patch_entity_metadata` on `EvolveClient`
- Concrete `patch_entity` on `BaseEntityBackend` (+ filesystem override) enables metadata-only patches without changing entity ID or content

### Unit Tests (291 total)

| File | Tests | What's covered |
|------|-------|----------------|
| `test_entity_sharing.py` | 12 | `create_entity`, `publish_entity`, `unpublish_entity`, `get_entities(include_public)` — all mocked |
| `test_entity_sharing_e2e.py` | 10 | publish/unpublish round-trips, cross-namespace discovery, `patch_entity_metadata` persistence, type filtering — real `FilesystemEntityBackend` |
| `test_postgres_backend.py` | 3 | Native `UPDATE ... metadata \|\| jsonb`, missing entity error, non-numeric ID rejection |
| `test_milvus_backend.py` | 3 | Native `milvus.query` fetch + upsert merge, missing entity error, non-numeric ID rejection |
| *(pre-existing)* | 263 | All other backend, client, MCP, and pipeline tests |

### E2E Tests — 30 total (`--run-e2e`)

| File | Tests | Backends | What's covered |
|------|-------|----------|----------------|
| `test_sharing.py` | 5 × 2 = **10** | filesystem + milvus | publish/unpublish via MCP, `create_entity(visibility=public)`, content preservation after metadata patch, not-found error handling |
| `test_mcp.py` | 10 × 2 = **20** | filesystem + milvus | Pre-existing MCP tool tests, now parameterized against both backends |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Entity sharing: public/private visibility, owner and published_at metadata; publish/unpublish operations; create entities with visibility/owner; cross-namespace public listing (include_public).
  * Client APIs: fetch single entity by id, patch entity metadata, and list public entities.
  * MCP tools: create_entity accepts visibility/owner, save_trajectory accepts owner, get_entities supports include_public.

* **Documentation**
  * Added sharing docs, examples, and a note about deferred REST/UI work.

* **Tests**
  * New unit and e2e tests covering sharing, metadata patching, public discovery, and backend updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->