### PR TITLE
Ignore .omx runtime files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ demo/workdir/.claude/
 dist
 .coverage
 .evolve
+.omx
 .secrets
 event.json
 site/


### PR DESCRIPTION
## Summary
- Add `.omx` to the repository ignore list so local OMX runtime state stays out of git status.

## Testing
- Not run (not requested)