### PR TITLE
fix(claude-plugin): replace agent-type stop hook with command-type block decision

### DIFF
--- a/platform-integrations/claude/plugins/evolve-lite/hooks/hooks.json
+++ b/platform-integrations/claude/plugins/evolve-lite/hooks/hooks.json
@@ -27,9 +27,8 @@
         "matcher": "",
         "hooks": [
           {
-            "type": "agent",
-            "prompt": "Run the evolve-lite:learn skill, unless stop_hook_active is set in $ARGUMENTS.",
-            "timeout": 120
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/skills/learn/scripts/on_stop.sh"
           }
         ]
       }

--- a/platform-integrations/claude/plugins/evolve-lite/hooks/hooks.json
+++ b/platform-integrations/claude/plugins/evolve-lite/hooks/hooks.json
@@ -28,7 +28,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/skills/learn/scripts/on_stop.sh"
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/skills/learn/scripts/on_stop.py"
           }
         ]
       }

--- a/platform-integrations/claude/plugins/evolve-lite/skills/learn/scripts/on_stop.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/learn/scripts/on_stop.py
@@ -14,12 +14,16 @@ def main():
     if input_data.get("stop_hook_active") is True:
         return
 
-    print(json.dumps({
-        "decision": "block",
-        "reason": "Run the /evolve-lite:learn skill to extract guidelines from this conversation.",
-        "suppressOutput": True,
-        "statusMessage": "Running the evolve-lite learn skill...",
-    }))
+    print(
+        json.dumps(
+            {
+                "decision": "block",
+                "reason": "Run the /evolve-lite:learn skill to extract guidelines from this conversation.",
+                "suppressOutput": True,
+                "statusMessage": "Running the evolve-lite learn skill...",
+            }
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/platform-integrations/claude/plugins/evolve-lite/skills/learn/scripts/on_stop.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/learn/scripts/on_stop.py
@@ -20,7 +20,7 @@ def main():
                 "decision": "block",
                 "reason": "Run the /evolve-lite:learn skill to extract guidelines from this conversation.",
                 "suppressOutput": True,
-                "statusMessage": "Running the evolve-lite learn skill...",
+                "systemMessage": "Running the evolve-lite learn skill...",
             }
         )
     )

--- a/platform-integrations/claude/plugins/evolve-lite/skills/learn/scripts/on_stop.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/learn/scripts/on_stop.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Stop hook that triggers the learn skill to extract guidelines."""
+
+import json
+import sys
+
+
+def main():
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        input_data = {}
+
+    if input_data.get("stop_hook_active") is True:
+        return
+
+    print(json.dumps({
+        "decision": "block",
+        "reason": "Run the /evolve-lite:learn skill to extract guidelines from this conversation.",
+        "suppressOutput": True,
+        "statusMessage": "Running the evolve-lite learn skill...",
+    }))
+
+
+if __name__ == "__main__":
+    main()

--- a/platform-integrations/claude/plugins/evolve-lite/skills/learn/scripts/on_stop.sh
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/learn/scripts/on_stop.sh
@@ -11,5 +11,5 @@ echo '{
   "decision": "block",
   "reason": "Run the /evolve-lite:learn skill to extract guidelines from this conversation.",
   "suppressOutput": true,
-  "statusMessage": "Running the evolve-lite learn skill..."
+  "systemMessage": "Running the evolve-lite learn skill..."
 }'

--- a/platform-integrations/claude/plugins/evolve-lite/skills/learn/scripts/on_stop.sh
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/learn/scripts/on_stop.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+INPUT=$(cat)
+STOP_HOOK_ACTIVE=$(echo "$INPUT" | jq -r '.stop_hook_active')
+
+# Guard against infinite loop — don't inject if already continuing from a stop hook
+if [ "$STOP_HOOK_ACTIVE" = "true" ]; then
+  exit 0
+fi
+
+echo '{
+  "decision": "block",
+  "reason": "Run the /evolve-lite:learn skill to extract guidelines from this conversation.",
+  "suppressOutput": true,
+  "statusMessage": "Running the evolve-lite learn skill..."
+}'

--- a/tests/platform_integrations/test_plugin_structure.py
+++ b/tests/platform_integrations/test_plugin_structure.py
@@ -50,10 +50,10 @@ class TestHooksManifest:
                     if hook.get("type") == "command":
                         cmd = hook["command"]
                         resolved = cmd.replace("${CLAUDE_PLUGIN_ROOT}", str(_PLUGIN_ROOT))
-                        # Find the .py token — commands may have trailing flags
-                        py_tokens = [t for t in resolved.split() if t.endswith(".py")]
-                        assert py_tokens, f"No .py script found in hook command: {cmd}"
-                        script_path = Path(py_tokens[0])
+                        # Find the script token — commands may have trailing flags
+                        script_tokens = [t for t in resolved.split() if t.endswith((".py", ".sh"))]
+                        assert script_tokens, f"No script found in hook command: {cmd}"
+                        script_path = Path(script_tokens[0])
                         assert script_path.exists(), f"Hook script missing: {script_path} (event: {event})"
 
 


### PR DESCRIPTION
## Summary
- Replace the agent-type Stop hook with a command-type hook that returns a block decision, fixing the learn skill not running at session end
- The agent-type hook spawned a sub-agent without conversation context, so the learn skill had nothing to analyze
- Add `on_stop.sh` script with recursion guard and block decision JSON

Closes #212

## Test plan
- [ ] Verify the stop hook fires at session end and triggers the learn skill
- [ ] Verify the `stop_hook_active` guard prevents recursion on block-decision continuation
- [ ] Verify `suppressOutput` and `statusMessage` produce clean UX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Stop hook simplified to run a direct command that checks a runtime "stop" flag and exits silently when set.
  * If not stopped, the hook now returns a blocked response with suppressed output and an explicit instruction to run the learn workflow.

* **Tests**
  * Plugin tests updated to accept hook command scripts in either Python or shell formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->