### PR TITLE
feat(evolve-lite): unify sharing into scoped repos list (#217)

### DIFF
--- a/platform-integrations/bob/evolve-lite/README.md
+++ b/platform-integrations/bob/evolve-lite/README.md
@@ -8,7 +8,7 @@ A Bob integration that helps you learn from conversations by automatically extra
 
 - **Manual Learning**: Use `evolve-lite:learn` to extract and save guidelines from conversations
 - **Manual Retrieval**: Use `evolve-lite:recall` to retrieve and apply stored guidelines
-- **Guideline Sharing**: Publish your guidelines and subscribe to others' via Git repositories
+- **Guideline Sharing**: Subscribe to read-scope repos and publish to write-scope repos via Git
 
 ## Installation
 
@@ -27,17 +27,21 @@ This installs:
 
 ### Guideline Storage
 
-Guidelines are stored as individual markdown files in `.evolve/entities/`, organized by source:
+Guidelines are stored as individual markdown files in `.evolve/entities/`,
+organized by source. Both read-scope subscriptions and write-scope publish
+targets live under `entities/subscribed/{name}/`:
 
 ```text
 .evolve/entities/
-  guideline/                    # Private guidelines
+  guideline/                            # Private guidelines
     use-context-managers.md
-  public/                       # Your published guidelines
-    best-practice.md
   subscribed/
-    alice/                      # Guidelines from alice
-      her-guideline.md
+    memory/                             # write-scope clone (publishes land here)
+      guideline/
+        my-published-guideline.md
+    alice/                              # read-scope clone
+      guideline/
+        her-guideline.md
 ```
 
 Each file uses markdown with YAML frontmatter:
@@ -58,79 +62,111 @@ Context managers ensure proper resource cleanup
 
 ## Sharing Guidelines
 
-Evolve Lite supports sharing guidelines between users via public Git repositories. You can publish your own guidelines so others can subscribe to them, and subscribe to guidelines published by others.
+Evolve Lite treats shared guidelines as multi-reader / multi-writer git
+databases. A single unified `repos:` list in `evolve.config.yaml`
+describes every external guideline repo; each entry has a `scope` of
+`read` (subscribe only) or `write` (publish target that is also pulled
+on sync).
 
 ### Setup
 
-Sharing requires an `evolve.config.yaml` at the project root. If it doesn't exist, the subscribe or publish skills will prompt you to create one. Minimal structure:
+Sharing requires `evolve.config.yaml` at the project root. If it doesn't
+exist, the subscribe or publish skills will prompt you to create one.
+Minimal structure:
 
 ```yaml
 identity:
   user: yourname          # used to stamp ownership on published guidelines
-public_repo:
-  remote: git@github.com:yourname/evolve-guidelines.git
-  branch: main
-subscriptions: []
+
+repos:
+  - name: memory
+    scope: write
+    remote: git@github.com:yourname/evolve-memory.git
+    branch: main
+    notes: public memory for my open-source projects
+  - name: team
+    scope: read
+    remote: git@github.com:myorg/evolve-guidelines.git
+    branch: main
+
+sync:
+  on_session_start: false
 ```
 
-The `.evolve/` directory is kept out of version control — the skills automatically add it to `.gitignore`.
+The `.evolve/` directory is kept out of version control — the skills
+automatically add it to `.gitignore`.
 
-### Publishing Guidelines
+### Subscribing to a Repo
 
-Use `evolve-lite:publish` to share one or more of your local guidelines with others:
-
-1. The skill lists files in `.evolve/entities/guideline/`
-2. You pick which ones to publish
-3. Each selected file is moved to `.evolve/public/guideline/`, stamped with your username as the owner, committed, and pushed to your `public_repo.remote`
-
-Others can then subscribe using that remote URL.
-
-### Subscribing to Guidelines
-
-Use `evolve-lite:subscribe` to pull in guidelines from another user's public repo:
+Use `evolve-lite:subscribe` to add either a read-scope subscription or a
+write-scope publish target:
 
 ```text
 evolve-lite:subscribe
 > Remote URL: git@github.com:alice/evolve-guidelines.git
 > Short name: alice
+> Scope: read
 ```
 
-The repo is cloned directly into `.evolve/entities/subscribed/alice/` (this directory serves as both the git clone and the recall mirror).
+The repo is cloned directly into `.evolve/entities/subscribed/{name}/`
+(this directory serves as both the git clone and the recall mirror).
 
-### Syncing Subscriptions
+### Publishing Guidelines
 
-Use `evolve-lite:sync` to pull the latest changes from all subscribed repos:
+Use `evolve-lite:publish` to share local guidelines via a **write-scope** repo:
+
+1. The skill picks (or asks about) the write-scope target repo
+2. Lists files in `.evolve/entities/guideline/`
+3. You pick which ones to publish
+4. Each selected file is moved into the write-scope clone at
+   `.evolve/entities/subscribed/{repo}/guideline/`, stamped with your
+   username, committed, and pushed to the remote
+
+Because the publish target is also a subscribed repo, your next sync
+pulls in anything other writers have pushed to the same remote.
+
+### Syncing Repos
+
+Use `evolve-lite:sync` to pull the latest changes from every configured
+repo:
 
 ```text
 evolve-lite:sync
-> Synced 2 repo(s): alice (+2 added, 0 updated, 0 removed), bob (+0 added, 1 updated, 0 removed)
+> Synced 2 repo(s): memory [write] (+0 added, 1 updated, 0 removed), alice [read] (+2 added, 0 updated, 0 removed)
 ```
+
+Read-scope repos use `git fetch` + `git reset --hard`. Write-scope repos
+use `git fetch` + `git rebase` so any unpushed local publish commits are
+preserved.
 
 ### Unsubscribing
 
-Use `evolve-lite:unsubscribe` to remove a subscription and delete its locally cloned files:
+Use `evolve-lite:unsubscribe` to remove a configured repo and delete
+its locally cloned files:
 
 ```text
 evolve-lite:unsubscribe
-> Which subscription would you like to remove?
-> 1. alice
-> 2. bob
+> Which repo would you like to remove?
+> 1. memory [write]
+> 2. alice [read]
 ```
 
 The skill confirms before deleting `.evolve/entities/subscribed/{name}/`.
+Removing a write-scope repo will also discard any unpushed local
+publish commits, so the skill warns first.
 
 ### Sharing Storage Layout
 
 ```text
 .evolve/
-  public/                     # git repo pushed to your public remote
-    guideline/
-      guideline-name.md       # owner-stamped guideline
   entities/
-    guideline/                # your private guidelines
+    guideline/                      # your private guidelines
       my-guideline.md
     subscribed/
-      alice/                  # git clone (also serves as recall mirror)
+      memory/                       # write-scope clone (publishes land here)
+        guideline/
+          my-published-guideline.md
+      alice/                        # read-scope clone (also serves as recall mirror)
         guideline/
           her-guideline.md
 ```
@@ -147,38 +183,38 @@ Manually invoke to extract guidelines from the current conversation:
 ### `evolve-lite:recall`
 
 Manually invoke to retrieve and display stored guidelines:
-- Loads guidelines from private, public, and subscribed sources
+- Loads guidelines from private and subscribed sources
 - Formats and displays them for your review
 - Annotates subscribed guidelines with their source
 
 ### `evolve-lite:publish`
 
-Publish private guidelines to your public repository:
+Publish private guidelines to a write-scope repo:
 - Lists available private guidelines
-- Moves selected guidelines to `.evolve/public/`
-- Stamps with owner and published_at metadata
-- Commits and pushes to your public remote
+- Moves selected guidelines into the write-scope clone at
+  `.evolve/entities/subscribed/{repo}/guideline/`
+- Stamps with `owner`, `published_at`, and `source` metadata
+- Commits and pushes to the configured remote
 
 ### `evolve-lite:subscribe`
 
-Subscribe to another user's public guidelines:
-- Clones their public repository
-- Mirrors guidelines to `.evolve/entities/subscribed/`
-- Adds subscription to config
+Add a configured repo to the unified `repos:` list:
+- Clones the remote into `.evolve/entities/subscribed/{name}/`
+- Adds an entry with `scope: read` or `scope: write` to config
 
 ### `evolve-lite:sync`
 
-Sync all subscribed repositories:
-- Pulls latest changes from each subscription
-- Updates mirrored guidelines
+Sync every configured repo:
+- Read-scope: fetch + reset --hard (clobbers any local edits)
+- Write-scope: fetch + rebase (preserves unpushed local publishes)
 - Reports changes (added, updated, removed)
 
 ### `evolve-lite:unsubscribe`
 
-Remove a subscription:
-- Lists current subscriptions
-- Deletes selected subscription's local files
-- Removes from config
+Remove a configured repo:
+- Lists current repos with their scope and notes
+- Deletes the local clone at `.evolve/entities/subscribed/{name}/`
+- Removes the entry from config
 
 ## Environment Variables
 

--- a/platform-integrations/bob/evolve-lite/commands/evolve-lite:publish.md
+++ b/platform-integrations/bob/evolve-lite/commands/evolve-lite:publish.md
@@ -1,5 +1,5 @@
 ---
 name: evolve-lite:publish
-description: Publish a private guideline to your public repo
+description: Publish a private guideline to a configured write-scope repo
 ---
-Use the publish skill to share your private guidelines with others. Follow the skill's instructions exactly.
+Use the publish skill to share your private guidelines via a configured write-scope repo. Follow the skill's instructions exactly.

--- a/platform-integrations/bob/evolve-lite/commands/evolve-lite:subscribe.md
+++ b/platform-integrations/bob/evolve-lite/commands/evolve-lite:subscribe.md
@@ -1,5 +1,5 @@
 ---
 name: evolve-lite:subscribe
-description: Subscribe to another user's public guidelines repo
+description: Add a shared guidelines repo (read- or write-scope) to the unified repos list
 ---
-Use the subscribe skill to learn from others' guidelines. Follow the skill's instructions exactly.
+Use the subscribe skill to add a shared guidelines repo — either a read-scope subscription or a write-scope publish target. Follow the skill's instructions exactly.

--- a/platform-integrations/bob/evolve-lite/commands/evolve-lite:sync.md
+++ b/platform-integrations/bob/evolve-lite/commands/evolve-lite:sync.md
@@ -1,5 +1,5 @@
 ---
 name: evolve-lite:sync
-description: Pull the latest guidelines from all subscribed repos
+description: Pull the latest guidelines from every configured repo (read- and write-scope)
 ---
-Use the sync skill to update your subscribed guidelines. Follow the skill's instructions exactly.
+Use the sync skill to update your configured guidelines repos. Follow the skill's instructions exactly.

--- a/platform-integrations/bob/evolve-lite/commands/evolve-lite:unsubscribe.md
+++ b/platform-integrations/bob/evolve-lite/commands/evolve-lite:unsubscribe.md
@@ -1,5 +1,5 @@
 ---
 name: evolve-lite:unsubscribe
-description: Remove a subscription and delete locally synced guidelines
+description: Remove a repo from the unified repos list and delete its local clone
 ---
-Use the unsubscribe skill to remove a subscription. Follow the skill's instructions exactly.
+Use the unsubscribe skill to remove a configured repo and delete its local clone. Follow the skill's instructions exactly.

--- a/platform-integrations/bob/evolve-lite/skills/evolve-lite:publish/SKILL.md
+++ b/platform-integrations/bob/evolve-lite/skills/evolve-lite:publish/SKILL.md
@@ -1,47 +1,31 @@
 ---
 name: publish
-description: Publish a private guideline to your public repo so others can subscribe to it.
+description: Publish a private guideline to a configured write-scope repo.
 ---
 
-# Publish Guideline
+# Publish a Guideline
 
 ## Overview
 
-This skill publishes one or more private guidelines from your local `.evolve/entities/guideline/` directory to your public git repository, making them available for others to subscribe to.
+Publish one or more private guidelines from `.evolve/entities/guideline/`
+into a configured **write-scope** repo. The entity is stamped with
+`visibility: public`, `owner`, `published_at`, and `source`, moved into
+the local clone of the write repo, and committed / pushed to the remote.
+
+The same local clone is also what `evolve-lite:sync` pulls from — so you
+and anyone else publishing to the same repo stay in sync.
 
 ## Workflow
 
-### Step 1: Bootstrap config if missing or incomplete
+### Step 1: Require a write-scope repo
 
-Check whether `evolve.config.yaml` exists in the project root.
+Read `evolve.config.yaml`. If no entry has `scope: write`, tell the user:
 
-**If it does not exist**, ask the user:
+> "You need at least one write-scope repo to publish to. Run evolve-lite:subscribe with --scope write to set one up, then come back."
 
-> "No `evolve.config.yaml` found. What username would you like to use? (e.g. `vatche`)"
-> "What is the remote URL for your public guidelines repo? (e.g. `git@github.com:vatche/evolve-guidelines.git`)"
+Then stop.
 
-Create `evolve.config.yaml`:
-
-```yaml
-identity:
-  user: {username}
-public_repo:
-  remote: {remote}
-  branch: main
-subscriptions: []
-sync:
-  on_session_start: false
-```
-
-**If it exists** but `identity.user` is missing, ask for it and add it to the config.
-
-**If it exists** but `public_repo.remote` is missing, ask:
-
-> "What is the remote URL for your public guidelines repo? (e.g. `git@github.com:vatche/evolve-guidelines.git`)"
-
-Add it to the config.
-
-Read `identity.user` from config to use as `{user}` when stamping ownership.
+If `identity.user` is missing, ask for it and add it to the config.
 
 ### Step 2: First-time setup
 
@@ -51,52 +35,111 @@ Ensure `.evolve/` is gitignored at the project root:
 grep -qxF '.evolve/' .gitignore 2>/dev/null || echo '.evolve/' >> .gitignore
 ```
 
-If `.evolve/public/` does not already contain a `.git` directory, initialise it, create the branch, and add the remote:
+### Step 3: Pick the target write-scope repo
 
-```bash
-git init .evolve/public
-git -C .evolve/public checkout -b "{public_repo.branch}"
-git -C .evolve/public remote add origin {public_repo.remote}
-```
+Filter `repos:` to entries with `scope: write` (Step 1 already aborted if
+there were zero, so at least one exists here).
 
-Where `{public_repo.branch}` defaults to `main` if not set in config. Creating the branch explicitly ensures the subsequent push will succeed regardless of the system's `init.defaultBranch` setting.
+- Exactly one entry → use it as default.
+- Multiple entries → show a numbered list with `notes` and ask which to publish to.
 
-### Step 3: List and select entities
+Let `{repo}` be the chosen repo name and `{branch}` its configured branch (default `main`).
 
-List the files in `.evolve/entities/guideline/` (filenames only) and display them numbered. Ask the user:
+### Step 4: List and select entities
 
-> "Which guideline(s) would you like to publish? Enter a number or comma-separated list of numbers."
+List files in `.evolve/entities/guideline/` and ask the user which to publish.
 
-Wait for the user's selection.
+### Step 5: Run publish script
 
-### Step 4: Run publish script
-
-For each selected entity file, run:
+For each selected file, run:
 
 ```bash
 python3 scripts/publish.py \
   --entity "{filename}" \
+  --repo "{repo}" \
   --user "{identity.user}"
 ```
 
-### Step 5: Commit and push
+### Step 6: Commit and push
+
+Build `{names}` as a comma-joined list of selected filenames, and
+`{guideline_paths}` as a space-joined list of the corresponding
+`guideline/{filename}` paths inside the clone (the files the publish
+script just wrote).
 
 ```bash
-git -C .evolve/public add .
-git -C .evolve/public commit -m "[evolve] publish: {name}"
-git -C .evolve/public push origin "{public_repo.branch}"
+git -C ".evolve/entities/subscribed/{repo}" add -- {guideline_paths}
+git -C ".evolve/entities/subscribed/{repo}" commit -m "[evolve] publish: {names}"
+git -C ".evolve/entities/subscribed/{repo}" push origin "{branch}"
 ```
 
-Where `{public_repo.branch}` defaults to `main` if not set in config.
+On push success, continue to Step 7.
 
-### Step 6: Confirm
+### Step 6a: Recover from non-fast-forward rejection
 
-Tell the user:
+If the push fails and stderr mentions `rejected` / `non-fast-forward`
+/ `fetch first`, another writer pushed to `{branch}` in between.
+Rebase the local commit and push once more:
 
-> "Published {name} to {public_repo.remote}."
+```bash
+git -C ".evolve/entities/subscribed/{repo}" fetch origin "{branch}"
+git -C ".evolve/entities/subscribed/{repo}" rebase "origin/{branch}"
+```
+
+- Rebase clean → retry `git push origin "{branch}"` once, then Step 7.
+- Rebase conflicted → attempt to resolve, then hand off for user
+  review. Do not `git rebase --continue` or `git push` without an
+  explicit user confirmation.
+
+  1. `git -C ".evolve/entities/subscribed/{repo}" status --porcelain`
+     lists the conflicted paths. If any are `UD`, `DU`, or binary,
+     skip to the abort step — those aren't safe to auto-resolve.
+  2. For each `UU`/`AA` file, read the conflict markers. During a
+     rebase, `<<<<<<< HEAD` is the **remote's** version and the
+     section under the commit sha is the **publish change** being
+     replayed (opposite of a regular merge). Write an
+     intent-preserving resolution; don't `git add` yet.
+  3. Show the user the diff (`git -C ".evolve/entities/subscribed/{repo}" diff HEAD -- {file}`) per
+     resolved file with a one-line strategy summary, and ask whether
+     to **continue** (stage + `rebase --continue` + push) or **abort**
+     (roll back for manual resolution).
+  4. On **continue**:
+
+     ```bash
+     git -C ".evolve/entities/subscribed/{repo}" add {resolved-files}
+     git -C ".evolve/entities/subscribed/{repo}" rebase --continue
+     git -C ".evolve/entities/subscribed/{repo}" push origin "{branch}"
+     ```
+
+     Then Step 7. If `rebase --continue` surfaces a new conflict, loop
+     from step 1.
+  5. On **abort** — user declined, conflict isn't safely resolvable,
+     or the proposed merge feels unsafe:
+
+     ```bash
+     git -C ".evolve/entities/subscribed/{repo}" rebase --abort
+     ```
+
+     The local publish commit is preserved at
+     `.evolve/entities/subscribed/{repo}` but not on the remote. Tell
+     the user to either (a) resolve manually in that directory
+     (`git fetch origin {branch} && git rebase origin/{branch}`, fix
+     conflicts, `git add` + `git rebase --continue`, `git push origin
+     {branch}`) or (b) re-run `evolve-lite:publish` with a different
+     filename if the conflict is a shared name.
+
+If the push fails for any other reason (auth, network, missing remote
+ref), surface git's error and stop — rebase will not help.
+
+### Step 7: Confirm
+
+Tell the user what was published and to which repo.
 
 ## Notes
 
-- Published entities are **moved** from `.evolve/entities/guideline/` to `.evolve/public/guideline/` with `visibility: public`, `owner: {user}`, and `source` stamped in frontmatter
+- Published entities are **moved** from `.evolve/entities/guideline/` into
+  the write-scope clone at `.evolve/entities/subscribed/{repo}/guideline/`,
+  with `visibility: public`, `owner: {user}`, `published_at`, and `source`
+  stamped in frontmatter
 - The original private entity is deleted after successful publication
 - All publish actions are logged to `.evolve/audit.log`

--- a/platform-integrations/bob/evolve-lite/skills/evolve-lite:publish/scripts/publish.py
+++ b/platform-integrations/bob/evolve-lite/skills/evolve-lite:publish/scripts/publish.py
@@ -1,18 +1,13 @@
 #!/usr/bin/env python3
-"""Publish a private guideline entity to the public directory.
-
-- Moves source from .evolve/entities/guideline/{filename}
-- to .evolve/public/guideline/{filename}
-- Updates frontmatter: visibility=public, owner={user}, published_at={now}
-- Appends to audit.log
-"""
+"""Publish a private guideline entity to a write-scope repo (Bob)."""
 
 import argparse
 import datetime
 import os
 import re
 import sys
-from pathlib import Path
+import tempfile
+from pathlib import Path, PurePath
 
 # Smart import: walk up to find evolve-lib
 current = Path(__file__).resolve()
@@ -22,113 +17,137 @@ for parent in current.parents:
         sys.path.insert(0, str(lib_path))
         break
 
-from entity_io import markdown_to_entity, entity_to_markdown  # noqa: E402
-from audit import append as audit_append  # noqa: E402 # noqa: E402
-from config import load_config  # noqa: E402 # noqa: E402
+from audit import append as audit_append  # noqa: E402
+from config import get_repo, load_config, normalize_repos, write_repos  # noqa: E402
+from entity_io import entity_to_markdown, markdown_to_entity  # noqa: E402
 
 
-def _resolve_source(cfg, user_arg):
-    """Derive a source label from config or fallback to user arg."""
-    remote = cfg.get("public_repo", {})
-    if isinstance(remote, dict):
-        remote = remote.get("remote", "")
-    if remote:
-        # Extract user/repo from SSH or HTTPS remote URLs
-        m = re.search(r"[:/]([^/:]+/[^/]+?)(?:\.git)?$", remote)
-        if m:
-            return m.group(1)
-    identity = cfg.get("identity", {})
-    if isinstance(identity, dict) and identity.get("user"):
-        return identity["user"]
-    return user_arg
+def _resolve_source(repo, effective_user):
+    remote = repo.get("remote") if isinstance(repo, dict) else None
+    if isinstance(remote, str):
+        match = re.search(r"[:/]([^/:]+/[^/]+?)(?:\.git)?$", remote)
+        if match:
+            return match.group(1)
+    return effective_user
+
+
+def _select_target_repo(cfg, requested_name):
+    write = write_repos(cfg)
+
+    if requested_name:
+        repo = get_repo(cfg, requested_name)
+        if repo is None:
+            available = ", ".join(r["name"] for r in normalize_repos(cfg)) or "(none)"
+            return None, f"no repo named '{requested_name}' is configured. Configured repos: {available}"
+        if repo.get("scope") != "write":
+            return None, f"repo '{requested_name}' has scope={repo.get('scope')!r}; publish requires scope=write"
+        return repo, None
+
+    if not write:
+        return None, ("no write-scope repo configured. Run evolve-lite:subscribe with --scope write to set up a publish target.")
+    if len(write) > 1:
+        names = ", ".join(r["name"] for r in write)
+        return None, f"multiple write-scope repos configured; pick one with --repo. Available: {names}"
+    return write[0], None
 
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--entity", required=True, help="Basename of the .md file to publish")
     parser.add_argument("--user", default=None, help="Username to stamp as owner")
+    parser.add_argument("--repo", default=None, help="Write-scope repo name (optional if exactly one is configured)")
     args = parser.parse_args()
 
     evolve_dir = Path(os.environ.get("EVOLVE_DIR", ".evolve"))
+    resolved_evolve_dir = evolve_dir.resolve()
+    project_root = str(resolved_evolve_dir) if evolve_dir.name != ".evolve" else str(resolved_evolve_dir.parent)
 
-    # Validate entity name is a simple basename (no path separators or special components)
-    from pathlib import PurePath
-
-    if PurePath(args.entity).name != args.entity or args.entity in (".", ".."):
+    if PurePath(args.entity).name != args.entity or args.entity in {".", ".."}:
         print(f"Error: invalid entity name: {args.entity!r}", file=sys.stderr)
         sys.exit(1)
 
-    # Check for symlinks before resolving
-    original_path = evolve_dir / "entities" / "guideline" / args.entity
-    if original_path.is_symlink():
-        print(f"Error: cannot publish symlinked entity: {args.entity}", file=sys.stderr)
-        sys.exit(1)
-
-    # Validate entity name: resolve and confirm it stays within the intended dir
     src_base = (evolve_dir / "entities" / "guideline").resolve()
-    src_path = original_path.resolve()
+    src_path = (evolve_dir / "entities" / "guideline" / args.entity).resolve()
+
     if not src_path.is_relative_to(src_base):
         print(f"Error: invalid entity name: {args.entity!r}", file=sys.stderr)
         sys.exit(1)
 
-    if not src_path.exists():
-        print(f"Error: entity file not found: {src_path}", file=sys.stderr)
+    if not src_path.is_file():
+        print(f"Error: entity file not found or is a directory: {src_path}", file=sys.stderr)
         sys.exit(1)
 
-    # Parse entity
+    config = load_config(project_root)
+    target, err = _select_target_repo(config, args.repo)
+    if err is not None:
+        print(f"Error: {err}", file=sys.stderr)
+        sys.exit(1)
+
+    identity = config.get("identity", {})
+    effective_user = args.user or (identity.get("user") if isinstance(identity, dict) else None)
+
     entity = markdown_to_entity(src_path)
-
-    # Update frontmatter fields
     entity["visibility"] = "public"
+    if effective_user:
+        entity["owner"] = effective_user
     entity["published_at"] = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-    cfg = load_config(str(evolve_dir.resolve().parent))
-
-    # Determine user: prefer args.user, fallback to cfg.identity.user
-    user = args.user
-    if not user:
-        identity = cfg.get("identity", {})
-        if isinstance(identity, dict):
-            user = identity.get("user")
-
-    if user:
-        entity["owner"] = user
-
-    source = _resolve_source(cfg, args.user)
+    source = _resolve_source(target, effective_user)
     if source:
         entity["source"] = source
 
-    # Write to public directory
-    dest_dir = evolve_dir / "public" / "guideline"
+    clone_root = evolve_dir / "entities" / "subscribed" / target["name"]
+    if not (clone_root / ".git").exists():
+        print(
+            f"Error: target repo clone not found at {clone_root}. "
+            f"Run evolve-lite:subscribe with --scope write first, or evolve-lite:sync "
+            f"to clone it.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    dest_dir = clone_root / "guideline"
     dest_dir.mkdir(parents=True, exist_ok=True)
     dest_base = dest_dir.resolve()
     dest_path = (dest_dir / args.entity).resolve()
     if not dest_path.is_relative_to(dest_base):
         print(f"Error: invalid entity name: {args.entity!r}", file=sys.stderr)
         sys.exit(1)
-
     if dest_path.exists():
         print(f"Error: already published: {dest_path}\nUnpublish it first or delete it manually.", file=sys.stderr)
         sys.exit(1)
 
-    # Write to temp file in destination directory first, then atomic move
-    content = entity_to_markdown(entity)
-    temp_path = dest_path.with_suffix(".tmp")
-    temp_path.write_text(content, encoding="utf-8")
-    temp_path.replace(dest_path)
-    original_path.unlink()
+    temp_path = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=dest_dir,
+            prefix=f".{args.entity}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temp_file:
+            temp_file.write(entity_to_markdown(entity))
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+            temp_path = Path(temp_file.name)
 
-    # Audit log (don't let audit failures break the operation)
+        temp_path.replace(dest_path)
+        src_path.unlink()
+    finally:
+        if temp_path is not None and temp_path.exists():
+            temp_path.unlink()
+
     try:
         audit_append(
-            project_root=str(evolve_dir.resolve().parent),
+            project_root=project_root,
             action="publish",
-            actor=user or "unknown",
+            actor=effective_user or "unknown",
             entity=args.entity,
+            repo=target["name"],
         )
-    except Exception as e:
-        print(f"Warning: failed to write audit log: {e}", file=sys.stderr)
+    except Exception as exc:
+        print(f"Warning: failed to append audit entry for publish: {exc}", file=sys.stderr)
 
-    print(f"Published: {args.entity} -> {dest_path}")
+    print(f"Published: {args.entity} -> {dest_path} (repo: {target['name']})")
 
 
 if __name__ == "__main__":

--- a/platform-integrations/bob/evolve-lite/skills/evolve-lite:recall/SKILL.md
+++ b/platform-integrations/bob/evolve-lite/skills/evolve-lite:recall/SKILL.md
@@ -11,20 +11,24 @@ This skill retrieves relevant entities from a stored knowledge base based on the
 
 Entities can come from multiple sources:
 - **Private entities**: Your own local entities (not shared)
-- **Public entities**: Your own entities marked for sharing
-- **Subscribed entities**: Entities from other users you've subscribed to
+- **Subscribed entities**: Entities cloned from any configured repo —
+  read-scope subscriptions and write-scope publish targets both live
+  under `.evolve/entities/subscribed/{name}/`
 
 ## How It Works
 
-1. List all `.md` files under `.evolve/entities/`, `.evolve/public/`, and their subdirectories
-2. Read each file — the YAML frontmatter contains `type` and `trigger`, the body contains the entity content and rationale
+1. List all `.md` files under `.evolve/entities/` and its subdirectories
+2. Read each file — the YAML frontmatter contains `type` and `trigger`,
+   the body contains the entity content and rationale
 3. Review each entity for relevance to the current task
 4. Apply relevant entities as additional context for your work
 
 **Directory structure**:
 - `.evolve/entities/guideline/` - Your private entities
-- `.evolve/entities/subscribed/{name}/` - Mirrored entities from subscriptions
-- `.evolve/public/guideline/` - Your published entities
+- `.evolve/entities/subscribed/{name}/` - Cloned repos (read- or write-scope)
+
+Write-scope clones are also where `evolve-lite:publish` lands new
+guidelines, so your published entities show up here too.
 
 ## Usage
 
@@ -32,26 +36,25 @@ Entities can come from multiple sources:
 python3 scripts/retrieve_entities.py
 ```
 
-This retrieves all entities from all sources (private, public, and subscribed).
+This retrieves all entities from all sources (private, plus everything
+under `.evolve/entities/subscribed/`).
 
 ## Entities Storage
 
-Entities are stored as individual markdown files in `.evolve/entities/`, organized by source:
+Entities are stored as individual markdown files in `.evolve/entities/`,
+organized by source:
 
 ```text
 .evolve/entities/
-  guideline/                    # Private entities
+  guideline/                            # Private entities
     use-context-managers.md
-  public/                       # Your published entities
-    guideline/
-      cache-api-responses.md
-  subscribed/                   # Entities from others
-    alice/
+  subscribed/
+    memory/                             # write-scope clone (publishes land here)
+      guideline/
+        my-published-guideline.md
+    alice/                              # read-scope clone
       guideline/
         error-handling.md
-    bob-team/
-      policy/
-        code-review.md
 ```
 
 Each file uses markdown with YAML frontmatter:

--- a/platform-integrations/bob/evolve-lite/skills/evolve-lite:recall/scripts/retrieve_entities.py
+++ b/platform-integrations/bob/evolve-lite/skills/evolve-lite:recall/scripts/retrieve_entities.py
@@ -12,7 +12,7 @@ for parent in current.parents:
         sys.path.insert(0, str(lib_path))
         break
 
-from entity_io import find_entities_dir, get_evolve_dir, markdown_to_entity, log as _log  # noqa: E402
+from entity_io import find_entities_dir, markdown_to_entity, log as _log  # noqa: E402
 
 
 def log(message):
@@ -53,29 +53,32 @@ def load_entities_with_source(entities_dir):
     """Glob all .md files under entities_dir and parse each.
 
     Entities stored under entities/subscribed/{name}/ have ``_source`` set to
-    the subscription name so format_entities can annotate them. The owner field
-    written by publish.py is preserved; _source is just a routing key used
-    internally and is never written to disk.
+    the repo name so format_entities can annotate them. Both read-scope and
+    write-scope clones live under entities/subscribed/{name}/, so write-scope
+    publishes land in this same path and are picked up automatically.
+
+    Symlinks and any files inside a ``.git`` directory are skipped so we
+    don't surface git's own bookkeeping or sneak past path validation.
     """
     entities_dir = Path(entities_dir)
     entities = []
-    for md in sorted(entities_dir.glob("**/*.md")):
+    for md in sorted(p for p in entities_dir.glob("**/*.md") if ".git" not in p.parts):
         if md.is_symlink():
             continue
         try:
             entity = markdown_to_entity(md)
-            entity.pop("_source", None)
-            if not entity.get("content"):
-                continue
-            try:
-                rel_parts = md.relative_to(entities_dir).parts
-            except ValueError:
-                rel_parts = md.parts
-            if rel_parts[0] == "subscribed" and len(rel_parts) > 1:
-                entity["_source"] = rel_parts[1]
-            entities.append(entity)
         except (OSError, UnicodeDecodeError):
-            pass
+            continue
+        entity.pop("_source", None)
+        if not entity.get("content"):
+            continue
+        try:
+            rel_parts = md.relative_to(entities_dir).parts
+        except ValueError:
+            rel_parts = md.parts
+        if rel_parts and rel_parts[0] == "subscribed" and len(rel_parts) > 1:
+            entity["_source"] = rel_parts[1]
+        entities.append(entity)
     return entities
 
 
@@ -88,11 +91,6 @@ def main():
     entities = []
     if entities_dir:
         entities = load_entities_with_source(entities_dir)
-
-    public_dir = get_evolve_dir() / "public"
-    if public_dir.is_dir():
-        log(f"Loading public entities from: {public_dir}")
-        entities += load_entities_with_source(public_dir)
 
     if not entities:
         log("No entities found")

--- a/platform-integrations/bob/evolve-lite/skills/evolve-lite:subscribe/SKILL.md
+++ b/platform-integrations/bob/evolve-lite/skills/evolve-lite:subscribe/SKILL.md
@@ -1,30 +1,44 @@
 ---
 name: subscribe
-description: Subscribe to another user's public guidelines repo.
+description: Add a shared guidelines repo (read-scope subscription or write-scope publish target) to the unified repos list.
 ---
 
-# Subscribe to Guidelines
+# Subscribe to a Shared Repo
 
 ## Overview
 
-This skill subscribes to another user's public guidelines repository. Their guidelines will be cloned locally and made available in your recall context.
+Configured guidelines repos are multi-reader / multi-writer git databases,
+described in a single unified list in `evolve.config.yaml`:
+
+```yaml
+repos:
+  - name: memory
+    scope: write
+    remote: git@github.com:alice/evolve.git
+    branch: main
+    notes: public memory for foobar project
+  - name: org-memory
+    scope: read
+    remote: git@github.com:acme/org-memory.git
+    branch: main
+    notes: private memory shared only within my org
+```
+
+- `scope: read` — download-only. Synced on every run.
+- `scope: write` — publish target. Synced on every run too, so you see
+  what you have already published and anything others have pushed.
 
 ## Workflow
 
 ### Step 1: Bootstrap config if missing
 
-Check whether `evolve.config.yaml` exists in the project root.
-
-If it does **not** exist, ask the user:
-
-> "No `evolve.config.yaml` found. What username would you like to use? (e.g. `vatche`)"
-
-Then create `evolve.config.yaml` with this minimal content:
+If `evolve.config.yaml` does not exist, ask the user for a username and
+create:
 
 ```yaml
 identity:
   user: {username}
-subscriptions: []
+repos: []
 sync:
   on_session_start: false
 ```
@@ -37,39 +51,34 @@ grep -qxF '.evolve/' .gitignore 2>/dev/null || echo '.evolve/' >> .gitignore
 
 ### Step 2: Gather details
 
-Ask the user:
+Ask the user for:
 
-> "What is the remote URL for the guidelines repo? (e.g. `git@github.com:alice/evolve-guidelines.git`)"
+- the remote URL for the guidelines repo
+- a short local name such as `alice`
+- the scope: `read` (default, subscribe-only) or `write` (also a publish target)
+- an optional note
 
-Then ask:
-
-> "What short name would you like for this subscription? (e.g. `alice`)"
-
-### Step 3: Check for duplicates
-
-Read `evolve.config.yaml` from the project root. If the name already exists in the `subscriptions` list, tell the user:
-
-> "A subscription named '{name}' already exists. Please unsubscribe first or choose a different name."
-
-Then stop.
-
-### Step 4: Run subscribe script
+### Step 3: Run subscribe script
 
 ```bash
 python3 scripts/subscribe.py \
   --name "{name}" \
   --remote "{remote}" \
-  --branch main
+  --branch main \
+  --scope "{scope}" \
+  --notes "{notes}"
 ```
 
-### Step 5: Confirm
+### Step 4: Confirm
 
-Tell the user:
-
-> "Subscribed to {name}. Run evolve-lite:sync to pull their guidelines."
+Tell the user the repo was added and they can run `evolve-lite:sync`
+immediately if they want to pull updates now.
 
 ## Notes
 
-- Subscribed repos are cloned to `.evolve/subscribed/{name}/`
-- After subscribing, run `evolve-lite:sync` to mirror entities to `.evolve/entities/subscribed/{name}/`
-- Subscribed entities will appear in recall with `[from: {name}]` annotations
+- The repo is cloned directly into `.evolve/entities/subscribed/{name}/`,
+  which doubles as the recall mirror
+- Subscribed entities will appear in recall with `[from: {name}]`
+  annotations
+- Read-scope repos use a shallow clone; write-scope repos use a full
+  clone so publish commits can be rebased and pushed cleanly

--- a/platform-integrations/bob/evolve-lite/skills/evolve-lite:subscribe/scripts/subscribe.py
+++ b/platform-integrations/bob/evolve-lite/skills/evolve-lite:subscribe/scripts/subscribe.py
@@ -1,13 +1,9 @@
 #!/usr/bin/env python3
-"""Subscribe to another user's public guidelines repo.
-
-- Adds entry to subscriptions list in evolve.config.yaml
-- Clones the remote into .evolve/entities/subscribed/{name}
-- Appends to audit.log
-"""
+"""Add a repo to the unified ``repos`` list and clone it locally (Bob)."""
 
 import argparse
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -20,109 +16,88 @@ for parent in current.parents:
         sys.path.insert(0, str(lib_path))
         break
 
-from config import load_config, save_config  # noqa: E402
 from audit import append as audit_append  # noqa: E402
-
-_GIT_TIMEOUT = 30  # seconds
+from config import (  # noqa: E402
+    VALID_SCOPES,
+    is_valid_repo_name,
+    load_config,
+    normalize_repos,
+    save_config,
+    set_repos,
+)
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--name", required=True, help="Short subscription name (e.g. alice)")
+    parser.add_argument("--name", required=True, help="Short repo name")
     parser.add_argument("--remote", required=True, help="Git remote URL")
-    parser.add_argument("--branch", default="main", help="Branch to track (default: main)")
+    parser.add_argument("--branch", default="main", help="Branch to track")
+    parser.add_argument("--scope", default="read", choices=VALID_SCOPES)
+    parser.add_argument("--notes", default="")
     args = parser.parse_args()
 
     evolve_dir = Path(os.environ.get("EVOLVE_DIR", ".evolve"))
-    project_root = str(evolve_dir.resolve().parent)
-
-    # Validate name: resolve and confirm it stays within the subscribed directory
+    project_root = str(evolve_dir.resolve()) if evolve_dir.name != ".evolve" else str(evolve_dir.resolve().parent)
     subscribed_base = (evolve_dir / "entities" / "subscribed").resolve()
     dest = (evolve_dir / "entities" / "subscribed" / args.name).resolve()
-    if not dest.is_relative_to(subscribed_base) or dest == subscribed_base:
+
+    if not is_valid_repo_name(args.name) or dest == subscribed_base or not dest.is_relative_to(subscribed_base):
         print(f"Error: invalid subscription name: {args.name!r}", file=sys.stderr)
         sys.exit(1)
 
     cfg = load_config(project_root)
+    repos = normalize_repos(cfg)
 
-    # Ensure subscriptions list exists
-    subscriptions = cfg.get("subscriptions", [])
-    if not isinstance(subscriptions, list):
-        subscriptions = []
-
-    # Check for duplicate
-    for sub in subscriptions:
-        if isinstance(sub, dict) and sub.get("name") == args.name:
-            print(
-                f"Error: subscription '{args.name}' already exists in config.",
-                file=sys.stderr,
-            )
+    for repo in repos:
+        if repo.get("name") == args.name:
+            print(f"Error: subscription '{args.name}' already exists in config.", file=sys.stderr)
             sys.exit(1)
 
-    # Clone the repo
-    cloned_now = False
     if dest.exists():
-        print(
-            f"Error: directory already exists: {dest}\nRun evolve-lite:unsubscribe to remove it before re-subscribing.",
-            file=sys.stderr,
-        )
+        print(f"Error: destination already exists: {dest}", file=sys.stderr)
         sys.exit(1)
 
     dest.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        subprocess.run(
-            [
-                "git",
-                "clone",
-                args.remote,
-                str(dest),
-                "--branch",
-                args.branch,
-                "--depth",
-                "1",
-            ],
-            check=True,
-            capture_output=True,
-            text=True,
-            timeout=_GIT_TIMEOUT,
-        )
-        cloned_now = True
-    except subprocess.TimeoutExpired:
-        print(f"Error: git clone timed out after {_GIT_TIMEOUT} seconds", file=sys.stderr)
-        sys.exit(1)
-    except subprocess.CalledProcessError as e:
-        print(f"Error: git clone failed: {e.stderr}", file=sys.stderr)
-        sys.exit(1)
+    # Write-scope repos need full history so the user can safely rebase and
+    # push publish commits. Read-scope repos only mirror, so shallow is enough.
+    clone_cmd = ["git", "clone", args.remote, str(dest), "--branch", args.branch]
+    if args.scope == "read":
+        clone_cmd += ["--depth", "1"]
+    subprocess.run(clone_cmd, check=True)
 
-    # Update config and audit - rollback clone on failure
+    repos.append(
+        {
+            "name": args.name,
+            "scope": args.scope,
+            "remote": args.remote,
+            "branch": args.branch,
+            "notes": args.notes,
+        }
+    )
+    set_repos(cfg, repos)
     try:
-        subscriptions.append({"name": args.name, "remote": args.remote, "branch": args.branch})
-        cfg["subscriptions"] = subscriptions
         save_config(cfg, project_root)
-
-        # Read identity.user for audit
-        identity = cfg.get("identity", {})
-        actor = identity.get("user", "unknown") if isinstance(identity, dict) else "unknown"
-
-        try:
-            audit_append(
-                project_root=project_root,
-                action="subscribe",
-                actor=actor,
-                name=args.name,
-                remote=args.remote,
-            )
-        except Exception as e:
-            print(f"Warning: audit log failed: {e}", file=sys.stderr)
     except Exception:
-        # Rollback: remove cloned directory if config save failed
-        if cloned_now and dest.exists():
-            import shutil
-
+        repos.pop()
+        if dest.exists():
             shutil.rmtree(dest)
         raise
 
-    print(f"Subscribed to '{args.name}' from {args.remote}")
+    identity = cfg.get("identity", {})
+    actor = identity.get("user", "unknown") if isinstance(identity, dict) else "unknown"
+    try:
+        audit_append(
+            project_root=project_root,
+            action="subscribe",
+            actor=actor,
+            name=args.name,
+            scope=args.scope,
+            remote=args.remote,
+        )
+    except Exception as exc:
+        print(f"Warning: failed to append audit entry for subscribe: {exc}", file=sys.stderr)
+
+    print(f"Subscribed to '{args.name}' (scope={args.scope}) from {args.remote}")
 
 
 if __name__ == "__main__":

--- a/platform-integrations/bob/evolve-lite/skills/evolve-lite:subscribe/scripts/subscribe.py
+++ b/platform-integrations/bob/evolve-lite/skills/evolve-lite:subscribe/scripts/subscribe.py
@@ -95,7 +95,16 @@ def main():
             remote=args.remote,
         )
     except Exception as exc:
-        print(f"Warning: failed to append audit entry for subscribe: {exc}", file=sys.stderr)
+        repos.pop()
+        set_repos(cfg, repos)
+        try:
+            save_config(cfg, project_root)
+        except Exception:
+            pass
+        if dest.exists():
+            shutil.rmtree(dest)
+        print(f"Error: failed to record subscription — clone removed: {exc}", file=sys.stderr)
+        sys.exit(1)
 
     print(f"Subscribed to '{args.name}' (scope={args.scope}) from {args.remote}")
 

--- a/platform-integrations/bob/evolve-lite/skills/evolve-lite:sync/SKILL.md
+++ b/platform-integrations/bob/evolve-lite/skills/evolve-lite:sync/SKILL.md
@@ -1,15 +1,19 @@
 ---
 name: sync
-description: Pull the latest guidelines from all subscribed repos.
+description: Pull the latest guidelines from every configured repo (read- and write-scope).
 ---
 
-# Sync Subscriptions
+# Sync Repos
 
 ## Overview
 
-This skill pulls the latest guidelines from all repos you have subscribed to, keeping your local copies up to date.
+Pull the latest guidelines from every repo in `evolve.config.yaml`
+`repos:` list — both `scope: read` (subscribe-only) and `scope: write`
+(publish targets). Write-scope repos use a rebase strategy so any
+unpushed local publish commits are preserved.
 
-**Note**: Unlike Claude Code, Bob does not auto-sync on session start. You must manually invoke this skill when you want to update subscribed guidelines.
+**Note**: Unlike Claude Code, Bob does not auto-sync on session start.
+You must invoke this skill manually when you want to update guidelines.
 
 ## Workflow
 
@@ -21,18 +25,14 @@ python3 scripts/sync.py
 
 ### Step 2: Display summary
 
-Display the summary output from the script to the user. For example:
-
-> "Synced 2 repo(s): alice (+2 added, 0 updated, 0 removed), bob (+0 added, 1 updated, 0 removed)"
-
-If there is nothing to report (no subscriptions or no changes), confirm:
-
-> "All subscriptions are up to date."
+Show the script output to the user. If there are no repos configured,
+tell them they can add one with `evolve-lite:subscribe`. If there are
+no changes, explain that everything is already up to date.
 
 ## Notes
 
-- This skill must be invoked manually (no auto-sync on session start)
-- Pulls latest changes from all subscribed repos
-- Mirrors entities to `.evolve/entities/subscribed/{name}/` for recall
-- Updates are logged to `.evolve/audit.log`
+- Read-scope repos are mirrored exactly via `git fetch` + `git reset --hard`
+- Write-scope repos use `git fetch` + `git rebase` so unpushed local
+  publish commits are preserved
+- Sync results are logged to `.evolve/audit.log`
 - Run this periodically to stay up to date with shared guidelines

--- a/platform-integrations/bob/evolve-lite/skills/evolve-lite:sync/scripts/sync.py
+++ b/platform-integrations/bob/evolve-lite/skills/evolve-lite:sync/scripts/sync.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-"""Pull the latest guidelines from all subscribed repos.
+"""Pull the latest guidelines from every configured repo (Bob).
 
-Subscribed repos are cloned directly into .evolve/entities/subscribed/{name}/
-so the recall hook can read them without a separate mirror step.
+Read-scope repos are mirrored exactly via fetch + reset --hard; write-scope
+repos use fetch + rebase so any unpushed local publish commits are preserved.
 
 Usage:
   --quiet        Suppress output if no changes.
@@ -11,7 +11,6 @@ Usage:
 
 import argparse
 import os
-import re
 import subprocess
 import sys
 from pathlib import Path
@@ -24,58 +23,48 @@ for parent in current.parents:
         sys.path.insert(0, str(lib_path))
         break
 
-from config import load_config  # noqa: E402
 from audit import append as audit_append  # noqa: E402
+from config import is_valid_repo_name, load_config, normalize_repos  # noqa: E402
 
 
 _GIT_TIMEOUT = 30  # seconds
 
 
-def git_sync(repo_path, branch):
-    """Fetch and hard-reset to origin. Returns CompletedProcess, or None on timeout.
-
-    Hard reset ensures local clone always matches remote exactly — restores deleted
-    files, discards any local modifications. Subscribed repos are read-only mirrors
-    so there is nothing worth preserving locally.
-    """
+def _git(repo_path, *args, timeout=_GIT_TIMEOUT):
     try:
-        fetch = subprocess.run(
-            ["git", "-C", str(repo_path), "fetch", "origin", branch],
-            capture_output=True,
-            text=True,
-            timeout=_GIT_TIMEOUT,
-        )
-        if fetch.returncode != 0:
-            return fetch
         return subprocess.run(
-            ["git", "-C", str(repo_path), "reset", "--hard", f"origin/{branch}"],
+            ["git", "-C", str(repo_path), *args],
             capture_output=True,
             text=True,
-            timeout=_GIT_TIMEOUT,
+            timeout=timeout,
         )
     except subprocess.TimeoutExpired:
-        print(f"Warning: git sync timed out for {repo_path} (branch: {branch})", file=sys.stderr)
         return None
 
 
+def sync_read_only(repo_path, branch):
+    """Fetch and hard-reset to origin/{branch} (read-only mirror)."""
+    fetch = _git(repo_path, "fetch", "origin", branch)
+    if fetch is None or fetch.returncode != 0:
+        return fetch
+    return _git(repo_path, "reset", "--hard", f"origin/{branch}")
+
+
+def sync_writable(repo_path, branch):
+    """Fetch and rebase local commits onto origin/{branch} (preserves publishes)."""
+    fetch = _git(repo_path, "fetch", "origin", branch)
+    if fetch is None or fetch.returncode != 0:
+        return fetch
+    rebase = _git(repo_path, "rebase", f"origin/{branch}")
+    if rebase is None or rebase.returncode != 0:
+        _git(repo_path, "rebase", "--abort")
+        return rebase
+    return rebase
+
+
 def count_delta(repo_path):
-    """Count added/modified/deleted .md files since last pull.
-
-    Returns dict: {added: int, updated: int, removed: int}
-    """
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(repo_path), "diff", "--name-status", "HEAD@{1}", "HEAD"],
-            capture_output=True,
-            text=True,
-            timeout=_GIT_TIMEOUT,
-        )
-    except subprocess.TimeoutExpired:
-        print(f"Warning: git diff timed out for {repo_path} after {_GIT_TIMEOUT} seconds", file=sys.stderr)
-        return {"added": 0, "updated": 0, "removed": 0}
-
-    if result.returncode != 0:
-        # HEAD@{1} doesn't exist (initial sync) — count all .md files as added
+    result = _git(repo_path, "diff", "--name-status", "HEAD@{1}", "HEAD")
+    if result is None or result.returncode != 0:
         added = len(list(repo_path.glob("**/*.md")))
         return {"added": added, "updated": 0, "removed": 0}
     added = updated = removed = 0
@@ -109,25 +98,20 @@ def main():
 
     evolve_dir = Path(os.environ.get("EVOLVE_DIR", ".evolve"))
 
-    # Determine project_root from config path or EVOLVE_DIR
     if args.config:
-        # Derive project_root from the directory containing the config file
         config_path = Path(args.config).resolve()
         project_root = str(config_path.parent)
     elif "EVOLVE_DIR" in os.environ:
-        project_root = str(evolve_dir.parent)
+        project_root = str(evolve_dir.resolve().parent)
     else:
         project_root = "."
 
     cfg = load_config(project_root)
+    repos = normalize_repos(cfg)
 
-    subscriptions = cfg.get("subscriptions", [])
-    if not isinstance(subscriptions, list):
-        subscriptions = []
-
-    if not subscriptions:
+    if not repos:
         if not args.quiet:
-            print("No subscriptions configured.")
+            print("No subscriptions configured. Add one with the evolve-lite:subscribe skill to start syncing shared guidelines.")
         sys.exit(0)
 
     identity = cfg.get("identity", {})
@@ -137,62 +121,87 @@ def main():
     total_delta = {}
     any_changes = False
 
-    _SAFE_NAME = re.compile(r"^[A-Za-z0-9._-]+$")
-    subscribed_base = (evolve_dir / "entities" / "subscribed").resolve()
+    for repo in repos:
+        raw_name = repo.get("name", "unknown")
+        scope = repo.get("scope", "read")
+        branch = repo.get("branch", "main")
+        remote = repo.get("remote")
 
-    for sub in subscriptions:
-        if not isinstance(sub, dict):
+        if not is_valid_repo_name(raw_name):
+            summaries.append(f"{raw_name!r} (skipped — invalid subscription name)")
             continue
-        name = sub.get("name", "unknown")
-        branch = sub.get("branch", "main")
+        name = raw_name.strip()
 
-        # Reject path traversal attempts and non-string names
-        if not isinstance(name, str) or name in {".", ".."} or not _SAFE_NAME.match(name):
+        if not isinstance(branch, str) or not branch.strip():
+            summaries.append(f"{raw_name!r} (skipped — invalid subscription config)")
+            continue
+        branch = branch.strip()
+
+        subscribed_base = (evolve_dir / "entities" / "subscribed").resolve()
+        repo_path = (evolve_dir / "entities" / "subscribed" / name).resolve()
+
+        if repo_path == subscribed_base or not repo_path.is_relative_to(subscribed_base):
             summaries.append(f"{name!r} (skipped — invalid subscription name)")
             continue
 
-        repo_path = evolve_dir / "entities" / "subscribed" / name
-
-        # Defense-in-depth: verify resolved path is within subscribed directory
-        repo_path_resolved = repo_path.resolve()
-        if not repo_path_resolved.is_relative_to(subscribed_base) or repo_path_resolved == subscribed_base:
-            summaries.append(f"{name!r} (skipped — path traversal detected)")
-            continue
-
         if not repo_path.is_dir():
-            summaries.append(f"{name} (not cloned — run evolve-lite:subscribe first)")
-            continue
+            if not remote:
+                summaries.append(f"{name} (not cloned)")
+                continue
+            repo_path.parent.mkdir(parents=True, exist_ok=True)
+            clone_cmd = ["git", "clone", "--branch", branch]
+            if scope == "read":
+                clone_cmd += ["--depth", "1"]
+            clone_cmd += ["--", remote, str(repo_path)]
+            try:
+                clone_result = subprocess.run(
+                    clone_cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=_GIT_TIMEOUT,
+                )
+            except subprocess.TimeoutExpired:
+                summaries.append(f"{name} (re-clone failed — timeout)")
+                total_delta[name] = {"added": 0, "updated": 0, "removed": 0}
+                any_changes = True
+                continue
+            if clone_result.returncode != 0:
+                summaries.append(f"{name} (re-clone failed: {clone_result.stderr.strip()})")
+                total_delta[name] = {"added": 0, "updated": 0, "removed": 0}
+                any_changes = True
+                continue
 
-        pull_result = git_sync(repo_path, branch)
-        if pull_result is None or pull_result.returncode != 0:
-            summaries.append(f"{name} (sync failed — skipping)")
+        if scope == "write":
+            pull_result = sync_writable(repo_path, branch)
+        else:
+            pull_result = sync_read_only(repo_path, branch)
+
+        if pull_result is None:
+            summaries.append(f"{name} (sync failed — timeout)")
             total_delta[name] = {"added": 0, "updated": 0, "removed": 0}
+            any_changes = True
+            continue
+        if pull_result.returncode != 0:
+            error_lines = (pull_result.stderr or pull_result.stdout or "").strip().splitlines()
+            short_error = error_lines[-1] if error_lines else f"git exited with {pull_result.returncode}"
+            summaries.append(f"{name} (sync failed: {short_error})")
+            total_delta[name] = {"added": 0, "updated": 0, "removed": 0}
+            any_changes = True
             continue
 
         delta = count_delta(repo_path)
         total_delta[name] = delta
-
-        has_changes = any(v > 0 for v in delta.values())
-        if has_changes:
+        if any(value > 0 for value in delta.values()):
             any_changes = True
 
-        delta_str = f"+{delta['added']} added, {delta['updated']} updated, {delta['removed']} removed"
-        summaries.append(f"{name} ({delta_str})")
+        summaries.append(f"{name} [{scope}] (+{delta['added']} added, {delta['updated']} updated, {delta['removed']} removed)")
 
-    # Audit
-    audit_append(
-        project_root=project_root,
-        action="sync",
-        actor=actor,
-        delta=total_delta,
-    )
+    audit_append(project_root=project_root, action="sync", actor=actor, delta=total_delta)
 
     if args.quiet and not any_changes:
         sys.exit(0)
 
-    n = len(summaries)
-    summary_line = f"Synced {n} repo(s): " + ", ".join(summaries)
-    print(summary_line)
+    print(f"Synced {len(summaries)} repo(s): " + ", ".join(summaries))
 
 
 if __name__ == "__main__":

--- a/platform-integrations/bob/evolve-lite/skills/evolve-lite:unsubscribe/SKILL.md
+++ b/platform-integrations/bob/evolve-lite/skills/evolve-lite:unsubscribe/SKILL.md
@@ -1,53 +1,49 @@
 ---
 name: unsubscribe
-description: Remove a subscription and delete the locally synced guidelines.
+description: Remove a repo from the unified repos list and delete its local clone.
 ---
 
-# Unsubscribe from Guidelines
+# Remove a Repo
 
 ## Overview
 
-This skill removes a subscription and deletes the locally cloned guidelines for that subscription.
+Remove a configured repo (any scope) from `evolve.config.yaml` and delete
+its local clone at `.evolve/entities/subscribed/{name}/`. Warn the user
+before removing a write-scope repo since any unpushed local publish
+commits will be lost.
 
 ## Workflow
 
-### Step 1: List subscriptions
+### Step 1: List repos
 
-Run the following and display the output as a numbered list:
+Run:
 
 ```bash
 python3 scripts/unsubscribe.py --list
 ```
 
-### Step 2: Pick one
+Show the repos to the user (including `scope` and `notes`) and ask which
+one to remove.
 
-Ask the user:
+### Step 2: Confirm
 
-> "Which subscription would you like to remove? Enter the number."
+Confirm deletion of `.evolve/entities/subscribed/{name}/`. If the repo
+has `scope: write`, add a warning that unpushed local publishes will be
+lost.
 
-### Step 3: Confirm
-
-Ask the user:
-
-> "This will remove '{name}' and delete `.evolve/subscribed/{name}/`. Continue? (y/n)"
-
-If the user answers anything other than `y` or `yes`, stop and tell them the operation was cancelled.
-
-### Step 4: Run unsubscribe script
+### Step 3: Run unsubscribe script
 
 ```bash
-python3 scripts/unsubscribe.py --name {name}
+python3 scripts/unsubscribe.py --name "{name}"
 ```
 
-### Step 5: Confirm
+### Step 4: Confirm
 
-Tell the user:
-
-> "Unsubscribed from {name}."
+Tell the user the repo was removed.
 
 ## Notes
 
-- This removes the subscription from `evolve.config.yaml`
-- Deletes `.evolve/subscribed/{name}/` (the cloned repo)
-- Deletes `.evolve/entities/subscribed/{name}/` (mirrored entities)
+- This removes the entry from `evolve.config.yaml` `repos:` list
+- Deletes `.evolve/entities/subscribed/{name}/` (the local clone, also
+  the recall mirror)
 - The entities will no longer appear in recall

--- a/platform-integrations/bob/evolve-lite/skills/evolve-lite:unsubscribe/scripts/unsubscribe.py
+++ b/platform-integrations/bob/evolve-lite/skills/evolve-lite:unsubscribe/scripts/unsubscribe.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-"""Remove a subscription and delete the locally cloned directory.
+"""Remove a repo from the unified ``repos`` list and delete its local clone (Bob).
 
 Usage:
-  --list          Print subscriptions as a JSON array and exit.
-  --name {name}   Remove named subscription from config and delete local dir.
+  --list          Print repos as a JSON array and exit.
+  --name {name}   Remove named repo from config and delete its local clone.
 """
 
 import argparse
@@ -21,66 +21,58 @@ for parent in current.parents:
         sys.path.insert(0, str(lib_path))
         break
 
-from config import load_config, save_config  # noqa: E402
-from audit import append as audit_append  # noqa: E402 # noqa: E402
+from audit import append as audit_append  # noqa: E402
+from config import (  # noqa: E402
+    is_valid_repo_name,
+    load_config,
+    normalize_repos,
+    save_config,
+    set_repos,
+)
 
 
 def main():
     parser = argparse.ArgumentParser()
     group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument("--list", action="store_true", help="Print subscriptions as JSON array")
-    group.add_argument("--name", help="Name of subscription to remove")
+    group.add_argument("--list", action="store_true", help="Print repos as JSON array")
+    group.add_argument("--name", help="Name of repo to remove")
     args = parser.parse_args()
 
-    evolve_dir = Path(os.environ.get("EVOLVE_DIR", ".evolve")).resolve()
-    # Derive project_root from evolve_dir to ensure consistency
-    project_root = str(evolve_dir.parent)
+    evolve_dir = Path(os.environ.get("EVOLVE_DIR", ".evolve"))
+    project_root = str(evolve_dir.resolve()) if evolve_dir.name != ".evolve" else str(evolve_dir.resolve().parent)
 
     cfg = load_config(project_root)
-    subscriptions = cfg.get("subscriptions", [])
-    if not isinstance(subscriptions, list):
-        subscriptions = []
+    repos = normalize_repos(cfg)
 
     if args.list:
-        print(json.dumps(subscriptions, indent=2))
+        print(json.dumps(repos, indent=2))
         return
 
-    # --name: remove the named subscription
     name = args.name
-
-    # Validate name: resolve and confirm it stays within the subscribed directory
     subscribed_base = (evolve_dir / "entities" / "subscribed").resolve()
     dest = (evolve_dir / "entities" / "subscribed" / name).resolve()
-    if not dest.is_relative_to(subscribed_base) or dest == subscribed_base:
+
+    if not is_valid_repo_name(name) or dest == subscribed_base or not dest.is_relative_to(subscribed_base):
         print(f"Error: invalid subscription name: {name!r}", file=sys.stderr)
         sys.exit(1)
 
-    new_subs = [s for s in subscriptions if not (isinstance(s, dict) and s.get("name") == name)]
-
-    if len(new_subs) == len(subscriptions):
+    new_repos = [r for r in repos if r.get("name") != name]
+    if len(new_repos) == len(repos):
         print(f"Error: subscription '{name}' not found.", file=sys.stderr)
         sys.exit(1)
 
-    # Delete local clone
     if dest.exists():
         shutil.rmtree(dest)
         print(f"Deleted {dest}")
     else:
         print(f"Warning: {dest} did not exist.", file=sys.stderr)
 
-    # Update config
-    cfg["subscriptions"] = new_subs
+    set_repos(cfg, new_repos)
     save_config(cfg, project_root)
 
-    # Audit
     identity = cfg.get("identity", {})
     actor = identity.get("user", "unknown") if isinstance(identity, dict) else "unknown"
-    audit_append(
-        project_root=project_root,
-        action="unsubscribe",
-        actor=actor,
-        name=name,
-    )
+    audit_append(project_root=project_root, action="unsubscribe", actor=actor, name=name)
 
     print(f"Removed subscription '{name}' from config.")
 

--- a/platform-integrations/claude/plugins/evolve-lite/README.md
+++ b/platform-integrations/claude/plugins/evolve-lite/README.md
@@ -57,86 +57,108 @@ You can also manually invoke `/evolve-lite:learn` at any time.
 
 ## Sharing Guidelines
 
-Evolve Lite supports sharing guidelines between users via public Git repositories. You can publish your own guidelines so others can subscribe to them, and subscribe to guidelines published by others.
+Evolve Lite treats shared guidelines as multi-reader / multi-writer git
+databases. A single unified `repos:` list in `evolve.config.yaml` describes
+every external guideline repo you read from or publish to; each entry has a
+`scope` of `read` (subscribe only) or `write` (publish target, also synced).
 
 ### Setup
 
-Sharing requires an `evolve.config.yaml` at the project root. If it doesn't exist, the subscribe or publish skills will prompt you to create one. Minimal structure:
+Sharing requires an `evolve.config.yaml` at the project root. The subscribe
+and publish skills will help you create one if it is missing. Structure:
 
 ```yaml
 identity:
   user: yourname          # used to stamp ownership on published guidelines
-public_repo:
-  remote: git@github.com:yourname/evolve-guidelines.git
-  branch: main
-subscriptions: []
+repos:
+  - name: memory
+    scope: write
+    remote: git@github.com:yourname/evolve-memory.git
+    branch: main
+    notes: public memory for my open-source projects
+  - name: org-memory
+    scope: read
+    remote: git@github.com:acme/org-memory.git
+    branch: main
+    notes: private memory shared only within my org
 sync:
   on_session_start: true  # auto-sync on each session start
 ```
 
-The `.evolve/` directory is kept out of version control — the skills automatically add it to `.gitignore`.
+- `scope: read` — pulled on sync. Cannot be published to.
+- `scope: write` — publish target **and** pulled on sync (so you see
+  everything pushed to it, including by other writers).
 
-### Publishing Guidelines
+The `.evolve/` directory is kept out of version control — the skills
+automatically add it to `.gitignore`.
 
-Use `/evolve-lite:publish` to share one or more of your local guidelines with others:
+### Subscribing to a Repo
 
-1. The skill lists files in `.evolve/entities/guideline/`
-2. You pick which ones to publish
-3. Each selected file is moved into `.evolve/public/guideline/`, stamped with `visibility: public`, `published_at`, and your username as the owner, committed, and pushed to your `public_repo.remote`
-
-Others can then subscribe using that remote URL.
-
-### Subscribing to Guidelines
-
-Use `/evolve-lite:subscribe` to pull in guidelines from another user's public repo:
+Use `/evolve-lite:subscribe` to add either a read-only subscription or a
+write-scope publish target:
 
 ```text
 /evolve-lite:subscribe
 > Remote URL: git@github.com:alice/evolve-guidelines.git
 > Short name: alice
+> Scope: read
 ```
 
-The repo is cloned to `.evolve/subscribed/alice/` and mirrored into `.evolve/entities/subscribed/alice/` so recall picks them up immediately.
-The repo is cloned directly into `.evolve/entities/subscribed/alice/` so recall can pick it up immediately. Subscription names must use only letters, numbers, `.`, `_`, and `-`.
+The repo is cloned into `.evolve/entities/subscribed/alice/` so recall can
+pick it up immediately. Repo names must use only letters, numbers, `.`,
+`_`, and `-`.
 
-### Syncing Subscriptions
+### Publishing Guidelines
 
-Use `/evolve-lite:sync` to pull the latest changes from all subscribed repos:
+Use `/evolve-lite:publish` to share one or more of your local guidelines
+via a **write-scope** repo:
+
+1. The skill selects (or asks about) the write-scope target repo
+2. It lists files in `.evolve/entities/guideline/`
+3. You pick which ones to publish
+4. Each selected file is moved into `.evolve/entities/subscribed/{repo}/guideline/`,
+   stamped with `visibility: public`, `owner`, `published_at`, and
+   `source`, committed, and pushed to the remote
+
+Because the publish target is also a subscribed repo, your next sync will
+pull in anything other writers have pushed to the same repo.
+
+### Syncing Repos
+
+Use `/evolve-lite:sync` to pull the latest changes from every configured
+repo (both scopes):
 
 ```text
 /evolve-lite:sync
-> Synced 2 repo(s): alice (+2 added, 0 updated, 0 removed), bob (+0 added, 1 updated, 0 removed)
+> Synced 2 repo(s): memory [write] (+2 added, 0 updated, 0 removed), bob [read] (+0 added, 1 updated, 0 removed)
 ```
 
-If `sync.on_session_start: true` is set in config, this runs automatically at the start of each session.
+If `sync.on_session_start: true` is set in config, this runs automatically
+at the start of each session.
 
-> **Note:** Sync uses `git fetch` + `git reset --hard` on each cloned subscription repo, so local state always matches the remote exactly. Accidentally deleted or modified files are automatically restored on the next sync.
+> **Note:** Read-scope repos use `git fetch` + `git reset --hard`, so the
+> local clone always matches the remote exactly (deleted or modified files
+> are restored). Write-scope repos use `git fetch` + `git rebase` so any
+> unpushed local publish commits are preserved.
 
-### Unsubscribing
+### Removing a Repo
 
-Use `/evolve-lite:unsubscribe` to remove a subscription and delete its locally cloned files:
-
-```text
-/evolve-lite:unsubscribe
-> Which subscription would you like to remove?
-> 1. alice
-> 2. bob
-```
-
-The skill confirms before deleting `.evolve/entities/subscribed/{name}/`.
+Use `/evolve-lite:unsubscribe` to remove any repo and delete its local
+clone. The skill shows scope and notes for each configured repo and warns
+before removing a write-scope repo (unpushed publishes would be lost).
 
 ### Sharing Storage Layout
 
 ```text
 .evolve/
-  public/
-    guideline/
-      guideline-name.md       # owner-stamped published guideline
   entities/
     guideline/
       private-guideline.md
     subscribed/
-      alice/                  # git clone used directly by recall
+      memory/                 # write-scope clone — publishes land here
+        guideline/
+          my-published-guideline.md
+      alice/                  # read-scope clone
         guideline/
           her-guideline.md
 ```
@@ -232,6 +254,22 @@ evolve/
 │   │   ├── SKILL.md
 │   │   └── scripts/
 │   │       └── retrieve_entities.py
+│   ├── subscribe/
+│   │   ├── SKILL.md
+│   │   └── scripts/
+│   │       └── subscribe.py
+│   ├── publish/
+│   │   ├── SKILL.md
+│   │   └── scripts/
+│   │       └── publish.py
+│   ├── sync/
+│   │   ├── SKILL.md
+│   │   └── scripts/
+│   │       └── sync.py
+│   ├── unsubscribe/
+│   │   ├── SKILL.md
+│   │   └── scripts/
+│   │       └── unsubscribe.py
 │   ├── save/
 │   │   └── SKILL.md
 │   └── save-trajectory/

--- a/platform-integrations/claude/plugins/evolve-lite/lib/config.py
+++ b/platform-integrations/claude/plugins/evolve-lite/lib/config.py
@@ -6,6 +6,12 @@ used by evolve-lite config files (scalars and lists of scalar-valued dicts).
 """
 
 import pathlib
+import re
+import sys
+
+
+VALID_SCOPES = ("read", "write")
+_SAFE_NAME = re.compile(r"^[A-Za-z0-9._-]+$")
 
 
 # ---------------------------------------------------------------------------
@@ -316,6 +322,114 @@ def save_config(cfg, project_root="."):
     path.write_text(content + "\n", encoding="utf-8")
 
 
+# ---------------------------------------------------------------------------
+# Unified repo model (issue #217)
+# ---------------------------------------------------------------------------
+
+
+def _coerce_repo(entry):
+    """Normalize a single repo dict. Returns None if required fields are missing."""
+    if not isinstance(entry, dict):
+        return None
+    name = entry.get("name")
+    remote = entry.get("remote")
+    if not isinstance(name, str) or not name.strip():
+        return None
+    if not isinstance(remote, str) or not remote.strip():
+        return None
+    scope = entry.get("scope", "read")
+    if isinstance(scope, str):
+        scope = scope.strip()
+    if scope not in VALID_SCOPES:
+        print(
+            f"evolve-lite: ignoring repo entry {name!r} — unknown scope {entry.get('scope')!r} (expected one of {', '.join(VALID_SCOPES)})",
+            file=sys.stderr,
+        )
+        return None
+    branch = entry.get("branch", "main")
+    if not isinstance(branch, str) or not branch.strip():
+        branch = "main"
+    notes = entry.get("notes", "")
+    if not isinstance(notes, str):
+        notes = ""
+    return {
+        "name": name.strip(),
+        "scope": scope,
+        "remote": remote.strip(),
+        "branch": branch.strip(),
+        "notes": notes,
+    }
+
+
+def normalize_repos(cfg):
+    """Return the unified ``repos`` list from *cfg* with invalid entries dropped.
+
+    Invalid entries (missing ``name`` or ``remote``, duplicate names, unknown
+    scopes) are silently skipped so callers can trust every returned dict.
+    """
+    if not isinstance(cfg, dict):
+        return []
+    raw = cfg.get("repos")
+    if not isinstance(raw, list):
+        return []
+    result = []
+    seen = set()
+    for entry in raw:
+        repo = _coerce_repo(entry)
+        if repo is None or repo["name"] in seen:
+            continue
+        seen.add(repo["name"])
+        result.append(repo)
+    return result
+
+
+def get_repo(cfg, name):
+    """Return the repo with the given name, or None."""
+    for repo in normalize_repos(cfg):
+        if repo.get("name") == name:
+            return repo
+    return None
+
+
+def write_repos(cfg):
+    """Return only the write-scope repos."""
+    return [r for r in normalize_repos(cfg) if r.get("scope") == "write"]
+
+
+def read_repos(cfg):
+    """Return only the read-scope repos."""
+    return [r for r in normalize_repos(cfg) if r.get("scope") == "read"]
+
+
+def set_repos(cfg, repos):
+    """Replace the ``repos`` list in-place with sanitized entries."""
+    if not isinstance(cfg, dict):
+        return cfg
+    sanitized = []
+    seen = set()
+    for entry in repos or []:
+        repo = _coerce_repo(entry)
+        if repo is None or repo["name"] in seen:
+            continue
+        seen.add(repo["name"])
+        sanitized.append(repo)
+    cfg["repos"] = sanitized
+    return cfg
+
+
+def is_valid_repo_name(name):
+    """Return True if *name* is safe to use as a repo / directory name.
+
+    Rejects leading '-' so names can't be confused with git CLI flags when
+    interpolated into clone paths.
+    """
+    if not isinstance(name, str):
+        return False
+    if name in (".", "..") or name.startswith("-"):
+        return False
+    return bool(_SAFE_NAME.match(name))
+
+
 if __name__ == "__main__":
     # Quick self-test
     import tempfile
@@ -323,14 +437,30 @@ if __name__ == "__main__":
     with tempfile.TemporaryDirectory() as d:
         cfg = {
             "identity": {"user": "alice"},
-            "public_repo": {"remote": "git@github.com:alice/evolve.git", "branch": "main"},
-            "subscriptions": [{"name": "bob", "remote": "git@github.com:bob/evolve.git", "branch": "main"}],
+            "repos": [
+                {
+                    "name": "memory",
+                    "scope": "write",
+                    "remote": "git@github.com:alice/evolve.git",
+                    "branch": "main",
+                    "notes": "public memory for foobar project",
+                },
+                {
+                    "name": "bob",
+                    "scope": "read",
+                    "remote": "git@github.com:bob/evolve.git",
+                    "branch": "main",
+                    "notes": "",
+                },
+            ],
             "sync": {"on_session_start": True},
         }
         save_config(cfg, d)
         loaded = load_config(d)
         assert loaded["identity"]["user"] == "alice", loaded
         assert loaded["sync"]["on_session_start"] is True, loaded
-        assert isinstance(loaded["subscriptions"], list), loaded
-        assert loaded["subscriptions"][0]["name"] == "bob", loaded
+        repos = normalize_repos(loaded)
+        assert len(repos) == 2, repos
+        assert repos[0]["scope"] == "write", repos
+        assert repos[1]["name"] == "bob", repos
     print("config.py ok")

--- a/platform-integrations/claude/plugins/evolve-lite/lib/entity_io.py
+++ b/platform-integrations/claude/plugins/evolve-lite/lib/entity_io.py
@@ -78,12 +78,12 @@ def find_entities_dir():
 def find_recall_entity_dirs():
     """Locate all directories that should be searched during recall.
 
-    Returns the existing recall roots in priority order:
-    ``entities/`` first, then ``public/`` under the configured Evolve dir.
-    Missing directories are skipped.
+    Returns the existing recall roots. Only ``entities/`` is canonical —
+    private entities live in ``entities/guideline/`` and shared entities
+    live in ``entities/subscribed/{repo}/guideline/``.
     """
     evolve_dir = get_evolve_dir()
-    candidates = [evolve_dir / "entities", evolve_dir / "public"]
+    candidates = [evolve_dir / "entities"]
     return [path for path in candidates if path.is_dir()]
 
 

--- a/platform-integrations/claude/plugins/evolve-lite/skills/publish/SKILL.md
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/publish/SKILL.md
@@ -1,13 +1,19 @@
 ---
 name: publish
-description: Publish a private guideline to your public repo so others can subscribe to it.
+description: Publish a private guideline to a configured write-scope repo.
 ---
 
-# Publish Guideline
+# Publish a Guideline
 
 ## Overview
 
-This skill publishes one or more private guidelines from your local `.evolve/entities/guideline/` directory to your public git repository, making them available for others to subscribe to.
+Publish one or more private guidelines from `.evolve/entities/guideline/`
+into a configured **write-scope** repo. The entity is stamped with
+`visibility: public`, `owner`, `published_at`, and `source`, moved into the
+local clone of the write repo, and committed / pushed to the remote.
+
+After publish, the same local clone is also what `/evolve-lite:sync` pulls
+from — so you (and anyone else publishing to the same repo) stay in sync.
 
 ## Workflow
 
@@ -15,30 +21,16 @@ This skill publishes one or more private guidelines from your local `.evolve/ent
 
 Check whether `evolve.config.yaml` exists in the project root.
 
-**If it does not exist**, ask the user:
+**If it does not exist**, or has no write-scope repo configured, first ask:
 
-> "No `evolve.config.yaml` found. What username would you like to use? (e.g. `vatche`)"
+> "You need at least one write-scope repo to publish to. Run /evolve-lite:subscribe with --scope write to set one up, then come back."
 
-> "What is the remote URL for your public guidelines repo? (e.g. `git@github.com:vatche/evolve-guidelines.git`)"
+Then stop. (Do not silently create a config — the user must explicitly
+choose the namespace they publish to.)
 
-Create `evolve.config.yaml`:
+**If it exists** but `identity.user` is missing, ask:
 
-```yaml
-identity:
-  user: {username}
-public_repo:
-  remote: {remote}
-  branch: main
-subscriptions: []
-sync:
-  on_session_start: true
-```
-
-**If it exists** but `identity.user` is missing, ask for it and add it to the config.
-
-**If it exists** but `public_repo.remote` is missing, ask:
-
-> "What is the remote URL for your public guidelines repo? (e.g. `git@github.com:vatche/evolve-guidelines.git`)"
+> "What username would you like to use? (e.g. `alice`)"
 
 Add it to the config.
 
@@ -52,43 +44,171 @@ Ensure `.evolve/` is gitignored at the project root:
 grep -qxF '.evolve/' .gitignore 2>/dev/null || echo '.evolve/' >> .gitignore
 ```
 
-If `.evolve/public/` does not already contain a `.git` directory, initialise it and add the remote:
+### Step 3: Pick the target write-scope repo
 
-```bash
-git init .evolve/public
-git -C .evolve/public remote add origin {public_repo.remote}
-```
+Read `repos:` from `evolve.config.yaml`. Filter to entries with
+`scope: write`.
 
-### Step 3: List and select entities
+- **Zero entries** → tell the user to subscribe to a write-scope repo first, then stop.
+- **Exactly one entry** → use it as the default (no prompt).
+- **Multiple entries** → display them as a numbered list with their `notes`
+  and ask which one to publish to.
 
-List the files in `.evolve/entities/guideline/` (filenames only) and display them numbered. Ask the user:
+Bind `{repo}` = the chosen entry's `name`, `{remote}` = its `remote`, and
+`{branch}` = its `branch` (default `main`). These are referenced in
+Steps 5–8 below.
 
-> "Which guideline(s) would you like to publish? Enter a number or comma-separated list of numbers."
+### Step 4: List and select entities
+
+List the files in `.evolve/entities/guideline/` (filenames only), display
+them numbered, and ask:
+
+> "Which guideline(s) would you like to publish to '{repo}'? Enter a number or comma-separated list of numbers."
 
 Wait for the user's selection.
 
-### Step 4: Run publish script
+### Step 5: Ensure the local clone exists
+
+The target clone lives at `.evolve/entities/subscribed/{repo}/`. If it is
+not already a git repo, clone it now:
+
+```bash
+git clone --branch "{branch}" -- "{remote}" ".evolve/entities/subscribed/{repo}"
+```
+
+(This usually already exists because `/evolve-lite:subscribe` cloned it.)
+
+### Step 6: Run publish script
 
 For each selected entity file, run:
 
 ```bash
 python3 ${CLAUDE_PLUGIN_ROOT}/skills/publish/scripts/publish.py \
   --entity "{filename}" \
+  --repo "{repo}" \
   --user "{identity.user}"
 ```
 
-### Step 5: Commit and push
+### Step 7: Commit and push
+
+Build `{filenames_list}` as a comma-joined list of all selected filenames,
+and `{guideline_paths}` as a space-joined list of the corresponding
+`guideline/{filename}` paths inside the clone (these are the files the
+publish script just wrote).
 
 ```bash
-git -C .evolve/public add .
-git -C .evolve/public commit -m "[evolve] publish: {filename}"
-git -C .evolve/public push origin {public_repo.branch}
+git -C ".evolve/entities/subscribed/{repo}" add -- {guideline_paths}
+git -C ".evolve/entities/subscribed/{repo}" commit -m "[evolve] publish: {filenames_list}"
+git -C ".evolve/entities/subscribed/{repo}" push origin "{branch}"
 ```
 
-Where `{public_repo.branch}` defaults to `main` if not set in config.
+If `git push` succeeds, continue to Step 8.
 
-### Step 6: Confirm
+### Step 7a: Recover from non-fast-forward rejection
+
+If `git push` failed **and** its stderr contains `rejected`,
+`non-fast-forward`, or `fetch first`, another writer pushed to
+`{branch}` since your last sync. The local publish commit is intact —
+rebase it onto the new remote tip and push once more:
+
+```bash
+git -C ".evolve/entities/subscribed/{repo}" fetch origin "{branch}"
+git -C ".evolve/entities/subscribed/{repo}" rebase "origin/{branch}"
+```
+
+- **Rebase clean** → retry the push and continue to Step 8:
+
+  ```bash
+  git -C ".evolve/entities/subscribed/{repo}" push origin "{branch}"
+  ```
+
+- **Rebase conflicted** → attempt to resolve, then hand off to the
+  user for review. Do **not** `git rebase --continue` or `git push`
+  without an explicit user confirmation.
+
+  1. List the conflicted files:
+
+     ```bash
+     git -C ".evolve/entities/subscribed/{repo}" status --porcelain
+     ```
+
+     Conflict codes: `UU` = both modified, `AA` = both added,
+     `UD`/`DU` = delete/modify, `A` + binary = binary add. If **any**
+     file is `UD`, `DU`, or binary, skip straight to the abort branch
+     below — those are not safe to auto-resolve.
+
+  2. For each `UU` / `AA` file, read it and produce a resolution:
+     - The working tree contains `<<<<<<<`, `=======`, `>>>>>>>`
+       markers. During a rebase, the section above `=======` (labeled
+       `HEAD`) is the **remote's** version and the section below
+       (labeled with the publish commit's sha) is **the publish
+       change being replayed** — i.e., "theirs" and "ours" are
+       swapped relative to a regular merge.
+     - Decide an intent-preserving merge: if the edits are
+       independent (different sections), interleave them. If they
+       target the same paragraph, prefer keeping both distinct
+       guideline bodies (e.g. append one under a subheading) rather
+       than picking a side silently.
+     - Write the resolved content back to the file. Do **not**
+       `git add` it yet.
+
+  3. Show the user what you propose — per file, include a one-line
+     merge strategy plus the diff against the remote:
+
+     ```bash
+     git -C ".evolve/entities/subscribed/{repo}" diff HEAD -- {file}
+     ```
+
+     Then ask:
+
+     > "I've attempted to resolve {N} conflicted file(s): {list}.
+     > Each proposed resolution is in
+     > `.evolve/entities/subscribed/{repo}/`. Review them and say
+     > **continue** to finish the rebase and push, or **abort** to
+     > roll back and resolve by hand."
+
+  4. **User says continue** → stage the resolved files, finish the
+     rebase, and push:
+
+     ```bash
+     git -C ".evolve/entities/subscribed/{repo}" add {resolved-files}
+     git -C ".evolve/entities/subscribed/{repo}" rebase --continue
+     git -C ".evolve/entities/subscribed/{repo}" push origin "{branch}"
+     ```
+
+     Then continue to Step 8. If `rebase --continue` surfaces a
+     **new** conflict (unusual for publish since there's normally one
+     commit), loop back to step 1 of this block.
+
+  5. **User says abort**, or the conflict isn't safely resolvable
+     (binary / delete-modify), or you lack confidence in the merge:
+
+     ```bash
+     git -C ".evolve/entities/subscribed/{repo}" rebase --abort
+     ```
+
+     After the abort the local publish commit is preserved at
+     `.evolve/entities/subscribed/{repo}` but is not on the remote.
+     Tell the user:
+
+     > "Rolled back. Your commit for {filenames_list} is preserved
+     > locally — nothing was lost, but it's not on the remote yet.
+     > To finish publishing, either:
+     >
+     > 1. Resolve by hand:
+     >    - `cd .evolve/entities/subscribed/{repo}`
+     >    - `git fetch origin {branch} && git rebase origin/{branch}`
+     >    - edit the conflicted files, `git add` them, `git rebase --continue`
+     >    - `git push origin {branch}`
+     > 2. Or, if the conflict is on a shared filename, re-run
+     >    `/evolve-lite:publish` for a different name."
+
+If `git push` failed for any **other** reason (auth, network, missing
+remote ref), surface git's error to the user as-is and stop — a rebase
+will not help.
+
+### Step 8: Confirm
 
 Tell the user:
 
-> "Published {filename} to {public_repo.remote}."
+> "Published {filenames_list} to repo '{repo}' ({remote})."

--- a/platform-integrations/claude/plugins/evolve-lite/skills/publish/scripts/publish.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/publish/scripts/publish.py
@@ -1,10 +1,16 @@
 #!/usr/bin/env python3
-"""Publish a private guideline entity to the public directory.
+"""Publish a private guideline entity to a write-scope repo.
 
-- Moves source from .evolve/entities/guideline/{filename}
-- to .evolve/public/guideline/{filename}
-- Updates frontmatter: visibility=public, owner={user}, published_at={now}
-- Appends to audit.log
+The ``--repo`` flag selects which configured write-scope repo to publish to.
+If omitted and exactly one write-scope repo is configured, it is used by
+default. The entity is moved from ``.evolve/entities/guideline/{filename}``
+into the target repo's local clone at
+``.evolve/entities/subscribed/{repo}/guideline/{filename}``. The skill
+orchestration (SKILL.md) is responsible for the subsequent git add / commit
+/ push.
+
+Published entities are stamped with ``visibility=public``, ``owner``,
+``published_at``, and ``source``.
 """
 
 import argparse
@@ -17,31 +23,51 @@ from pathlib import Path
 
 # Add lib to path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent.parent / "lib"))
-from entity_io import markdown_to_entity, entity_to_markdown
-from audit import append as audit_append
-from config import load_config
+from entity_io import markdown_to_entity, entity_to_markdown  # noqa: E402
+from audit import append as audit_append  # noqa: E402
+from config import get_repo, load_config, normalize_repos, write_repos  # noqa: E402
 
 
-def _resolve_source(cfg, user_arg):
-    """Derive a source label from config or fallback to user arg."""
-    remote = cfg.get("public_repo", {})
-    if isinstance(remote, dict):
-        remote = remote.get("remote", "")
-    if remote:
-        # Extract user/repo from SSH or HTTPS remote URLs
+def _resolve_source(repo, effective_user):
+    """Derive the ``source`` frontmatter tag for a published entity."""
+    remote = repo.get("remote") if isinstance(repo, dict) else None
+    if isinstance(remote, str):
         m = re.search(r"[:/]([^/:]+/[^/]+?)(?:\.git)?$", remote)
         if m:
             return m.group(1)
-    identity = cfg.get("identity", {})
-    if isinstance(identity, dict) and identity.get("user"):
-        return identity["user"]
-    return user_arg
+    return effective_user
+
+
+def _select_target_repo(cfg, requested_name):
+    """Pick the write-scope repo to publish to, or return (None, error_message)."""
+    write = write_repos(cfg)
+
+    if requested_name:
+        repo = get_repo(cfg, requested_name)
+        if repo is None:
+            available = ", ".join(r["name"] for r in normalize_repos(cfg)) or "(none)"
+            return None, f"no repo named '{requested_name}' is configured. Configured repos: {available}"
+        if repo.get("scope") != "write":
+            return None, f"repo '{requested_name}' has scope={repo.get('scope')!r}; publish requires scope=write"
+        return repo, None
+
+    if not write:
+        return None, ("no write-scope repo configured. Run /evolve-lite:subscribe with --scope write to set up a publish target.")
+    if len(write) > 1:
+        names = ", ".join(r["name"] for r in write)
+        return None, f"multiple write-scope repos configured; pick one with --repo. Available: {names}"
+    return write[0], None
 
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--entity", required=True, help="Basename of the .md file to publish")
     parser.add_argument("--user", default=None, help="Username to stamp as owner")
+    parser.add_argument(
+        "--repo",
+        default=None,
+        help="Name of the write-scope repo to publish to (optional if exactly one is configured)",
+    )
     args = parser.parse_args()
 
     evolve_dir = Path(os.environ.get("EVOLVE_DIR", ".evolve"))
@@ -61,24 +87,36 @@ def main():
         print(f"Error: entity file not found or is a directory: {src_path}", file=sys.stderr)
         sys.exit(1)
 
-    # Parse entity
-    entity = markdown_to_entity(src_path)
-
     cfg = load_config(str(evolve_dir.resolve().parent))
+    target, err = _select_target_repo(cfg, args.repo)
+    if err is not None:
+        print(f"Error: {err}", file=sys.stderr)
+        sys.exit(1)
+
     identity = cfg.get("identity", {})
     effective_user = args.user or (identity.get("user") if isinstance(identity, dict) else None)
 
-    # Update frontmatter fields
+    # Parse entity and stamp frontmatter
+    entity = markdown_to_entity(src_path)
     entity["visibility"] = "public"
     if effective_user:
         entity["owner"] = effective_user
-    entity["published_at"] = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
-    source = _resolve_source(cfg, effective_user)
+    entity["published_at"] = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    source = _resolve_source(target, effective_user)
     if source:
         entity["source"] = source
 
-    # Write to public directory
-    dest_dir = evolve_dir / "public" / "guideline"
+    # Destination: the local clone of the target write-scope repo.
+    clone_root = evolve_dir / "entities" / "subscribed" / target["name"]
+    if not (clone_root / ".git").exists():
+        print(
+            f"Error: target repo clone not found at {clone_root}. "
+            f"Run /evolve-lite:subscribe with --scope write first, or /evolve-lite:sync "
+            f"to clone it.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    dest_dir = clone_root / "guideline"
     dest_dir.mkdir(parents=True, exist_ok=True)
     dest_base = dest_dir.resolve()
     dest_path = (dest_dir / args.entity).resolve()
@@ -118,11 +156,12 @@ def main():
             action="publish",
             actor=effective_user or "unknown",
             entity=args.entity,
+            repo=target["name"],
         )
     except Exception as e:
         print(f"Warning: audit log failed: {e}", file=sys.stderr)
 
-    print(f"Published: {args.entity} -> {dest_path}")
+    print(f"Published: {args.entity} -> {dest_path} (repo: {target['name']})")
 
 
 if __name__ == "__main__":

--- a/platform-integrations/claude/plugins/evolve-lite/skills/recall/SKILL.md
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/recall/SKILL.md
@@ -14,26 +14,25 @@ This skill retrieves relevant entities from a stored knowledge base based on the
 
 1. Hook fires on user prompt submission
 2. Script reads prompt from stdin (JSON with `prompt` field)
-3. Loads entities from two sources: `.evolve/entities/` (private + subscribed) and `.evolve/public/` (your published guidelines)
+3. Loads entities from `.evolve/entities/` — covers private entities,
+   subscribed read-scope repos, and write-scope publish targets (which
+   are themselves cloned under `entities/subscribed/{repo}/`)
 4. Outputs formatted entities to stdout
 5. Claude receives entities as additional context and applies relevant ones
 
 ## Entities Storage
-
-Entities are loaded from two locations:
 
 ```text
 .evolve/entities/
   guideline/
     use-context-managers-for-file-operations.md   ← private
   subscribed/
-    alice/
+    memory/                                       ← write-scope clone (publishes land here)
+      guideline/
+        my-published-guideline.md
+    alice/                                        ← read-scope clone
       guideline/
         alice-guideline.md                              ← annotated [from: alice]
-
-.evolve/public/
-  guideline/
-    published-guideline.md                              ← your own public, no annotation
 ```
 
 Each file uses markdown with YAML frontmatter:

--- a/platform-integrations/claude/plugins/evolve-lite/skills/recall/scripts/retrieve_entities.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/recall/scripts/retrieve_entities.py
@@ -119,6 +119,7 @@ def main():
     entities = []
     for entities_dir in recall_dirs:
         entities.extend(load_entities_with_source(entities_dir))
+
     if not entities:
         log("No entities found")
         return

--- a/platform-integrations/claude/plugins/evolve-lite/skills/subscribe/SKILL.md
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/subscribe/SKILL.md
@@ -1,13 +1,35 @@
 ---
 name: subscribe
-description: Subscribe to another user's public guidelines repo.
+description: Add a shared guidelines repo (read-scope subscription or write-scope publish target) to the unified repos list.
 ---
 
-# Subscribe to Guidelines
+# Subscribe to a Shared Repo
 
 ## Overview
 
-This skill subscribes to another user's public guidelines repository. Their guidelines will be cloned locally and made available in your recall context.
+Configured guidelines repos are multi-reader / multi-writer git databases,
+described in a single unified list in `evolve.config.yaml`:
+
+```yaml
+repos:
+  - name: memory
+    scope: write
+    remote: git@github.com:alice/evolve.git
+    branch: main
+    notes: public memory for foobar project
+  - name: org-memory
+    scope: read
+    remote: git@github.com:acme/org-memory.git
+    branch: main
+    notes: private memory shared only within my org
+```
+
+- `scope: read` — download-only. Synced on every run.
+- `scope: write` — publish target. Synced on every run too, so you see
+  what you have already published (and anything others have pushed to the
+  same repo).
+
+This skill adds one entry to `repos:` and clones it locally.
 
 ## Workflow
 
@@ -24,7 +46,7 @@ Then create `evolve.config.yaml` with this minimal content:
 ```yaml
 identity:
   user: {username}
-subscriptions: []
+repos: []
 sync:
   on_session_start: true
 ```
@@ -37,19 +59,19 @@ grep -qxF '.evolve/' .gitignore 2>/dev/null || echo '.evolve/' >> .gitignore
 
 ### Step 2: Gather details
 
-Ask the user:
+Ask the user in this order:
 
 > "What is the remote URL for the guidelines repo? (e.g. `git@github.com:alice/evolve-guidelines.git`)"
-
-Then ask:
-
-> "What short name would you like for this subscription? (e.g. `alice`)"
+> "What short name would you like for this repo? (e.g. `alice`)"
+> "Scope? `read` (download-only subscription) or `write` (you can also publish to it)."
+> "Optional note describing this repo (press Enter to skip)."
 
 ### Step 3: Check for duplicates
 
-Read `evolve.config.yaml` from the project root. If the name already exists in the `subscriptions` list, tell the user:
+Read `evolve.config.yaml` from the project root. If the name already exists
+in `repos:`, tell the user:
 
-> "A subscription named '{name}' already exists. Please unsubscribe first or choose a different name."
+> "A repo named '{name}' is already configured. Unsubscribe it first or choose a different name."
 
 Then stop.
 
@@ -57,13 +79,15 @@ Then stop.
 
 ```bash
 python3 ${CLAUDE_PLUGIN_ROOT}/skills/subscribe/scripts/subscribe.py \
-  --name {name} \
-  --remote {remote} \
-  --branch main
+  --name "{name}" \
+  --remote "{remote}" \
+  --branch main \
+  --scope "{scope}" \
+  --notes "{notes}"
 ```
 
 ### Step 5: Confirm
 
 Tell the user:
 
-> "Subscribed to {name}. Run /sync to pull their guidelines."
+> "Added '{name}' (scope={scope}). Run /evolve-lite:sync to pull the latest guidelines."

--- a/platform-integrations/claude/plugins/evolve-lite/skills/subscribe/scripts/subscribe.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/subscribe/scripts/subscribe.py
@@ -127,7 +127,15 @@ def main():
             remote=args.remote,
         )
     except Exception as exc:
-        print(f"Warning: audit log could not be updated: {exc}", file=sys.stderr)
+        repos.pop()
+        set_repos(cfg, repos)
+        try:
+            save_config(cfg, project_root)
+        except Exception:
+            pass
+        shutil.rmtree(dest, ignore_errors=True)
+        print(f"Error: failed to record subscription — clone removed: {exc}", file=sys.stderr)
+        sys.exit(1)
 
     print(f"Subscribed to '{args.name}' (scope={args.scope}) from {args.remote}")
 

--- a/platform-integrations/claude/plugins/evolve-lite/skills/subscribe/scripts/subscribe.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/subscribe/scripts/subscribe.py
@@ -1,14 +1,27 @@
 #!/usr/bin/env python3
-"""Subscribe to another user's public guidelines repo.
+"""Add a repo to the unified ``repos`` list and clone it locally.
 
-- Adds entry to subscriptions list in evolve.config.yaml
-- Clones the remote into .evolve/entities/subscribed/{name}
-- Appends to audit.log
+Shared (multi-reader, multi-writer) repos are described in evolve.config.yaml as:
+
+    repos:
+      - name: memory
+        scope: write
+        remote: git@github.com:alice/evolve.git
+        branch: main
+        notes: public memory for foobar project
+      - name: org-memory
+        scope: read
+        remote: git@github.com:acme/org-memory.git
+        branch: main
+        notes: private memory shared only within my org
+
+``scope: read``  — download-only (pulled by sync).
+``scope: write`` — publish target; also pulled by sync so you see what
+                   others push and what you have already published.
 """
 
 import argparse
 import os
-import re
 import shutil
 import subprocess
 import sys
@@ -16,30 +29,41 @@ from pathlib import Path
 
 # Add lib to path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent.parent / "lib"))
-from config import load_config, save_config
-from audit import append as audit_append
-
-_SAFE_NAME = re.compile(r"^[A-Za-z0-9._-]+$")
+from config import (  # noqa: E402
+    VALID_SCOPES,
+    is_valid_repo_name,
+    load_config,
+    normalize_repos,
+    save_config,
+    set_repos,
+)
+from audit import append as audit_append  # noqa: E402
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--name", required=True, help="Short subscription name (e.g. alice)")
+    parser.add_argument("--name", required=True, help="Short repo name (e.g. alice, memory)")
     parser.add_argument("--remote", required=True, help="Git remote URL")
     parser.add_argument("--branch", default="main", help="Branch to track (default: main)")
+    parser.add_argument(
+        "--scope",
+        default="read",
+        choices=VALID_SCOPES,
+        help="'read' (subscribe only) or 'write' (publish target; also synced).",
+    )
+    parser.add_argument("--notes", default="", help="Free-form note describing this repo")
     args = parser.parse_args()
 
     evolve_dir = Path(os.environ.get("EVOLVE_DIR", ".evolve"))
     project_root = str(evolve_dir.resolve().parent)
 
-    if not _SAFE_NAME.match(args.name):
+    if not is_valid_repo_name(args.name):
         print(
             f"Error: invalid subscription name: {args.name!r} (only A-Z, a-z, 0-9, '.', '_', '-' allowed)",
             file=sys.stderr,
         )
         sys.exit(1)
 
-    # Validate name: resolve and confirm it stays within the subscribed directory
     subscribed_base = (evolve_dir / "entities" / "subscribed").resolve()
     dest = (evolve_dir / "entities" / "subscribed" / args.name).resolve()
     if not dest.is_relative_to(subscribed_base) or dest == subscribed_base:
@@ -47,22 +71,16 @@ def main():
         sys.exit(1)
 
     cfg = load_config(project_root)
+    repos = normalize_repos(cfg)
 
-    # Ensure subscriptions list exists
-    subscriptions = cfg.get("subscriptions", [])
-    if not isinstance(subscriptions, list):
-        subscriptions = []
-
-    # Check for duplicate
-    for sub in subscriptions:
-        if isinstance(sub, dict) and sub.get("name") == args.name:
+    for repo in repos:
+        if repo.get("name") == args.name:
             print(
                 f"Error: subscription '{args.name}' already exists in config.",
                 file=sys.stderr,
             )
             sys.exit(1)
 
-    # Clone the repo
     if dest.exists():
         print(
             f"Error: directory already exists: {dest}\nRun /evolve-lite:unsubscribe to remove it before re-subscribing.",
@@ -71,32 +89,32 @@ def main():
         sys.exit(1)
 
     dest.parent.mkdir(parents=True, exist_ok=True)
-    subprocess.run(
-        [
-            "git",
-            "clone",
-            args.remote,
-            str(dest),
-            "--branch",
-            args.branch,
-            "--depth",
-            "1",
-        ],
-        check=True,
-    )
+    # Write-scope repos need full history so the user can safely rebase and
+    # push publish commits. Read-scope repos only ever mirror, so a shallow
+    # clone is enough.
+    clone_cmd = ["git", "clone", args.remote, str(dest), "--branch", args.branch]
+    if args.scope == "read":
+        clone_cmd += ["--depth", "1"]
+    subprocess.run(clone_cmd, check=True)
 
-    # Update config — roll back clone only if save_config fails
-    subscriptions.append({"name": args.name, "remote": args.remote, "branch": args.branch})
-    cfg["subscriptions"] = subscriptions
+    repos.append(
+        {
+            "name": args.name,
+            "scope": args.scope,
+            "remote": args.remote,
+            "branch": args.branch,
+            "notes": args.notes,
+        }
+    )
+    set_repos(cfg, repos)
     try:
         save_config(cfg, project_root)
     except Exception as exc:
-        subscriptions.pop()
+        repos.pop()
         shutil.rmtree(dest, ignore_errors=True)
         print(f"Error: failed to record subscription — clone removed: {exc}", file=sys.stderr)
         sys.exit(1)
 
-    # Audit — non-fatal; never deletes the clone or exits on failure
     identity = cfg.get("identity", {})
     actor = identity.get("user", "unknown") if isinstance(identity, dict) else "unknown"
     try:
@@ -105,12 +123,13 @@ def main():
             action="subscribe",
             actor=actor,
             name=args.name,
+            scope=args.scope,
             remote=args.remote,
         )
     except Exception as exc:
         print(f"Warning: audit log could not be updated: {exc}", file=sys.stderr)
 
-    print(f"Subscribed to '{args.name}' from {args.remote}")
+    print(f"Subscribed to '{args.name}' (scope={args.scope}) from {args.remote}")
 
 
 if __name__ == "__main__":

--- a/platform-integrations/claude/plugins/evolve-lite/skills/sync/SKILL.md
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/sync/SKILL.md
@@ -1,13 +1,16 @@
 ---
 name: sync
-description: Pull the latest guidelines from all subscribed repos.
+description: Pull the latest guidelines from every configured repo (read- and write-scope).
 ---
 
-# Sync Subscriptions
+# Sync Repos
 
 ## Overview
 
-This skill pulls the latest guidelines from all repos you have subscribed to, keeping your local copies up to date.
+This skill pulls the latest guidelines from every repo in
+`evolve.config.yaml` `repos:` list — both `scope: read` (subscribe-only)
+and `scope: write` (publish targets). Write-scope repos use a rebase
+strategy so any unpushed local publish commits are preserved.
 
 ## Workflow
 
@@ -19,10 +22,10 @@ python3 ${CLAUDE_PLUGIN_ROOT}/skills/sync/scripts/sync.py
 
 ### Step 2: Display summary
 
-Display the summary output from the script to the user. For example:
+Display the script's stdout verbatim to the user. Example outputs:
 
-> "Synced 2 repo(s): alice (+2 added, 0 updated, 0 removed), bob (+0 added, 1 updated, 0 removed)"
+> "Synced 2 repo(s): memory [write] (+2 added, 0 updated, 0 removed), bob [read] (+0 added, 1 updated, 0 removed)"
 
-If there is nothing to report (no subscriptions or no changes), confirm:
+> "No subscriptions configured. Add one with /evolve-lite:subscribe to start syncing shared guidelines."
 
-> "All subscriptions are up to date."
+Under `--quiet`, the script exits silently when there's nothing to report.

--- a/platform-integrations/claude/plugins/evolve-lite/skills/sync/scripts/sync.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/sync/scripts/sync.py
@@ -1,55 +1,43 @@
 #!/usr/bin/env python3
-"""Pull the latest guidelines from all subscribed repos.
+"""Pull the latest guidelines from every configured repo.
 
-Subscribed repos are cloned directly into .evolve/entities/subscribed/{name}/
-so the recall hook can read them without a separate mirror step.
+Every repo in ``evolve.config.yaml`` (both read- and write-scope) is cloned
+into ``.evolve/entities/subscribed/{name}/`` so recall sees everything through
+a single root. Publish commits stay local until pushed, so write-scope repos
+use ``git pull --rebase`` (preserves unpushed commits) while read-scope repos
+use ``git fetch`` + ``git reset --hard`` (exact mirror).
 
 Usage:
-  --quiet        Suppress output if no changes.
-  --config PATH  Path to config file (default: evolve.config.yaml at project root).
+  --quiet            Suppress output if no changes.
+  --config PATH      Path to config file (default: evolve.config.yaml at project root).
+  --session-start    Apply the ``sync.on_session_start`` gate (automatic hook runs).
 """
 
 import argparse
 import os
-import re
 import subprocess
 import sys
 from pathlib import Path
 
 # Add lib to path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent.parent / "lib"))
-from config import load_config
-from audit import append as audit_append
+from config import is_valid_repo_name, load_config, normalize_repos  # noqa: E402
+from audit import append as audit_append  # noqa: E402
 
 
 _GIT_TIMEOUT = 30  # seconds
 
 
-def git_sync(repo_path, branch):
-    """Fetch and hard-reset to origin. Returns CompletedProcess, or None on timeout.
-
-    Hard reset ensures local clone always matches remote exactly — restores deleted
-    files, discards any local modifications. Subscribed repos are read-only mirrors
-    so there is nothing worth preserving locally.
-    """
-    git_base = ["git", "-c", f"safe.directory={repo_path}", "-C", str(repo_path)]
+def _git(repo_path, *args, timeout=_GIT_TIMEOUT):
+    """Run a git command inside ``repo_path`` with a timeout. Returns CompletedProcess or None."""
     try:
-        fetch = subprocess.run(
-            [*git_base, "fetch", "origin", branch],
-            capture_output=True,
-            text=True,
-            timeout=_GIT_TIMEOUT,
-        )
-        if fetch.returncode != 0:
-            return fetch
         return subprocess.run(
-            [*git_base, "reset", "--hard", f"origin/{branch}"],
+            ["git", "-c", f"safe.directory={repo_path}", "-C", str(repo_path), *args],
             capture_output=True,
             text=True,
-            timeout=_GIT_TIMEOUT,
+            timeout=timeout,
         )
     except subprocess.TimeoutExpired:
-        print(f"Warning: git sync timed out for {repo_path} (branch: {branch})", file=sys.stderr)
         return None
 
 
@@ -65,19 +53,51 @@ def _head_hash(repo_path):
     return result.stdout.strip()
 
 
-def count_delta(repo_path):
-    """Count added/modified/deleted .md files since last pull.
+def sync_read_only(repo_path, branch):
+    """Fetch and hard-reset to ``origin/{branch}``. Returns CompletedProcess or None on timeout.
 
-    Returns dict: {added: int, updated: int, removed: int}
+    Hard reset ensures the local clone always matches the remote exactly —
+    restores deleted files and discards any local modifications. Read-only
+    mirrors have no local commits worth preserving.
     """
-    result = subprocess.run(
-        ["git", "-c", f"safe.directory={repo_path}", "-C", str(repo_path), "diff", "--name-status", "HEAD@{1}", "HEAD"],
-        capture_output=True,
-        text=True,
-        timeout=_GIT_TIMEOUT,
+    fetch = _git(repo_path, "fetch", "origin", branch)
+    if fetch is None or fetch.returncode != 0:
+        return fetch
+    return _git(repo_path, "reset", "--hard", f"origin/{branch}")
+
+
+def sync_writable(repo_path, branch):
+    """Fetch and rebase local commits onto ``origin/{branch}``.
+
+    Write-scope repos may have local commits from publishing that have not
+    yet been pushed. Rebase preserves them (no-op when the working tree is
+    clean) so the user never loses unpushed publish commits.
+    """
+    fetch = _git(repo_path, "fetch", "origin", branch)
+    if fetch is None or fetch.returncode != 0:
+        return fetch
+    rebase = _git(repo_path, "rebase", f"origin/{branch}")
+    if rebase is None or rebase.returncode != 0:
+        # Abort a failed rebase so we don't leave the repo in a conflict state.
+        _git(repo_path, "rebase", "--abort")
+        return rebase
+    return rebase
+
+
+def count_delta(repo_path):
+    """Count added/modified/deleted .md files since last sync.
+
+    Returns dict: ``{added: int, updated: int, removed: int}``.
+    """
+    result = _git(
+        repo_path,
+        "diff",
+        "--name-status",
+        "HEAD@{1}",
+        "HEAD",
     )
-    if result.returncode != 0:
-        # HEAD@{1} doesn't exist (initial sync) — count all .md files as added
+    if result is None or result.returncode != 0:
+        # HEAD@{1} doesn't exist (initial sync) — count all .md files as added.
         added = len(list(repo_path.glob("**/*.md")))
         return {"added": added, "updated": 0, "removed": 0}
     added = updated = removed = 0
@@ -107,30 +127,31 @@ def main():
         default=None,
         help="Path to config file (default: evolve.config.yaml in project root)",
     )
+    parser.add_argument(
+        "--session-start",
+        action="store_true",
+        help="Apply session-start gating for automatic hook execution",
+    )
     args = parser.parse_args()
 
     evolve_dir = Path(os.environ.get("EVOLVE_DIR", ".evolve"))
     project_root = str(evolve_dir.parent) if "EVOLVE_DIR" in os.environ else "."
 
-    # Determine config path
     if args.config:
         cfg = load_config(filepath=args.config)
     else:
         cfg = load_config(project_root)
 
-    # Check sync.on_session_start — only short-circuits automatic hook runs
-    # (which pass --quiet). Manual invocations always execute.
+    # Check sync.on_session_start — only short-circuits automatic hook runs.
     sync_cfg = cfg.get("sync", {})
-    if args.quiet and isinstance(sync_cfg, dict) and sync_cfg.get("on_session_start") is False:
+    if args.session_start and isinstance(sync_cfg, dict) and sync_cfg.get("on_session_start") is False:
         sys.exit(0)
 
-    subscriptions = cfg.get("subscriptions", [])
-    if not isinstance(subscriptions, list):
-        subscriptions = []
+    repos = normalize_repos(cfg)
 
-    if not subscriptions:
+    if not repos:
         if not args.quiet:
-            print("No subscriptions configured.")
+            print("No subscriptions configured. Add one with /evolve-lite:subscribe to start syncing shared guidelines.")
         sys.exit(0)
 
     identity = cfg.get("identity", {})
@@ -140,25 +161,13 @@ def main():
     total_delta = {}
     any_changes = False
 
-    _SAFE_NAME = re.compile(r"^[A-Za-z0-9._-]+$")
+    for repo in repos:
+        name = repo.get("name")
+        scope = repo.get("scope", "read")
+        branch = repo.get("branch", "main")
+        remote = repo.get("remote")
 
-    for sub in subscriptions:
-        if not isinstance(sub, dict):
-            continue
-        name = sub.get("name")
-        branch = sub.get("branch", "main")
-
-        if not isinstance(name, str) or not name.strip():
-            summaries.append(f"{sub!r} (skipped — missing or non-string name)")
-            continue
-        name = name.strip()
-
-        if not isinstance(branch, str) or not branch.strip():
-            summaries.append(f"{name!r} (skipped — missing or non-string branch)")
-            continue
-        branch = branch.strip()
-
-        if not _SAFE_NAME.match(name):
+        if not is_valid_repo_name(name):
             summaries.append(f"{name!r} (skipped — invalid subscription name)")
             continue
 
@@ -166,28 +175,50 @@ def main():
 
         head_before = None
         if not repo_path.is_dir():
-            remote = sub.get("remote")
             if not remote:
                 summaries.append(f"{name} (not cloned — no remote in config, run /evolve-lite:subscribe first)")
                 continue
             repo_path.parent.mkdir(parents=True, exist_ok=True)
-            clone_result = subprocess.run(
-                ["git", "clone", remote, str(repo_path), "--branch", branch, "--depth", "1"],
-                capture_output=True,
-                text=True,
-                timeout=_GIT_TIMEOUT,
-            )
+            clone_cmd = ["git", "clone", "--branch", branch]
+            if scope == "read":
+                clone_cmd += ["--depth", "1"]
+            clone_cmd += ["--", remote, str(repo_path)]
+            try:
+                clone_result = subprocess.run(
+                    clone_cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=_GIT_TIMEOUT,
+                )
+            except subprocess.TimeoutExpired:
+                summaries.append(f"{name} (re-clone failed — timeout)")
+                total_delta[name] = {"added": 0, "updated": 0, "removed": 0}
+                any_changes = True
+                continue
             if clone_result.returncode != 0:
                 summaries.append(f"{name} (re-clone failed: {clone_result.stderr.strip()})")
                 total_delta[name] = {"added": 0, "updated": 0, "removed": 0}
+                any_changes = True
                 continue
         else:
             head_before = _head_hash(repo_path)
 
-        pull_result = git_sync(repo_path, branch)
-        if pull_result is None or pull_result.returncode != 0:
-            summaries.append(f"{name} (sync failed — skipping)")
+        if scope == "write":
+            pull_result = sync_writable(repo_path, branch)
+        else:
+            pull_result = sync_read_only(repo_path, branch)
+
+        if pull_result is None:
+            summaries.append(f"{name} (sync failed — timeout)")
             total_delta[name] = {"added": 0, "updated": 0, "removed": 0}
+            any_changes = True
+            continue
+        if pull_result.returncode != 0:
+            err = (pull_result.stderr or pull_result.stdout or "").strip().splitlines()
+            short_error = err[-1] if err else f"git exited with {pull_result.returncode}"
+            summaries.append(f"{name} (sync failed: {short_error})")
+            total_delta[name] = {"added": 0, "updated": 0, "removed": 0}
+            any_changes = True
             continue
 
         head_after = _head_hash(repo_path)
@@ -202,7 +233,7 @@ def main():
             any_changes = True
 
         delta_str = f"+{delta['added']} added, {delta['updated']} updated, {delta['removed']} removed"
-        summaries.append(f"{name} ({delta_str})")
+        summaries.append(f"{name} [{scope}] ({delta_str})")
 
     # Audit
     audit_append(

--- a/platform-integrations/claude/plugins/evolve-lite/skills/unsubscribe/SKILL.md
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/unsubscribe/SKILL.md
@@ -1,19 +1,22 @@
 ---
 name: unsubscribe
-description: Remove a subscription and delete the locally synced guidelines.
+description: Remove a repo from the unified repos list and delete its local clone.
 ---
 
-# Unsubscribe from Guidelines
+# Remove a Repo
 
 ## Overview
 
-This skill removes a subscription and deletes the locally cloned guidelines for that subscription.
+Remove a configured repo (any scope) from `evolve.config.yaml` and delete
+its local clone. Warn the user before removing a **write-scope** repo since
+any locally published entities that haven't been pushed will be lost.
 
 ## Workflow
 
-### Step 1: List subscriptions
+### Step 1: List repos
 
-Run the following and display the output as a numbered list:
+Run the following and display the output as a numbered list. Include each
+entry's `scope` and `notes`:
 
 ```bash
 python3 ${CLAUDE_PLUGIN_ROOT}/skills/unsubscribe/scripts/unsubscribe.py --list
@@ -23,15 +26,20 @@ python3 ${CLAUDE_PLUGIN_ROOT}/skills/unsubscribe/scripts/unsubscribe.py --list
 
 Ask the user:
 
-> "Which subscription would you like to remove? Enter the number."
+> "Which repo would you like to remove? Enter the number."
 
-### Step 3: Confirm
+### Step 3: Confirm (extra warning if write-scope)
 
-Ask the user:
+If the chosen entry has `scope: write`, warn:
 
-> "This will remove '{name}' and delete `.evolve/subscribed/{name}/`. Continue? (y/n)"
+> "'{name}' is a write-scope repo. Removing it will delete the local clone AND any locally published entities that have not yet been pushed. Continue? (y/n)"
 
-If the user answers anything other than `y` or `yes`, stop and tell them the operation was cancelled.
+Otherwise:
+
+> "This will remove '{name}' and delete `.evolve/entities/subscribed/{name}/`. Continue? (y/n)"
+
+If the user answers anything other than `y` or `yes`, stop and tell them
+the operation was cancelled.
 
 ### Step 4: Run unsubscribe script
 
@@ -43,4 +51,4 @@ python3 ${CLAUDE_PLUGIN_ROOT}/skills/unsubscribe/scripts/unsubscribe.py --name {
 
 Tell the user:
 
-> "Unsubscribed from {name}."
+> "Removed '{name}'."

--- a/platform-integrations/claude/plugins/evolve-lite/skills/unsubscribe/scripts/unsubscribe.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/unsubscribe/scripts/unsubscribe.py
@@ -1,76 +1,76 @@
 #!/usr/bin/env python3
-"""Remove a subscription and delete the locally cloned directory.
+"""Remove a repo from the unified ``repos`` list and delete its local clone.
+
+Works for both read-scope (subscribed) and write-scope (publish target) repos.
 
 Usage:
-  --list          Print subscriptions as a JSON array and exit.
-  --name {name}   Remove named subscription from config and delete local dir.
+  --list          Print configured repos as a JSON array and exit.
+  --name {name}   Remove the named repo from config and delete its local dir.
 """
 
 import argparse
 import json
 import os
-import re
 import shutil
 import sys
 from pathlib import Path
 
 # Add lib to path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent.parent / "lib"))
-from config import load_config, save_config
-from audit import append as audit_append
-
-_SAFE_NAME = re.compile(r"^[A-Za-z0-9._-]+$")
+from config import (  # noqa: E402
+    is_valid_repo_name,
+    load_config,
+    normalize_repos,
+    save_config,
+    set_repos,
+)
+from audit import append as audit_append  # noqa: E402
 
 
 def main():
     parser = argparse.ArgumentParser()
     group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument("--list", action="store_true", help="Print subscriptions as JSON array")
-    group.add_argument("--name", help="Name of subscription to remove")
+    group.add_argument("--list", action="store_true", help="Print repos as JSON array")
+    group.add_argument("--name", help="Name of repo to remove")
     args = parser.parse_args()
 
     project_root = "."
     evolve_dir = Path(os.environ.get("EVOLVE_DIR", ".evolve"))
 
     cfg = load_config(project_root)
-    subscriptions = cfg.get("subscriptions", [])
-    if not isinstance(subscriptions, list):
-        subscriptions = []
+    repos = normalize_repos(cfg)
 
     if args.list:
-        print(json.dumps(subscriptions, indent=2))
+        print(json.dumps(repos, indent=2))
         return
 
-    # --name: remove the named subscription
     name = args.name
-    if not _SAFE_NAME.match(name):
+
+    if not is_valid_repo_name(name):
         print(f"Error: invalid subscription name: {name!r}", file=sys.stderr)
         sys.exit(1)
-    new_subs = [s for s in subscriptions if not (isinstance(s, dict) and s.get("name") == name)]
 
-    if len(new_subs) == len(subscriptions):
+    subscribed_base = (evolve_dir / "entities" / "subscribed").resolve()
+    dest = (evolve_dir / "entities" / "subscribed" / name).resolve()
+    if not dest.is_relative_to(subscribed_base) or dest == subscribed_base:
+        print(f"Error: invalid subscription name: {name!r}", file=sys.stderr)
+        sys.exit(1)
+
+    new_repos = [r for r in repos if r.get("name") != name]
+
+    if len(new_repos) == len(repos):
         print(f"Error: subscription '{name}' not found.", file=sys.stderr)
         sys.exit(1)
 
-    # Delete local clone
-    dest = evolve_dir / "entities" / "subscribed" / name
     if dest.exists():
         shutil.rmtree(dest)
         print(f"Deleted {dest}")
     else:
         print(f"Warning: {dest} did not exist.", file=sys.stderr)
 
-    # Delete mirrored entities so they stop appearing in recall
-    entities_dest = evolve_dir / "entities" / "subscribed" / name
-    if entities_dest.exists():
-        shutil.rmtree(entities_dest)
-        print(f"Deleted {entities_dest}")
-
-    # Update config
-    cfg["subscriptions"] = new_subs
+    set_repos(cfg, new_repos)
     save_config(cfg, project_root)
 
-    # Audit
     identity = cfg.get("identity", {})
     actor = identity.get("user", "unknown") if isinstance(identity, dict) else "unknown"
     audit_append(

--- a/platform-integrations/codex/plugins/evolve-lite/README.md
+++ b/platform-integrations/codex/plugins/evolve-lite/README.md
@@ -21,35 +21,34 @@ Entities and sharing data are stored in the active workspace under:
 .evolve/
   entities/
     guideline/
-      use-context-managers-for-file-operations.md
+      use-context-managers-for-file-operations.md     # private
     subscribed/
-      alice/
+      memory/                                          # write-scope clone (publish target)
+        guideline/
+          my-published-guideline.md
+      alice/                                           # read-scope clone
         guideline/
           prefer-small-functions.md
-  public/
-    guideline/
-      no-eval.md
-  subscribed/
-    alice/
-      guideline/
-        prefer-small-functions.md
   audit.log
 ```
 
 Each entity is a markdown file with lightweight YAML frontmatter.
 
-Sharing configuration lives in `evolve.config.yaml` at the repo root:
+Sharing configuration lives in `evolve.config.yaml` at the repo root, as a
+single unified list of repos (both read- and write-scope):
 
 ```yaml
 identity:
   user: alice
 
-public_repo:
-  remote: git@github.com:alice/evolve-guidelines.git
-  branch: main
-
-subscriptions:
+repos:
+  - name: memory
+    scope: write
+    remote: git@github.com:alice/evolve-memory.git
+    branch: main
+    notes: public memory for foobar project
   - name: team
+    scope: read
     remote: git@github.com:myorg/evolve-guidelines.git
     branch: main
 
@@ -99,11 +98,14 @@ If you do not want to enable Codex hooks, you can still invoke the installed `ev
 
 The installed Codex hook does not require `git`. It walks upward from the current working directory until it finds the repo-local `plugins/evolve-lite/.../retrieve_entities.py` script.
 
-The installer always registers a `SessionStart` hook with matcher `startup|resume`; it runs on every Codex session start or resume and exits quickly unless `sync.on_session_start` is enabled and subscriptions are configured in `evolve.config.yaml`.
+The installer always registers a `SessionStart` hook with matcher `startup|resume`; it runs on every Codex session start or resume and exits quickly unless `sync.on_session_start` is enabled and at least one repo is configured in `evolve.config.yaml`.
 
 ## Sharing Guidelines
 
-Evolve Lite supports sharing guidelines between users via public Git repositories. You can publish your own guidelines so others can subscribe to them, and subscribe to guidelines published by others.
+Evolve Lite treats shared guidelines as multi-reader / multi-writer git
+databases. A single unified `repos:` list in `evolve.config.yaml` describes
+every external guideline repo; each entry has a `scope` of `read` (subscribe
+only) or `write` (publish target that is also pulled on sync).
 
 ### Setup
 
@@ -113,11 +115,12 @@ Sharing uses `evolve.config.yaml` at the project root. Minimal structure:
 identity:
   user: yourname
 
-public_repo:
-  remote: git@github.com:yourname/evolve-guidelines.git
-  branch: main
-
-subscriptions: []
+repos:
+  - name: memory
+    scope: write
+    remote: git@github.com:yourname/evolve-memory.git
+    branch: main
+    notes: public memory for my open-source projects
 
 sync:
   on_session_start: true
@@ -125,49 +128,58 @@ sync:
 
 The `.evolve/` directory is kept out of version control.
 
+### Subscribing to a Repo
+
+Use `evolve-lite:subscribe` to add either a read-only subscription or a
+write-scope publish target. The repo is cloned directly into
+`.evolve/entities/subscribed/{name}/` so recall picks it up immediately.
+Names must use only letters, numbers, `.`, `_`, and `-`.
+
 ### Publishing Guidelines
 
-Use `evolve-lite:publish` to share one or more of your local guidelines with others:
+Use `evolve-lite:publish` to share local guidelines via a **write-scope**
+repo:
 
-1. Pick a file from `.evolve/entities/guideline/`
-2. Publish it into `.evolve/public/guideline/`
-3. The published file is stamped with `visibility: public`, `published_at`, and a `source` label derived from config when available
-4. The original private guideline is removed from `.evolve/entities/guideline/`
+1. The skill selects (or asks about) the write-scope target repo
+2. Pick a file from `.evolve/entities/guideline/`
+3. Publish moves it into `.evolve/entities/subscribed/{repo}/guideline/`,
+   stamps it with `visibility: public`, `published_at`, `owner`, and a
+   `source` label derived from the repo's remote
+4. The original private guideline is removed from
+   `.evolve/entities/guideline/`
 
-Others can then subscribe using that public remote URL.
+Because the publish target is also a subscribed repo, your next sync pulls
+in anything other writers have pushed to the same remote.
 
-### Subscribing to Guidelines
+### Syncing Repos
 
-Use `evolve-lite:subscribe` to pull in guidelines from another user's public repo.
+Use `evolve-lite:sync` to pull the latest changes from every configured
+repo (both scopes). Read-scope repos use `git fetch` + `git reset --hard`;
+write-scope repos use `git fetch` + `git rebase` so unpushed local publish
+commits are preserved.
 
-The repo is cloned directly into `.evolve/entities/subscribed/{name}/` so recall can pick it up immediately. Subscription names must use only letters, numbers, `.`, `_`, and `-`.
+If `sync.on_session_start: true` is set in config, this runs automatically
+whenever a Codex session starts or resumes.
 
-### Syncing Subscriptions
+### Removing a Repo
 
-Use `evolve-lite:sync` to pull the latest changes from all subscribed repos already cloned under `.evolve/entities/subscribed/`.
-
-If `sync.on_session_start: true` is set in config, this runs automatically whenever a Codex session starts or resumes.
-
-### Unsubscribing
-
-Use `evolve-lite:unsubscribe` to remove a subscription and delete its locally cloned files.
-
-This removes `.evolve/entities/subscribed/{name}/`. If an older workspace still has `.evolve/subscribed/{name}/`, unsubscribe cleans that up too.
+Use `evolve-lite:unsubscribe` to remove any configured repo and delete its
+local clone at `.evolve/entities/subscribed/{name}/`.
 
 ### Sharing Storage Layout
 
 ```text
 .evolve/
-  public/
-    guideline/
-      guideline-name.md         # published guideline, included in recall
   entities/
     guideline/
       private-guideline.md      # private local guideline
     subscribed/
-      alice/
+      memory/                   # write-scope clone — publishes land here
         guideline/
-          her-guideline.md      # git clone used directly by recall, annotated [from: alice]
+          my-published-guideline.md
+      alice/                    # read-scope clone
+        guideline/
+          her-guideline.md      # recall annotates as [from: alice]
 ```
 
 ## Example Walkthrough
@@ -182,23 +194,30 @@ Analyze the current session and save proactive Evolve entities as markdown files
 
 ### `evolve-lite:recall`
 
-Show the entities already stored for the current workspace, including published guidelines under `.evolve/public/`.
+Show the entities already stored for the current workspace, including
+guidelines pulled from any write- or read-scope repo under
+`.evolve/entities/subscribed/`.
 
 ### `evolve-lite:publish`
 
-Move selected private guidelines into `.evolve/public/`, stamp them as public, and push them to your configured sharing repo.
+Move a selected private guideline into a configured write-scope repo's
+local clone at `.evolve/entities/subscribed/{repo}/guideline/`, stamp it
+as public, commit it, and push it.
 
 ### `evolve-lite:subscribe`
 
-Clone another user's public guideline repo into `.evolve/entities/subscribed/` and register it in `evolve.config.yaml`.
+Add an entry to the unified `repos:` list (read- or write-scope) and clone
+the remote into `.evolve/entities/subscribed/{name}/`.
 
 ### `evolve-lite:unsubscribe`
 
-Remove a configured subscription and delete its local cloned subscription data.
+Remove a configured repo from `repos:` and delete its local clone.
 
 ### `evolve-lite:sync`
 
-Pull every configured subscription under `.evolve/entities/subscribed/` so recall sees the latest shared guidelines automatically.
+Pull the latest from every configured repo (both scopes). Write-scope
+repos use rebase to preserve unpushed local publish commits; read-scope
+repos use hard reset to mirror the remote exactly.
 
 ## Environment Variables
 

--- a/platform-integrations/codex/plugins/evolve-lite/skills/publish/SKILL.md
+++ b/platform-integrations/codex/plugins/evolve-lite/skills/publish/SKILL.md
@@ -1,39 +1,31 @@
 ---
 name: publish
-description: Publish a private guideline to your public repo so others can subscribe to it.
+description: Publish a private guideline to a configured write-scope repo.
 ---
 
-# Publish Guideline
+# Publish a Guideline
 
 ## Overview
 
-This skill publishes one or more private guidelines from your local `.evolve/entities/guideline/` directory to your public git repository, moving them into the public store so others can subscribe to them.
+Publish one or more private guidelines from `.evolve/entities/guideline/`
+into a configured **write-scope** repo. The entity is stamped with
+`visibility: public`, `owner`, `published_at`, and `source`, moved into
+the local clone of the write repo, and committed / pushed to the remote.
+
+The same local clone is also what `/evolve-lite:sync` pulls from — so you
+and anyone else publishing to the same repo stay in sync.
 
 ## Workflow
 
-### Step 1: Bootstrap config if missing or incomplete
+### Step 1: Require a write-scope repo
 
-Check whether `evolve.config.yaml` exists in the project root.
+Read `evolve.config.yaml`. If no entry has `scope: write`, tell the user:
 
-If it does not exist, ask the user for:
+> "You need at least one write-scope repo to publish to. Run evolve-lite:subscribe with --scope write to set one up, then come back."
 
-- a username such as `vatche`
-- the remote URL for the public guidelines repo
+Then stop.
 
-Create `evolve.config.yaml` with:
-
-```yaml
-identity:
-  user: {username}
-public_repo:
-  remote: {remote}
-  branch: main
-subscriptions: []
-sync:
-  on_session_start: true
-```
-
-If the file exists but `identity.user` or `public_repo.remote` is missing, ask only for the missing values and update the file.
+If `identity.user` is missing, ask for it and add it to the config.
 
 ### Step 2: First-time setup
 
@@ -43,35 +35,102 @@ Ensure `.evolve/` is gitignored at the project root:
 grep -qxF '.evolve/' .gitignore 2>/dev/null || echo '.evolve/' >> .gitignore
 ```
 
-If `.evolve/public/` does not already contain a `.git` directory, initialize it and add the configured remote:
+### Step 3: Pick the target write-scope repo
 
-```bash
-git init .evolve/public
-git -C .evolve/public remote add origin {public_repo.remote}
-```
+Filter `repos:` to entries with `scope: write` (Step 1 already aborted if
+there were zero, so at least one exists here).
 
-### Step 3: List and select entities
+- Exactly one entry → use it as default.
+- Multiple entries → show a numbered list with `notes` and ask which to publish to.
 
-List the files in `.evolve/entities/guideline/` and ask the user which ones to publish.
+Let `{repo}` be the chosen repo name and `{branch}` its configured branch (default `main`).
 
-### Step 4: Run publish script
+### Step 4: List and select entities
+
+List files in `.evolve/entities/guideline/` and ask the user which to publish.
+
+### Step 5: Run publish script
 
 For each selected file, run:
 
 ```bash
 python3 plugins/evolve-lite/skills/publish/scripts/publish.py \
   --entity "{filename}" \
+  --repo "{repo}" \
   --user "{identity.user}"
 ```
 
-### Step 5: Commit and push
+### Step 6: Commit and push
+
+Build `{names}` as a comma-joined list of selected filenames, and
+`{guideline_paths}` as a space-joined list of the corresponding
+`guideline/{filename}` paths inside the clone (the files the publish
+script just wrote).
 
 ```bash
-git -C .evolve/public add .
-git -C .evolve/public commit -m "[evolve] publish: {name}"
-git -C .evolve/public push origin "{public_repo.branch}"
+git -C ".evolve/entities/subscribed/{repo}" add -- {guideline_paths}
+git -C ".evolve/entities/subscribed/{repo}" commit -m "[evolve] publish: {names}"
+git -C ".evolve/entities/subscribed/{repo}" push origin "{branch}"
 ```
 
-### Step 6: Confirm
+On push success, continue to Step 7.
 
-Tell the user what was published and where it was pushed.
+### Step 6a: Recover from non-fast-forward rejection
+
+If the push fails and stderr mentions `rejected` / `non-fast-forward`
+/ `fetch first`, another writer pushed to `{branch}` in between.
+Rebase the local commit and push once more:
+
+```bash
+git -C ".evolve/entities/subscribed/{repo}" fetch origin "{branch}"
+git -C ".evolve/entities/subscribed/{repo}" rebase "origin/{branch}"
+```
+
+- Rebase clean → retry `git push origin "{branch}"` once, then Step 7.
+- Rebase conflicted → attempt to resolve, then hand off for user
+  review. Do not `git rebase --continue` or `git push` without an
+  explicit user confirmation.
+
+  1. `git -C ".evolve/entities/subscribed/{repo}" status --porcelain`
+     lists the conflicted paths. If any are `UD`, `DU`, or binary,
+     skip to the abort step — those aren't safe to auto-resolve.
+  2. For each `UU`/`AA` file, read the conflict markers. During a
+     rebase, `<<<<<<< HEAD` is the **remote's** version and the
+     section under the commit sha is the **publish change** being
+     replayed (opposite of a regular merge). Write an
+     intent-preserving resolution; don't `git add` yet.
+  3. Show the user the diff (`git -C ".evolve/entities/subscribed/{repo}" diff HEAD -- {file}`) per
+     resolved file with a one-line strategy summary, and ask whether
+     to **continue** (stage + `rebase --continue` + push) or **abort**
+     (roll back for manual resolution).
+  4. On **continue**:
+
+     ```bash
+     git -C ".evolve/entities/subscribed/{repo}" add {resolved-files}
+     git -C ".evolve/entities/subscribed/{repo}" rebase --continue
+     git -C ".evolve/entities/subscribed/{repo}" push origin "{branch}"
+     ```
+
+     Then Step 7. If `rebase --continue` surfaces a new conflict, loop
+     from step 1.
+  5. On **abort** — user declined, conflict isn't safely resolvable,
+     or the proposed merge feels unsafe:
+
+     ```bash
+     git -C ".evolve/entities/subscribed/{repo}" rebase --abort
+     ```
+
+     The local publish commit is preserved at
+     `.evolve/entities/subscribed/{repo}` but not on the remote. Tell
+     the user to either (a) resolve manually in that directory
+     (`git fetch origin {branch} && git rebase origin/{branch}`, fix
+     conflicts, `git add` + `git rebase --continue`, `git push origin
+     {branch}`) or (b) re-run `evolve-lite:publish` with a different
+     filename if the conflict is a shared name.
+
+If the push fails for any other reason (auth, network, missing remote
+ref), surface git's error and stop — rebase will not help.
+
+### Step 7: Confirm
+
+Tell the user what was published and to which repo.

--- a/platform-integrations/codex/plugins/evolve-lite/skills/publish/scripts/publish.py
+++ b/platform-integrations/codex/plugins/evolve-lite/skills/publish/scripts/publish.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Publish a private guideline entity to the public directory."""
+"""Publish a private guideline entity to a write-scope repo (Codex)."""
 
 import argparse
 import datetime
@@ -27,35 +27,49 @@ if _lib is None:
 sys.path.insert(0, str(_lib))
 from audit import append as audit_append  # noqa: E402
 from entity_io import entity_to_markdown, markdown_to_entity  # noqa: E402
-from config import load_config  # noqa: E402
+from config import get_repo, load_config, normalize_repos, write_repos  # noqa: E402
 
 
-def _resolve_source(cfg, user_arg):
-    """Derive a source label from config or fallback to the provided user."""
-    remote = cfg.get("public_repo", {})
-    if isinstance(remote, dict):
-        remote = remote.get("remote", "")
-    if remote:
+def _resolve_source(repo, effective_user):
+    remote = repo.get("remote") if isinstance(repo, dict) else None
+    if isinstance(remote, str):
         match = re.search(r"[:/]([^/:]+/[^/]+?)(?:\.git)?$", remote)
         if match:
             return match.group(1)
+    return effective_user
 
-    identity = cfg.get("identity", {})
-    if isinstance(identity, dict) and identity.get("user"):
-        return identity["user"]
 
-    return user_arg
+def _select_target_repo(cfg, requested_name):
+    write = write_repos(cfg)
+
+    if requested_name:
+        repo = get_repo(cfg, requested_name)
+        if repo is None:
+            available = ", ".join(r["name"] for r in normalize_repos(cfg)) or "(none)"
+            return None, f"no repo named '{requested_name}' is configured. Configured repos: {available}"
+        if repo.get("scope") != "write":
+            return None, f"repo '{requested_name}' has scope={repo.get('scope')!r}; publish requires scope=write"
+        return repo, None
+
+    if not write:
+        return None, ("no write-scope repo configured. Run evolve-lite:subscribe with --scope write to set up a publish target.")
+    if len(write) > 1:
+        names = ", ".join(r["name"] for r in write)
+        return None, f"multiple write-scope repos configured; pick one with --repo. Available: {names}"
+    return write[0], None
 
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--entity", required=True, help="Basename of the .md file to publish")
     parser.add_argument("--user", default=None, help="Username to stamp as owner")
+    parser.add_argument("--repo", default=None, help="Write-scope repo name (optional if exactly one is configured)")
     args = parser.parse_args()
 
     evolve_dir = Path(os.environ.get("EVOLVE_DIR", ".evolve"))
     resolved_evolve_dir = evolve_dir.resolve()
     project_root = str(resolved_evolve_dir) if evolve_dir.name != ".evolve" else str(resolved_evolve_dir.parent)
+
     if PurePath(args.entity).name != args.entity or args.entity in {".", ".."}:
         print(f"Error: invalid entity name: {args.entity!r}", file=sys.stderr)
         sys.exit(1)
@@ -71,20 +85,34 @@ def main():
         print(f"Error: entity file not found or is a directory: {src_path}", file=sys.stderr)
         sys.exit(1)
 
-    entity = markdown_to_entity(src_path)
     config = load_config(project_root)
+    target, err = _select_target_repo(config, args.repo)
+    if err is not None:
+        print(f"Error: {err}", file=sys.stderr)
+        sys.exit(1)
+
     identity = config.get("identity", {})
     effective_user = args.user or (identity.get("user") if isinstance(identity, dict) else None)
 
+    entity = markdown_to_entity(src_path)
     entity["visibility"] = "public"
     if effective_user:
         entity["owner"] = effective_user
     entity["published_at"] = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-    source = _resolve_source(config, effective_user)
+    source = _resolve_source(target, effective_user)
     if source:
         entity["source"] = source
 
-    dest_dir = evolve_dir / "public" / "guideline"
+    clone_root = evolve_dir / "entities" / "subscribed" / target["name"]
+    if not (clone_root / ".git").exists():
+        print(
+            f"Error: target repo clone not found at {clone_root}. "
+            f"Run evolve-lite:subscribe with --scope write first, or evolve-lite:sync "
+            f"to clone it.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    dest_dir = clone_root / "guideline"
     dest_dir.mkdir(parents=True, exist_ok=True)
     dest_base = dest_dir.resolve()
     dest_path = (dest_dir / args.entity).resolve()
@@ -122,11 +150,12 @@ def main():
             action="publish",
             actor=effective_user or "unknown",
             entity=args.entity,
+            repo=target["name"],
         )
     except Exception as exc:
         print(f"Warning: failed to append audit entry for publish: {exc}", file=sys.stderr)
 
-    print(f"Published: {args.entity} -> {dest_path}")
+    print(f"Published: {args.entity} -> {dest_path} (repo: {target['name']})")
 
 
 if __name__ == "__main__":

--- a/platform-integrations/codex/plugins/evolve-lite/skills/recall/SKILL.md
+++ b/platform-integrations/codex/plugins/evolve-lite/skills/recall/SKILL.md
@@ -27,7 +27,7 @@ Before any non-trivial local work, you must complete the recall workflow below. 
 
 Do not proceed to other analysis or tool use until all steps below are complete.
 
-1. Inspect `.evolve/entities/` and `.evolve/public/` for guidance relevant to the current task.
+1. Inspect `.evolve/entities/` for guidance relevant to the current task.
 2. Read each matching entity file that appears relevant.
 3. Summarize the applicable guidance in your own words before proceeding.
 4. If no relevant entities exist, state that explicitly before proceeding.
@@ -36,12 +36,12 @@ Do not proceed to other analysis or tool use until all steps below are complete.
 
 Before moving on, produce an explicit completion note in your reasoning or user update using one of these forms:
 
-- `Recall complete: searched .evolve/entities/ and .evolve/public/, read <files>, applicable guidance: <summary>`
-- `Recall complete: searched .evolve/entities/ and .evolve/public/, no relevant entities found`
+- `Recall complete: searched .evolve/entities/, read <files>, applicable guidance: <summary>`
+- `Recall complete: searched .evolve/entities/, no relevant entities found`
 
 ### Minimum Acceptable Procedure
 
-1. List or search files under `.evolve/entities/` and `.evolve/public/`.
+1. List or search files under `.evolve/entities/`.
 2. Identify candidate entities relevant to the task.
 3. Open and read those entity files.
 4. Summarize what applies, or state that nothing applies.
@@ -51,7 +51,7 @@ Before moving on, produce an explicit completion note in your reasoning or user 
 The skill is not complete if any of the following are true:
 
 - You only read this `SKILL.md`
-- You did not inspect `.evolve/entities/` and `.evolve/public/`
+- You did not inspect `.evolve/entities/`
 - You did not read the relevant entity files
 - You proceeded without stating whether guidance was found
 
@@ -59,26 +59,25 @@ The skill is not complete if any of the following are true:
 
 1. If Codex hooks are enabled in `~/.codex/config.toml` with `[features] codex_hooks = true`, the Codex `UserPromptSubmit` hook runs before the prompt is sent.
 2. The helper script reads the prompt JSON from stdin.
-3. It loads stored entities from `.evolve/entities/` and `.evolve/public/`.
+3. It loads stored entities from `.evolve/entities/` (covers private,
+   read-scope subscriptions, and write-scope publish targets which all
+   live under `entities/subscribed/{repo}/`).
 4. It prints formatted guidance to stdout.
 5. Codex adds that text as extra developer context for the turn.
 
 ## Entities Storage
-
-Entities are loaded from two locations:
 
 ```text
 .evolve/entities/
   guideline/
     use-context-managers-for-file-operations.md   <- private
   subscribed/
-    alice/
+    memory/                                       <- write-scope clone (publishes land here)
+      guideline/
+        my-published-guideline.md
+    alice/                                        <- read-scope clone
       guideline/
         alice-guideline.md                        <- annotated [from: alice]
-
-.evolve/public/
-  guideline/
-    published-guideline.md                        <- your own public, no annotation
 ```
 
 Each file uses markdown with YAML frontmatter:

--- a/platform-integrations/codex/plugins/evolve-lite/skills/recall/scripts/retrieve_entities.py
+++ b/platform-integrations/codex/plugins/evolve-lite/skills/recall/scripts/retrieve_entities.py
@@ -22,7 +22,7 @@ for _ancestor in _script.parents:
 if _lib is None:
     raise ImportError(f"Cannot find plugin lib directory above {_script}")
 sys.path.insert(0, str(_lib))
-from entity_io import find_entities_dir, get_evolve_dir, markdown_to_entity, log as _log  # noqa: E402
+from entity_io import find_entities_dir, markdown_to_entity, log as _log  # noqa: E402
 
 
 def log(message):
@@ -107,11 +107,6 @@ def main():
     entities = []
     if entities_dir:
         entities = load_entities_with_source(entities_dir)
-
-    public_dir = get_evolve_dir() / "public"
-    if public_dir.is_dir():
-        log(f"Loading public entities from: {public_dir}")
-        entities += load_entities_with_source(public_dir)
 
     if not entities:
         log("No entities found")

--- a/platform-integrations/codex/plugins/evolve-lite/skills/subscribe/SKILL.md
+++ b/platform-integrations/codex/plugins/evolve-lite/skills/subscribe/SKILL.md
@@ -1,26 +1,44 @@
 ---
 name: subscribe
-description: Subscribe to another user's public guidelines repo.
+description: Add a shared guidelines repo (read-scope subscription or write-scope publish target) to the unified repos list.
 ---
 
-# Subscribe to Guidelines
+# Subscribe to a Shared Repo
 
 ## Overview
 
-This skill subscribes to another user's public guidelines repository. Their guidelines are cloned locally and become available in recall after sync.
+Configured guidelines repos are multi-reader / multi-writer git databases,
+described in a single unified list in `evolve.config.yaml`:
+
+```yaml
+repos:
+  - name: memory
+    scope: write
+    remote: git@github.com:alice/evolve.git
+    branch: main
+    notes: public memory for foobar project
+  - name: org-memory
+    scope: read
+    remote: git@github.com:acme/org-memory.git
+    branch: main
+    notes: private memory shared only within my org
+```
+
+- `scope: read` — download-only. Synced on every run.
+- `scope: write` — publish target. Synced on every run too, so you see
+  what you have already published and anything others have pushed.
 
 ## Workflow
 
 ### Step 1: Bootstrap config if missing
 
-Check whether `evolve.config.yaml` exists in the project root.
-
-If it does not exist, ask the user for a username and create:
+If `evolve.config.yaml` does not exist, ask the user for a username and
+create:
 
 ```yaml
 identity:
   user: {username}
-subscriptions: []
+repos: []
 sync:
   on_session_start: true
 ```
@@ -37,6 +55,8 @@ Ask the user for:
 
 - the remote URL for the guidelines repo
 - a short local name such as `alice`
+- the scope: `read` (default, subscribe-only) or `write` (also a publish target)
+- an optional note
 
 ### Step 3: Run subscribe script
 
@@ -44,9 +64,12 @@ Ask the user for:
 python3 plugins/evolve-lite/skills/subscribe/scripts/subscribe.py \
   --name "{name}" \
   --remote "{remote}" \
-  --branch main
+  --branch main \
+  --scope "{scope}" \
+  --notes "{notes}"
 ```
 
 ### Step 4: Confirm
 
-Tell the user the subscription was added and they can run `evolve-lite:sync` immediately if they want to pull updates now.
+Tell the user the repo was added and they can run `evolve-lite:sync`
+immediately if they want to pull updates now.

--- a/platform-integrations/codex/plugins/evolve-lite/skills/subscribe/scripts/subscribe.py
+++ b/platform-integrations/codex/plugins/evolve-lite/skills/subscribe/scripts/subscribe.py
@@ -103,7 +103,16 @@ def main():
             remote=args.remote,
         )
     except Exception as exc:
-        print(f"Warning: failed to append audit entry for subscribe: {exc}", file=sys.stderr)
+        repos.pop()
+        set_repos(cfg, repos)
+        try:
+            save_config(cfg, project_root)
+        except Exception:
+            pass
+        if dest.exists():
+            shutil.rmtree(dest)
+        print(f"Error: failed to record subscription — clone removed: {exc}", file=sys.stderr)
+        sys.exit(1)
 
     print(f"Subscribed to '{args.name}' (scope={args.scope}) from {args.remote}")
 

--- a/platform-integrations/codex/plugins/evolve-lite/skills/subscribe/scripts/subscribe.py
+++ b/platform-integrations/codex/plugins/evolve-lite/skills/subscribe/scripts/subscribe.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
-"""Subscribe to another user's public guidelines repo."""
+"""Add a repo to the unified ``repos`` list and clone it locally (Codex)."""
 
 import argparse
 import os
-import re
 import shutil
 import subprocess
 import sys
@@ -26,60 +25,68 @@ if _lib is None:
     raise ImportError(f"Cannot find plugin lib directory above {_script}")
 sys.path.insert(0, str(_lib))
 from audit import append as audit_append  # noqa: E402
-from config import load_config, save_config  # noqa: E402
+from config import (  # noqa: E402
+    VALID_SCOPES,
+    is_valid_repo_name,
+    load_config,
+    normalize_repos,
+    save_config,
+    set_repos,
+)
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--name", required=True, help="Short subscription name")
+    parser.add_argument("--name", required=True, help="Short repo name")
     parser.add_argument("--remote", required=True, help="Git remote URL")
     parser.add_argument("--branch", default="main", help="Branch to track")
+    parser.add_argument("--scope", default="read", choices=VALID_SCOPES)
+    parser.add_argument("--notes", default="")
     args = parser.parse_args()
 
     evolve_dir = Path(os.environ.get("EVOLVE_DIR", ".evolve"))
-    safe_name = re.compile(r"^[A-Za-z0-9._-]+$")
     project_root = str(evolve_dir.resolve()) if evolve_dir.name != ".evolve" else str(evolve_dir.resolve().parent)
     subscribed_base = (evolve_dir / "entities" / "subscribed").resolve()
     dest = (evolve_dir / "entities" / "subscribed" / args.name).resolve()
-    legacy_dest = (evolve_dir / "subscribed" / args.name).resolve()
-    if args.name in {"", "."} or not safe_name.match(args.name) or dest == subscribed_base or not dest.is_relative_to(subscribed_base):
+
+    if not is_valid_repo_name(args.name) or dest == subscribed_base or not dest.is_relative_to(subscribed_base):
         print(f"Error: invalid subscription name: {args.name!r}", file=sys.stderr)
         sys.exit(1)
 
     cfg = load_config(project_root)
-    subscriptions = cfg.get("subscriptions", [])
-    if not isinstance(subscriptions, list):
-        subscriptions = []
+    repos = normalize_repos(cfg)
 
-    for sub in subscriptions:
-        if isinstance(sub, dict) and sub.get("name") == args.name:
+    for repo in repos:
+        if repo.get("name") == args.name:
             print(f"Error: subscription '{args.name}' already exists in config.", file=sys.stderr)
             sys.exit(1)
 
-    if dest.exists() or legacy_dest.exists():
+    if dest.exists():
         print(f"Error: destination already exists: {dest}", file=sys.stderr)
         sys.exit(1)
-    else:
-        dest.parent.mkdir(parents=True, exist_ok=True)
-        subprocess.run(
-            [
-                "git",
-                "clone",
-                args.remote,
-                str(dest),
-                "--branch",
-                args.branch,
-                "--depth",
-                "1",
-            ],
-            check=True,
-        )
 
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    # Write-scope repos need full history so the user can safely rebase and
+    # push publish commits. Read-scope repos only mirror, so shallow is enough.
+    clone_cmd = ["git", "clone", args.remote, str(dest), "--branch", args.branch]
+    if args.scope == "read":
+        clone_cmd += ["--depth", "1"]
+    subprocess.run(clone_cmd, check=True)
+
+    repos.append(
+        {
+            "name": args.name,
+            "scope": args.scope,
+            "remote": args.remote,
+            "branch": args.branch,
+            "notes": args.notes,
+        }
+    )
+    set_repos(cfg, repos)
     try:
-        subscriptions.append({"name": args.name, "remote": args.remote, "branch": args.branch})
-        cfg["subscriptions"] = subscriptions
         save_config(cfg, project_root)
     except Exception:
+        repos.pop()
         if dest.exists():
             shutil.rmtree(dest)
         raise
@@ -92,12 +99,13 @@ def main():
             action="subscribe",
             actor=actor,
             name=args.name,
+            scope=args.scope,
             remote=args.remote,
         )
     except Exception as exc:
         print(f"Warning: failed to append audit entry for subscribe: {exc}", file=sys.stderr)
 
-    print(f"Subscribed to '{args.name}' from {args.remote}")
+    print(f"Subscribed to '{args.name}' (scope={args.scope}) from {args.remote}")
 
 
 if __name__ == "__main__":

--- a/platform-integrations/codex/plugins/evolve-lite/skills/sync/SKILL.md
+++ b/platform-integrations/codex/plugins/evolve-lite/skills/sync/SKILL.md
@@ -1,13 +1,16 @@
 ---
 name: sync
-description: Pull the latest guidelines from all subscribed repos.
+description: Pull the latest guidelines from every configured repo (read- and write-scope).
 ---
 
-# Sync Subscriptions
+# Sync Repos
 
 ## Overview
 
-This skill pulls the latest guidelines from all subscribed repos and mirrors them into local recall storage.
+Pull the latest guidelines from every repo in `evolve.config.yaml`
+`repos:` list — both `scope: read` (subscribe-only) and `scope: write`
+(publish targets). Write-scope repos use a rebase strategy so any
+unpushed local publish commits are preserved.
 
 ## Workflow
 
@@ -19,4 +22,6 @@ python3 plugins/evolve-lite/skills/sync/scripts/sync.py
 
 ### Step 2: Display summary
 
-Show the script output to the user. If there are no subscriptions, tell them they can add one with `evolve-lite:subscribe`. If there are no changes, explain that everything is already up to date.
+Show the script output to the user. If there are no repos configured,
+tell them they can add one with `evolve-lite:subscribe`. If there are no
+changes, explain that everything is already up to date.

--- a/platform-integrations/codex/plugins/evolve-lite/skills/sync/scripts/sync.py
+++ b/platform-integrations/codex/plugins/evolve-lite/skills/sync/scripts/sync.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
-"""Pull the latest guidelines from all subscribed repos."""
+"""Pull the latest guidelines from every configured repo (Codex)."""
 
 import argparse
 import os
-import re
 import subprocess
 import sys
 from pathlib import Path
@@ -25,36 +24,47 @@ if _lib is None:
     raise ImportError(f"Cannot find plugin lib directory above {_script}")
 sys.path.insert(0, str(_lib))
 from audit import append as audit_append  # noqa: E402
-from config import _parse_yaml, load_config  # noqa: E402
+from config import is_valid_repo_name, load_config, normalize_repos  # noqa: E402
 
 
 _GIT_TIMEOUT = 30  # seconds
 
 
-def git_pull(repo_path, branch):
-    """Pull latest from origin. Returns CompletedProcess, or None on timeout."""
+def _git(repo_path, *args, timeout=_GIT_TIMEOUT):
     try:
         return subprocess.run(
-            ["git", "-C", str(repo_path), "pull", "origin", branch, "--ff-only"],
+            ["git", "-C", str(repo_path), *args],
             capture_output=True,
             text=True,
-            timeout=_GIT_TIMEOUT,
+            timeout=timeout,
         )
     except subprocess.TimeoutExpired:
-        print(f"Warning: git pull timed out for {repo_path} (branch: {branch})", file=sys.stderr)
         return None
 
 
+def sync_read_only(repo_path, branch):
+    """Fetch and hard-reset to origin/{branch} (read-only mirror)."""
+    fetch = _git(repo_path, "fetch", "origin", branch)
+    if fetch is None or fetch.returncode != 0:
+        return fetch
+    return _git(repo_path, "reset", "--hard", f"origin/{branch}")
+
+
+def sync_writable(repo_path, branch):
+    """Fetch and rebase local commits onto origin/{branch} (preserves publishes)."""
+    fetch = _git(repo_path, "fetch", "origin", branch)
+    if fetch is None or fetch.returncode != 0:
+        return fetch
+    rebase = _git(repo_path, "rebase", f"origin/{branch}")
+    if rebase is None or rebase.returncode != 0:
+        _git(repo_path, "rebase", "--abort")
+        return rebase
+    return rebase
+
+
 def count_delta(repo_path):
-    """Count added/modified/deleted .md files since last pull."""
-    result = subprocess.run(
-        ["git", "-C", str(repo_path), "diff", "--name-status", "HEAD@{1}", "HEAD"],
-        capture_output=True,
-        text=True,
-        timeout=_GIT_TIMEOUT,
-    )
-    if result.returncode != 0:
-        # HEAD@{1} doesn't exist (initial sync) — count all .md files as added.
+    result = _git(repo_path, "diff", "--name-status", "HEAD@{1}", "HEAD")
+    if result is None or result.returncode != 0:
         added = len(list(repo_path.glob("**/*.md")))
         return {"added": added, "updated": 0, "removed": 0}
     added = updated = removed = 0
@@ -93,8 +103,7 @@ def main():
     audit_root = resolved_evolve_dir if resolved_evolve_dir.name == ".evolve" else resolved_evolve_dir / ".evolve"
 
     if args.config:
-        cfg_path = Path(args.config)
-        cfg = _parse_yaml(cfg_path.read_text(encoding="utf-8")) if cfg_path.exists() else {}
+        cfg = load_config(filepath=args.config)
     else:
         cfg = load_config(project_root)
 
@@ -102,11 +111,9 @@ def main():
     if args.session_start and isinstance(sync_cfg, dict) and sync_cfg.get("on_session_start") is False:
         sys.exit(0)
 
-    subscriptions = cfg.get("subscriptions", [])
-    if not isinstance(subscriptions, list):
-        subscriptions = []
+    repos = normalize_repos(cfg)
 
-    if not subscriptions:
+    if not repos:
         if not args.quiet:
             print("No subscriptions configured. Add one with the evolve-lite:subscribe skill to start syncing shared guidelines.")
         sys.exit(0)
@@ -117,71 +124,81 @@ def main():
     summaries = []
     total_delta = {}
     any_changes = False
-    safe_name = re.compile(r"^[A-Za-z0-9._-]+$")
 
-    for sub in subscriptions:
-        if not isinstance(sub, dict):
+    for repo in repos:
+        raw_name = repo.get("name", "unknown")
+        scope = repo.get("scope", "read")
+        branch = repo.get("branch", "main")
+        remote = repo.get("remote")
+
+        if not is_valid_repo_name(raw_name):
+            summaries.append(f"{raw_name!r} (skipped - invalid subscription name)")
             continue
-        raw_name = sub.get("name", "unknown")
-        raw_branch = sub.get("branch", "main")
-
-        if not isinstance(raw_name, str) or not isinstance(raw_branch, str):
-            summaries.append(f"{raw_name!r} (skipped - invalid subscription config)")
-            continue
-
         name = raw_name.strip()
-        branch = raw_branch.strip()
 
-        if not name or not branch:
+        if not isinstance(branch, str) or not branch.strip():
             summaries.append(f"{raw_name!r} (skipped - invalid subscription config)")
             continue
-
-        if not safe_name.match(name):
-            summaries.append(f"{name!r} (skipped - invalid subscription name)")
-            continue
+        branch = branch.strip()
 
         subscribed_base = (evolve_dir / "entities" / "subscribed").resolve()
         repo_path = (evolve_dir / "entities" / "subscribed" / name).resolve()
-        legacy_base = (evolve_dir / "subscribed").resolve()
-        legacy_repo_path = (evolve_dir / "subscribed" / name).resolve()
 
         if repo_path == subscribed_base or not repo_path.is_relative_to(subscribed_base):
             summaries.append(f"{name!r} (skipped - invalid subscription name)")
             continue
 
-        if legacy_repo_path != legacy_base and legacy_repo_path.is_relative_to(legacy_base):
-            if legacy_repo_path.exists() and not repo_path.exists():
-                repo_path.parent.mkdir(parents=True, exist_ok=True)
-                legacy_repo_path.rename(repo_path)
-            elif legacy_repo_path.exists() and repo_path.exists():
-                summaries.append(f"{name} (duplicate subscription folders — remove .evolve/subscribed/{name})")
+        if not repo_path.is_dir():
+            if not remote:
+                summaries.append(f"{name} (not cloned)")
+                continue
+            repo_path.parent.mkdir(parents=True, exist_ok=True)
+            clone_cmd = ["git", "clone", "--branch", branch]
+            if scope == "read":
+                clone_cmd += ["--depth", "1"]
+            clone_cmd += ["--", remote, str(repo_path)]
+            try:
+                clone_result = subprocess.run(
+                    clone_cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=_GIT_TIMEOUT,
+                )
+            except subprocess.TimeoutExpired:
+                summaries.append(f"{name} (re-clone failed - timeout)")
+                total_delta[name] = {"added": 0, "updated": 0, "removed": 0}
+                any_changes = True
+                continue
+            if clone_result.returncode != 0:
+                summaries.append(f"{name} (re-clone failed: {clone_result.stderr.strip()})")
+                total_delta[name] = {"added": 0, "updated": 0, "removed": 0}
+                any_changes = True
                 continue
 
-        if not repo_path.is_dir():
-            summaries.append(f"{name} (not cloned)")
-            continue
+        if scope == "write":
+            pull_result = sync_writable(repo_path, branch)
+        else:
+            pull_result = sync_read_only(repo_path, branch)
 
-        pull_result = git_pull(repo_path, branch)
-        if pull_result is None or pull_result.returncode != 0:
-            if pull_result is None:
-                short_error = "timeout"
-            else:
-                error_lines = (pull_result.stderr or pull_result.stdout or "").strip().splitlines()
-                short_error = error_lines[-1] if error_lines else f"git exited with {pull_result.returncode}"
-            summaries.append(f"{name} (git pull failed: {short_error})")
+        if pull_result is None:
+            summaries.append(f"{name} (sync failed - timeout)")
+            total_delta[name] = {"added": 0, "updated": 0, "removed": 0}
+            any_changes = True
+            continue
+        if pull_result.returncode != 0:
+            error_lines = (pull_result.stderr or pull_result.stdout or "").strip().splitlines()
+            short_error = error_lines[-1] if error_lines else f"git exited with {pull_result.returncode}"
+            summaries.append(f"{name} (sync failed: {short_error})")
             total_delta[name] = {"added": 0, "updated": 0, "removed": 0}
             any_changes = True
             continue
 
-        if "Already up to date" in (pull_result.stdout or ""):
-            delta = {"added": 0, "updated": 0, "removed": 0}
-        else:
-            delta = count_delta(repo_path)
+        delta = count_delta(repo_path)
         total_delta[name] = delta
         if any(value > 0 for value in delta.values()):
             any_changes = True
 
-        summaries.append(f"{name} (+{delta['added']} added, {delta['updated']} updated, {delta['removed']} removed)")
+        summaries.append(f"{name} [{scope}] (+{delta['added']} added, {delta['updated']} updated, {delta['removed']} removed)")
 
     audit_append(project_root=str(audit_root.parent), action="sync", actor=actor, delta=total_delta)
 

--- a/platform-integrations/codex/plugins/evolve-lite/skills/unsubscribe/SKILL.md
+++ b/platform-integrations/codex/plugins/evolve-lite/skills/unsubscribe/SKILL.md
@@ -1,17 +1,20 @@
 ---
 name: unsubscribe
-description: Remove a subscription and delete the locally synced guidelines.
+description: Remove a repo from the unified repos list and delete its local clone.
 ---
 
-# Unsubscribe from Guidelines
+# Remove a Repo
 
 ## Overview
 
-This skill removes a subscription and deletes both the local clone and mirrored recall entities for that subscription.
+Remove a configured repo (any scope) from `evolve.config.yaml` and delete
+its local clone at `.evolve/entities/subscribed/{name}/`. Warn the user
+before removing a write-scope repo since any unpushed local publish
+commits will be lost.
 
 ## Workflow
 
-### Step 1: List subscriptions
+### Step 1: List repos
 
 Run:
 
@@ -19,14 +22,13 @@ Run:
 python3 plugins/evolve-lite/skills/unsubscribe/scripts/unsubscribe.py --list
 ```
 
-Show the subscriptions to the user and ask which one to remove.
+Show the repos to the user (including `scope` and `notes`) and ask which
+one to remove.
 
 ### Step 2: Confirm
 
-Confirm that removing the subscription will delete:
-
-- `.evolve/subscribed/{name}/`
-- `.evolve/entities/subscribed/{name}/`
+Confirm deletion of `.evolve/entities/subscribed/{name}/`. If the repo has
+`scope: write`, add a warning that unpushed local publishes will be lost.
 
 ### Step 3: Run unsubscribe script
 
@@ -36,4 +38,4 @@ python3 plugins/evolve-lite/skills/unsubscribe/scripts/unsubscribe.py --name "{n
 
 ### Step 4: Confirm
 
-Tell the user the subscription was removed.
+Tell the user the repo was removed.

--- a/platform-integrations/codex/plugins/evolve-lite/skills/unsubscribe/scripts/unsubscribe.py
+++ b/platform-integrations/codex/plugins/evolve-lite/skills/unsubscribe/scripts/unsubscribe.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Remove a subscription and delete the locally cloned directory."""
+"""Remove a repo from the unified ``repos`` list and delete its local clone (Codex)."""
 
 import argparse
 import json
@@ -25,43 +25,42 @@ if _lib is None:
     raise ImportError(f"Cannot find plugin lib directory above {_script}")
 sys.path.insert(0, str(_lib))
 from audit import append as audit_append  # noqa: E402
-from config import load_config, save_config  # noqa: E402
+from config import (  # noqa: E402
+    is_valid_repo_name,
+    load_config,
+    normalize_repos,
+    save_config,
+    set_repos,
+)
 
 
 def main():
     parser = argparse.ArgumentParser()
     group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument("--list", action="store_true", help="Print subscriptions as JSON array")
-    group.add_argument("--name", help="Name of subscription to remove")
+    group.add_argument("--list", action="store_true", help="Print repos as JSON array")
+    group.add_argument("--name", help="Name of repo to remove")
     args = parser.parse_args()
 
     evolve_dir = Path(os.environ.get("EVOLVE_DIR", ".evolve"))
     project_root = str(evolve_dir.resolve()) if evolve_dir.name != ".evolve" else str(evolve_dir.resolve().parent)
 
     cfg = load_config(project_root)
-    subscriptions = cfg.get("subscriptions", [])
-    if not isinstance(subscriptions, list):
-        subscriptions = []
+    repos = normalize_repos(cfg)
 
     if args.list:
-        print(json.dumps(subscriptions, indent=2))
+        print(json.dumps(repos, indent=2))
         return
 
     name = args.name
     subscribed_base = (evolve_dir / "entities" / "subscribed").resolve()
     dest = (evolve_dir / "entities" / "subscribed" / name).resolve()
-    if name in {"", "."} or dest == subscribed_base or not dest.is_relative_to(subscribed_base):
+
+    if not is_valid_repo_name(name) or dest == subscribed_base or not dest.is_relative_to(subscribed_base):
         print(f"Error: invalid subscription name: {name!r}", file=sys.stderr)
         sys.exit(1)
 
-    legacy_base = (evolve_dir / "subscribed").resolve()
-    legacy_dest = (evolve_dir / "subscribed" / name).resolve()
-    if legacy_dest == legacy_base or not legacy_dest.is_relative_to(legacy_base):
-        print(f"Error: invalid subscription name: {name!r}", file=sys.stderr)
-        sys.exit(1)
-
-    new_subs = [s for s in subscriptions if not (isinstance(s, dict) and s.get("name") == name)]
-    if len(new_subs) == len(subscriptions):
+    new_repos = [r for r in repos if r.get("name") != name]
+    if len(new_repos) == len(repos):
         print(f"Error: subscription '{name}' not found.", file=sys.stderr)
         sys.exit(1)
 
@@ -71,11 +70,7 @@ def main():
     else:
         print(f"Warning: {dest} did not exist.", file=sys.stderr)
 
-    if legacy_dest.exists():
-        shutil.rmtree(legacy_dest)
-        print(f"Deleted {legacy_dest}")
-
-    cfg["subscriptions"] = new_subs
+    set_repos(cfg, new_repos)
     save_config(cfg, project_root)
 
     identity = cfg.get("identity", {})

--- a/tests/platform_integrations/test_bob_sharing.py
+++ b/tests/platform_integrations/test_bob_sharing.py
@@ -1,5 +1,6 @@
 """Tests for Bob's entity sharing functionality (subscribe, unsubscribe, sync, publish)."""
 
+import importlib.util
 import json
 import os
 import subprocess
@@ -7,8 +8,6 @@ import sys
 from pathlib import Path
 
 import pytest
-
-import importlib.util
 
 
 def _load_claude_config_module():
@@ -40,7 +39,6 @@ def run_script(script, project_dir, args=None, evolve_dir=None, stdin_data=None,
     shared modules (config, audit, entity_io) without requiring a symlink in the repo.
     """
     env = {**os.environ}
-    # Inject Claude's lib into PYTHONPATH for imports
     env["PYTHONPATH"] = str(_CLAUDE_LIB) + os.pathsep + env.get("PYTHONPATH", "")
     if evolve_dir:
         env["EVOLVE_DIR"] = str(evolve_dir)
@@ -74,7 +72,7 @@ class TestBobSubscribe:
         assert (evolve_dir / "entities" / "subscribed" / "alice").is_dir()
         assert (evolve_dir / "entities" / "subscribed" / "alice" / ".git").exists()
 
-    def test_updates_config_with_subscription(self, temp_project_dir, local_repo):
+    def test_updates_config_with_repo_entry(self, temp_project_dir, local_repo):
         evolve_dir = temp_project_dir / ".evolve"
         run_script(
             SUBSCRIBE_SCRIPT,
@@ -83,11 +81,24 @@ class TestBobSubscribe:
             evolve_dir=evolve_dir,
         )
         cfg = cfg_module.load_config(str(temp_project_dir))
-        subs = cfg.get("subscriptions", [])
-        assert len(subs) == 1
-        assert subs[0]["name"] == "alice"
-        assert subs[0]["branch"] == "main"
-        assert str(local_repo["bare"]) in subs[0]["remote"]
+        repos = cfg_module.normalize_repos(cfg)
+        assert len(repos) == 1
+        assert repos[0]["name"] == "alice"
+        assert repos[0]["scope"] == "read"
+        assert repos[0]["branch"] == "main"
+        assert str(local_repo["bare"]) in repos[0]["remote"]
+
+    def test_write_scope_recorded_in_config(self, temp_project_dir, local_repo):
+        evolve_dir = temp_project_dir / ".evolve"
+        run_script(
+            SUBSCRIBE_SCRIPT,
+            temp_project_dir,
+            ["--name", "team", "--remote", str(local_repo["bare"]), "--branch", "main", "--scope", "write"],
+            evolve_dir=evolve_dir,
+        )
+        cfg = cfg_module.load_config(str(temp_project_dir))
+        repos = cfg_module.normalize_repos(cfg)
+        assert repos[0]["scope"] == "write"
 
     def test_writes_audit_log(self, temp_project_dir, local_repo):
         evolve_dir = temp_project_dir / ".evolve"
@@ -99,13 +110,12 @@ class TestBobSubscribe:
         )
         log_path = temp_project_dir / ".evolve" / "audit.log"
         assert log_path.exists()
-        # Parse JSONL format (one JSON object per line)
         entries = [json.loads(line) for line in log_path.read_text().splitlines() if line.strip()]
         actions = [e["action"] for e in entries]
         assert "subscribe" in actions
-        # Find the subscribe entry and verify its details
         subscribe_entry = next(e for e in entries if e["action"] == "subscribe")
         assert subscribe_entry["name"] == "alice"
+        assert subscribe_entry["scope"] == "read"
 
     def test_fails_on_duplicate_name(self, temp_project_dir, local_repo):
         evolve_dir = temp_project_dir / ".evolve"
@@ -141,7 +151,7 @@ class TestBobSubscribe:
         assert result.returncode != 0
         assert "already exists" in result.stderr
         cfg = cfg_module.load_config(str(temp_project_dir))
-        assert cfg.get("subscriptions", []) == []
+        assert cfg_module.normalize_repos(cfg) == []
 
     def test_rejects_empty_or_dot_name(self, temp_project_dir, local_repo):
         evolve_dir = temp_project_dir / ".evolve"
@@ -177,12 +187,12 @@ class TestBobSubscribe:
 class TestBobUnsubscribe:
     """Tests for Bob's unsubscribe.py script."""
 
-    def _subscribe(self, temp_project_dir, local_repo, name="alice"):
+    def _subscribe(self, temp_project_dir, local_repo, name="alice", scope="read"):
         evolve_dir = temp_project_dir / ".evolve"
         run_script(
             SUBSCRIBE_SCRIPT,
             temp_project_dir,
-            ["--name", name, "--remote", str(local_repo["bare"]), "--branch", "main"],
+            ["--name", name, "--remote", str(local_repo["bare"]), "--branch", "main", "--scope", scope],
             evolve_dir=evolve_dir,
         )
         return evolve_dir
@@ -192,18 +202,19 @@ class TestBobUnsubscribe:
         run_script(UNSUBSCRIBE_SCRIPT, temp_project_dir, ["--name", "alice"], evolve_dir=evolve_dir)
         assert not (evolve_dir / "entities" / "subscribed" / "alice").exists()
 
-    def test_removes_subscription_from_config(self, temp_project_dir, local_repo):
+    def test_removes_repo_from_config(self, temp_project_dir, local_repo):
         evolve_dir = self._subscribe(temp_project_dir, local_repo)
         run_script(UNSUBSCRIBE_SCRIPT, temp_project_dir, ["--name", "alice"], evolve_dir=evolve_dir)
         cfg = cfg_module.load_config(str(temp_project_dir))
-        assert cfg.get("subscriptions", []) == []
+        assert cfg_module.normalize_repos(cfg) == []
 
-    def test_list_flag_prints_subscriptions_as_json(self, temp_project_dir, local_repo):
+    def test_list_flag_prints_repos_as_json(self, temp_project_dir, local_repo):
         evolve_dir = self._subscribe(temp_project_dir, local_repo)
         result = run_script(UNSUBSCRIBE_SCRIPT, temp_project_dir, ["--list"], evolve_dir=evolve_dir)
         data = json.loads(result.stdout)
         assert isinstance(data, list)
         assert data[0]["name"] == "alice"
+        assert data[0]["scope"] == "read"
 
     def test_fails_when_name_not_found(self, temp_project_dir, local_repo):
         evolve_dir = self._subscribe(temp_project_dir, local_repo)
@@ -219,8 +230,6 @@ class TestBobUnsubscribe:
 
     def test_removes_mirrored_entities(self, temp_project_dir, local_repo):
         evolve_dir = self._subscribe(temp_project_dir, local_repo)
-        # Simulate mirrored entities (sync would create these)
-        # The subscription already created the directory, so just add a file to it
         mirrored = evolve_dir / "entities" / "subscribed" / "alice"
         assert mirrored.exists(), "Subscription should have created this directory"
         (mirrored / "tip.md").write_text("---\ntype: guideline\n---\n\nA tip.\n")
@@ -228,7 +237,7 @@ class TestBobUnsubscribe:
         run_script(UNSUBSCRIBE_SCRIPT, temp_project_dir, ["--name", "alice"], evolve_dir=evolve_dir)
         assert not mirrored.exists()
 
-    def test_list_empty_when_no_subscriptions(self, temp_project_dir):
+    def test_list_empty_when_no_repos(self, temp_project_dir):
         evolve_dir = temp_project_dir / ".evolve"
         result = run_script(UNSUBSCRIBE_SCRIPT, temp_project_dir, ["--list"], evolve_dir=evolve_dir)
         data = json.loads(result.stdout)
@@ -254,7 +263,7 @@ class TestBobUnsubscribe:
 
 @pytest.fixture
 def subscribed_project(temp_project_dir, local_repo):
-    """A project already subscribed to local_repo."""
+    """A project already subscribed to local_repo (read-scope)."""
     evolve_dir = temp_project_dir / ".evolve"
     run_script(
         SUBSCRIBE_SCRIPT,
@@ -283,15 +292,12 @@ class TestBobSync:
         assert "Always write tests." in guideline.read_text()
 
     def test_picks_up_new_entity_after_push(self, subscribed_project):
-        """After a new entity is pushed to the remote, a second sync picks it up."""
         p = subscribed_project
         lr = p["local_repo"]
         git_env = lr["env"]
 
-        # First sync — brings down the initial entity
         run_script(SYNC_SCRIPT, p["project_dir"], evolve_dir=p["evolve_dir"])
 
-        # Push a new entity to the remote via the working clone
         new_entity = lr["work"] / "guideline" / "tip-two.md"
         new_entity.write_text("---\ntype: guideline\n---\n\nDelete dead code promptly.\n")
         subprocess.run(["git", "-C", str(lr["work"]), "add", "."], check=True, env=git_env)
@@ -306,7 +312,6 @@ class TestBobSync:
             env=git_env,
         )
 
-        # Second sync — should pick up tip-two
         run_script(SYNC_SCRIPT, p["project_dir"], evolve_dir=p["evolve_dir"])
 
         mirrored = p["evolve_dir"] / "entities" / "subscribed" / "alice" / "guideline" / "tip-two.md"
@@ -315,13 +320,11 @@ class TestBobSync:
 
     def test_quiet_flag_suppresses_output_when_no_changes(self, subscribed_project):
         p = subscribed_project
-        # First sync to reach a clean state
         run_script(SYNC_SCRIPT, p["project_dir"], evolve_dir=p["evolve_dir"])
-        # Second sync with --quiet: nothing changed, no output expected
         result = run_script(SYNC_SCRIPT, p["project_dir"], ["--quiet"], evolve_dir=p["evolve_dir"])
         assert result.stdout.strip() == ""
 
-    def test_no_subscriptions_exits_cleanly(self, temp_project_dir):
+    def test_no_repos_exits_cleanly(self, temp_project_dir):
         evolve_dir = temp_project_dir / ".evolve"
         result = run_script(SYNC_SCRIPT, temp_project_dir, evolve_dir=evolve_dir)
         assert result.returncode == 0
@@ -340,10 +343,8 @@ class TestBobSync:
         lr = p["local_repo"]
         git_env = lr["env"]
 
-        # First sync to create the subscribed clone
         run_script(SYNC_SCRIPT, p["project_dir"], evolve_dir=p["evolve_dir"])
 
-        # Create a real file and a symlink in the working repo and push them
         real_file = lr["work"] / "guideline" / "real.md"
         real_file.write_text("---\ntype: guideline\n---\n\nReal content.\n")
         symlink_file = lr["work"] / "guideline" / "link.md"
@@ -361,62 +362,47 @@ class TestBobSync:
             env=git_env,
         )
 
-        # Second sync should pull the changes but skip the symlink
         run_script(SYNC_SCRIPT, p["project_dir"], evolve_dir=p["evolve_dir"])
 
         mirrored = p["evolve_dir"] / "entities" / "subscribed" / "alice" / "guideline"
         assert (mirrored / "real.md").exists(), "Real file should be present"
         assert (mirrored / "link.md").exists(), "Symlink should be present in git clone"
-        # Note: symlinks are filtered out by the retrieve script, not by sync
+        # Symlinks are filtered out by the retrieve script, not by sync.
 
     def test_skips_invalid_subscription_name(self, temp_project_dir):
         evolve_dir = temp_project_dir / ".evolve"
-        # Write config manually with an unsafe name
         cfg_path = temp_project_dir / "evolve.config.yaml"
-        cfg_path.write_text("subscriptions:\n  - name: ../outside\n    remote: git@github.com:x/y.git\n    branch: main\n")
+        cfg_path.write_text('repos:\n  - name: "../outside"\n    scope: "read"\n    remote: "git@github.com:x/y.git"\n    branch: "main"\n')
         result = run_script(SYNC_SCRIPT, temp_project_dir, evolve_dir=evolve_dir)
         assert result.returncode == 0
         assert "invalid subscription name" in result.stdout
         assert not (evolve_dir / "entities" / "subscribed" / "outside").exists()
 
     def test_rejects_dot_and_double_dot_names(self, temp_project_dir):
-        """Sync must reject '.' and '..' subscription names to prevent path traversal."""
+        """Sync must reject '.' and '..' repo names to prevent path traversal."""
         evolve_dir = temp_project_dir / ".evolve"
         cfg_path = temp_project_dir / "evolve.config.yaml"
 
-        # Test single dot
-        cfg_path.write_text("subscriptions:\n  - name: .\n    remote: git@github.com:x/y.git\n    branch: main\n")
+        cfg_path.write_text('repos:\n  - name: "."\n    scope: "read"\n    remote: "git@github.com:x/y.git"\n    branch: "main"\n')
         result = run_script(SYNC_SCRIPT, temp_project_dir, evolve_dir=evolve_dir)
         assert result.returncode == 0
-        assert "invalid subscription name" in result.stdout or "path traversal detected" in result.stdout
+        assert "invalid subscription name" in result.stdout
 
-        # Test double dot
-        cfg_path.write_text("subscriptions:\n  - name: ..\n    remote: git@github.com:x/y.git\n    branch: main\n")
+        cfg_path.write_text('repos:\n  - name: ".."\n    scope: "read"\n    remote: "git@github.com:x/y.git"\n    branch: "main"\n')
         result = run_script(SYNC_SCRIPT, temp_project_dir, evolve_dir=evolve_dir)
         assert result.returncode == 0
-        assert "invalid subscription name" in result.stdout or "path traversal detected" in result.stdout
-
-    def test_manual_run_ignores_on_session_start_false(self, subscribed_project):
-        p = subscribed_project
-        cfg_path = p["project_dir"] / "evolve.config.yaml"
-        cfg_path.write_text("sync:\n  on_session_start: false\nsubscriptions:\n  - name: alice\n    remote: x\n    branch: main\n")
-        # Manual run (no --quiet) must still execute even with on_session_start: false
-        result = run_script(SYNC_SCRIPT, p["project_dir"], evolve_dir=p["evolve_dir"])
-        assert result.returncode == 0
-        assert "Synced" in result.stdout
+        assert "invalid subscription name" in result.stdout
 
     def test_removed_entity_disappears_after_sync(self, subscribed_project):
-        """Entities deleted from the remote are removed from the mirror on next sync."""
+        """Entities deleted from a read-scope remote are removed from the mirror on next sync."""
         p = subscribed_project
         lr = p["local_repo"]
         git_env = lr["env"]
 
-        # First sync
         run_script(SYNC_SCRIPT, p["project_dir"], evolve_dir=p["evolve_dir"])
         guideline_one = p["evolve_dir"] / "entities" / "subscribed" / "alice" / "guideline" / "guideline-one.md"
         assert guideline_one.exists()
 
-        # Delete guideline-one from remote
         subprocess.run(
             ["git", "-C", str(lr["work"]), "rm", "guideline/guideline-one.md"],
             check=True,
@@ -433,7 +419,6 @@ class TestBobSync:
             env=git_env,
         )
 
-        # Second sync — mirror is cleared and re-copied without guideline-one
         run_script(SYNC_SCRIPT, p["project_dir"], evolve_dir=p["evolve_dir"])
         assert not guideline_one.exists()
 
@@ -443,57 +428,135 @@ class TestBobSync:
 # ============================================================================
 
 
+_WRITE_REPO_CONFIG = (
+    "repos:\n"
+    '  - name: "evolve-guidelines"\n'
+    '    scope: "write"\n'
+    '    remote: "git@github.com:alice/evolve-guidelines.git"\n'
+    '    branch: "main"\n'
+)
+
+
+def _published_path(project_dir, filename, repo="evolve-guidelines"):
+    return project_dir / ".evolve" / "entities" / "subscribed" / repo / "guideline" / filename
+
+
+def _clone_write_target(project_dir, local_repo, repo="evolve-guidelines"):
+    """Pre-create the local clone publish.py expects under entities/subscribed/<repo>/."""
+    clone_dir = project_dir / ".evolve" / "entities" / "subscribed" / repo
+    clone_dir.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["git", "clone", "--branch", "main", str(local_repo["bare"]), str(clone_dir)],
+        check=True,
+        capture_output=True,
+        env=local_repo["env"],
+    )
+    return clone_dir
+
+
 class TestBobPublish:
     """Tests for Bob's publish.py script."""
 
-    def test_moves_entity_to_public_dir(self, temp_project_dir):
+    def test_moves_entity_to_write_repo_clone(self, temp_project_dir, local_repo):
         evolve_dir = temp_project_dir / ".evolve"
         entities_dir = evolve_dir / "entities" / "guideline"
         entities_dir.mkdir(parents=True)
         entity = entities_dir / "tip.md"
         entity.write_text("---\ntype: guideline\nvisibility: private\n---\n\nAlways test.\n")
+        (temp_project_dir / "evolve.config.yaml").write_text(_WRITE_REPO_CONFIG)
+        _clone_write_target(temp_project_dir, local_repo)
 
-        run_script(PUBLISH_SCRIPT, temp_project_dir, ["--entity", "tip.md"], evolve_dir=evolve_dir)
+        run_script(
+            PUBLISH_SCRIPT,
+            temp_project_dir,
+            ["--entity", "tip.md", "--user", "alice"],
+            evolve_dir=evolve_dir,
+        )
 
-        public_entity = evolve_dir / "public" / "guideline" / "tip.md"
-        assert public_entity.exists()
+        published = _published_path(temp_project_dir, "tip.md")
+        assert published.exists()
         assert not entity.exists()
-        assert "visibility: public" in public_entity.read_text()
+        content = published.read_text()
+        assert "visibility: public" in content
+        assert "owner: alice" in content
+        assert "published_at:" in content
 
-    def test_publishes_when_public_git_repo_exists(self, temp_project_dir):
-        """Verifies publish succeeds when a git repo is already present in the public directory."""
+    def test_publish_writes_audit_with_repo_field(self, temp_project_dir, local_repo):
         evolve_dir = temp_project_dir / ".evolve"
         entities_dir = evolve_dir / "entities" / "guideline"
         entities_dir.mkdir(parents=True)
-        entity = entities_dir / "tip.md"
-        entity.write_text("---\ntype: guideline\n---\n\nTest.\n")
+        (entities_dir / "tip.md").write_text("---\ntype: guideline\n---\n\nTest.\n")
+        (temp_project_dir / "evolve.config.yaml").write_text(_WRITE_REPO_CONFIG)
+        _clone_write_target(temp_project_dir, local_repo)
 
-        # Initialize git repo manually (Bob expects this to be done via publish SKILL.md instructions)
-        public_dir = evolve_dir / "public"
-        public_dir.mkdir(parents=True)
-        subprocess.run(["git", "init"], cwd=str(public_dir), check=True, capture_output=True)
-        subprocess.run(["git", "checkout", "-b", "main"], cwd=str(public_dir), check=True, capture_output=True)
+        run_script(
+            PUBLISH_SCRIPT,
+            temp_project_dir,
+            ["--entity", "tip.md", "--user", "alice"],
+            evolve_dir=evolve_dir,
+        )
+        entries = [json.loads(line) for line in (evolve_dir / "audit.log").read_text().splitlines() if line.strip()]
+        publish_entry = next(e for e in entries if e["action"] == "publish")
+        assert publish_entry["actor"] == "alice"
+        assert publish_entry["repo"] == "evolve-guidelines"
 
-        run_script(PUBLISH_SCRIPT, temp_project_dir, ["--entity", "tip.md"], evolve_dir=evolve_dir)
-
-        assert (evolve_dir / "public" / ".git").exists()
-        assert (evolve_dir / "public" / "guideline" / "tip.md").exists()
-
-    def test_fails_if_entity_already_published(self, temp_project_dir):
+    def test_fails_if_entity_already_published(self, temp_project_dir, local_repo):
         evolve_dir = temp_project_dir / ".evolve"
-        public_dir = evolve_dir / "public" / "guideline"
-        public_dir.mkdir(parents=True)
-        existing = public_dir / "tip.md"
-        existing.write_text("---\ntype: guideline\nvisibility: public\n---\n\nExisting.\n")
-
         entities_dir = evolve_dir / "entities" / "guideline"
         entities_dir.mkdir(parents=True)
-        entity = entities_dir / "tip.md"
-        entity.write_text("---\ntype: guideline\n---\n\nNew version.\n")
+        source = entities_dir / "tip.md"
+        source.write_text("---\ntype: guideline\n---\n\nNew version.\n")
+        (temp_project_dir / "evolve.config.yaml").write_text(_WRITE_REPO_CONFIG)
+        _clone_write_target(temp_project_dir, local_repo)
 
-        result = run_script(PUBLISH_SCRIPT, temp_project_dir, ["--entity", "tip.md"], evolve_dir=evolve_dir, expect_success=False)
+        dest = _published_path(temp_project_dir, "tip.md")
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text("---\ntype: guideline\nvisibility: public\n---\n\nExisting.\n")
+
+        result = run_script(
+            PUBLISH_SCRIPT,
+            temp_project_dir,
+            ["--entity", "tip.md"],
+            evolve_dir=evolve_dir,
+            expect_success=False,
+        )
         assert result.returncode != 0
         assert "already published" in result.stderr
+        assert source.exists()
+
+    def test_publish_errors_without_write_scope_repo(self, temp_project_dir):
+        evolve_dir = temp_project_dir / ".evolve"
+        entities_dir = evolve_dir / "entities" / "guideline"
+        entities_dir.mkdir(parents=True)
+        (entities_dir / "tip.md").write_text("---\ntype: guideline\n---\n\nContent.\n")
+
+        result = run_script(
+            PUBLISH_SCRIPT,
+            temp_project_dir,
+            ["--entity", "tip.md"],
+            evolve_dir=evolve_dir,
+            expect_success=False,
+        )
+        assert result.returncode != 0
+        assert "no write-scope repo" in result.stderr
+
+    def test_publish_errors_when_target_clone_missing(self, temp_project_dir):
+        """Publish refuses to run unless the write-scope clone has been created."""
+        evolve_dir = temp_project_dir / ".evolve"
+        entities_dir = evolve_dir / "entities" / "guideline"
+        entities_dir.mkdir(parents=True)
+        (entities_dir / "tip.md").write_text("---\ntype: guideline\n---\n\nContent.\n")
+        (temp_project_dir / "evolve.config.yaml").write_text(_WRITE_REPO_CONFIG)
+
+        result = run_script(
+            PUBLISH_SCRIPT,
+            temp_project_dir,
+            ["--entity", "tip.md"],
+            evolve_dir=evolve_dir,
+            expect_success=False,
+        )
+        assert result.returncode != 0
+        assert "target repo clone not found" in result.stderr
 
 
 # ============================================================================
@@ -620,18 +683,19 @@ class TestBobRetrieveEntities:
         (entities_dir / "tip.md").write_text("---\ntype: guideline\n---\n\nPrivate tip.\n")
 
         result = run_script(RETRIEVE_SCRIPT, temp_project_dir, evolve_dir=evolve_dir)
-        # Bob outputs markdown, not JSON
         assert "Private tip" in result.stdout
         assert "## Entities for this task" in result.stdout
 
-    def test_returns_entities_from_public_dir(self, temp_project_dir):
+    def test_returns_published_entities_from_write_clone(self, temp_project_dir):
+        """Published guidelines live in entities/subscribed/{repo}/guideline/."""
         evolve_dir = temp_project_dir / ".evolve"
-        public_dir = evolve_dir / "public" / "guideline"
-        public_dir.mkdir(parents=True)
-        (public_dir / "tip.md").write_text("---\ntype: guideline\nvisibility: public\n---\n\nPublic tip.\n")
+        published_dir = evolve_dir / "entities" / "subscribed" / "my-memory" / "guideline"
+        published_dir.mkdir(parents=True)
+        (published_dir / "tip.md").write_text("---\ntype: guideline\nvisibility: public\n---\n\nPublished tip.\n")
 
         result = run_script(RETRIEVE_SCRIPT, temp_project_dir, evolve_dir=evolve_dir)
-        assert "Public tip" in result.stdout
+        assert "Published tip" in result.stdout
+        assert "[from: my-memory]" in result.stdout
 
     def test_returns_entities_from_subscribed_dir(self, temp_project_dir):
         evolve_dir = temp_project_dir / ".evolve"

--- a/tests/platform_integrations/test_codex_sharing.py
+++ b/tests/platform_integrations/test_codex_sharing.py
@@ -105,9 +105,10 @@ class TestCodexSaveAndRetrieve:
         own_dir = evolve_dir / "entities" / "guideline"
         own_dir.mkdir(parents=True)
         (own_dir / "guideline.md").write_text("---\ntype: guideline\n---\n\nKeep functions small.\n")
-        public_dir = evolve_dir / "public" / "guideline"
-        public_dir.mkdir(parents=True)
-        (public_dir / "published-guideline.md").write_text(
+        # Published entities live inside the write-scope repo's local clone.
+        published_dir = evolve_dir / "entities" / "subscribed" / "my-memory" / "guideline"
+        published_dir.mkdir(parents=True)
+        (published_dir / "published-guideline.md").write_text(
             "---\ntype: guideline\nvisibility: public\nsource: alice/evolve-guidelines\n---\n\nDocument edge cases.\n"
         )
 
@@ -121,15 +122,47 @@ class TestCodexSaveAndRetrieve:
         assert result.returncode == 0
         assert "Keep functions small." in result.stdout
         assert "Document edge cases." in result.stdout
-        assert "[from: alice/evolve-guidelines]" not in result.stdout
+
+
+_WRITE_REPO_CONFIG = (
+    "repos:\n"
+    '  - name: "evolve-guidelines"\n'
+    '    scope: "write"\n'
+    '    remote: "git@github.com:alice/evolve-guidelines.git"\n'
+    '    branch: "main"\n'
+)
+
+
+def _published_path(project_dir, filename, repo="evolve-guidelines"):
+    return project_dir / ".evolve" / "entities" / "subscribed" / repo / "guideline" / filename
+
+
+def _clone_write_target(project_dir, local_repo, repo="evolve-guidelines"):
+    """Pre-create the local clone publish.py expects under entities/subscribed/<repo>/.
+
+    publish.py refuses to run unless the write-scope repo has already been cloned;
+    that's normally subscribe/sync's job. In tests we stand it up directly from
+    the local_repo bare so the precondition is met.
+    """
+    clone_dir = project_dir / ".evolve" / "entities" / "subscribed" / repo
+    clone_dir.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["git", "clone", "--branch", "main", str(local_repo["bare"]), str(clone_dir)],
+        check=True,
+        capture_output=True,
+        env=local_repo["env"],
+    )
+    return clone_dir
 
 
 class TestCodexSharingScripts:
-    def test_publish_moves_entity_to_public_dir_and_audits(self, temp_project_dir):
+    def test_publish_moves_entity_to_target_repo_clone_and_audits(self, temp_project_dir, local_repo):
         guideline_dir = temp_project_dir / ".evolve" / "entities" / "guideline"
         guideline_dir.mkdir(parents=True)
         source = guideline_dir / "my-guideline.md"
         source.write_text("---\ntype: guideline\n---\n\nPrefer composition over inheritance.\n")
+        (temp_project_dir / "evolve.config.yaml").write_text(_WRITE_REPO_CONFIG)
+        _clone_write_target(temp_project_dir, local_repo)
 
         run_script(
             PUBLISH_SCRIPT,
@@ -138,7 +171,7 @@ class TestCodexSharingScripts:
             evolve_dir=temp_project_dir / ".evolve",
         )
 
-        published = temp_project_dir / ".evolve" / "public" / "guideline" / "my-guideline.md"
+        published = _published_path(temp_project_dir, "my-guideline.md")
         assert published.exists()
         assert not source.exists()
         content = published.read_text()
@@ -149,14 +182,14 @@ class TestCodexSharingScripts:
         entry = json.loads((temp_project_dir / ".evolve" / "audit.log").read_text().strip())
         assert entry["action"] == "publish"
         assert entry["actor"] == "alice"
+        assert entry["repo"] == "evolve-guidelines"
 
-    def test_publish_stamps_source_from_public_repo_remote(self, temp_project_dir):
+    def test_publish_stamps_source_from_repo_remote(self, temp_project_dir, local_repo):
         guideline_dir = temp_project_dir / ".evolve" / "entities" / "guideline"
         guideline_dir.mkdir(parents=True)
         (guideline_dir / "my-guideline.md").write_text("---\ntype: guideline\n---\n\nPrefer composition over inheritance.\n")
-        (temp_project_dir / "evolve.config.yaml").write_text(
-            'public_repo:\n  remote: "git@github.com:alice/evolve-guidelines.git"\n  branch: "main"\n'
-        )
+        (temp_project_dir / "evolve.config.yaml").write_text(_WRITE_REPO_CONFIG)
+        _clone_write_target(temp_project_dir, local_repo)
 
         run_script(
             PUBLISH_SCRIPT,
@@ -165,14 +198,16 @@ class TestCodexSharingScripts:
             evolve_dir=temp_project_dir / ".evolve",
         )
 
-        content = (temp_project_dir / ".evolve" / "public" / "guideline" / "my-guideline.md").read_text()
+        content = _published_path(temp_project_dir, "my-guideline.md").read_text()
         assert "source: alice/evolve-guidelines" in content
 
-    def test_publish_uses_identity_user_as_owner_source_and_audit_fallback(self, temp_project_dir):
+    def test_publish_uses_identity_user_as_owner_and_audit_fallback(self, temp_project_dir, local_repo):
+        """Without --user, publish falls back to identity.user for owner/actor."""
         guideline_dir = temp_project_dir / ".evolve" / "entities" / "guideline"
         guideline_dir.mkdir(parents=True)
         (guideline_dir / "my-guideline.md").write_text("---\ntype: guideline\n---\n\nPrefer composition over inheritance.\n")
-        (temp_project_dir / "evolve.config.yaml").write_text('identity:\n  user: "alice"\n')
+        (temp_project_dir / "evolve.config.yaml").write_text('identity:\n  user: "alice"\n' + _WRITE_REPO_CONFIG)
+        _clone_write_target(temp_project_dir, local_repo)
 
         run_script(
             PUBLISH_SCRIPT,
@@ -181,13 +216,15 @@ class TestCodexSharingScripts:
             evolve_dir=temp_project_dir / ".evolve",
         )
 
-        content = (temp_project_dir / ".evolve" / "public" / "guideline" / "my-guideline.md").read_text()
+        content = _published_path(temp_project_dir, "my-guideline.md").read_text()
         assert "owner: alice" in content
-        assert "source: alice" in content
+        # source is derived from the remote when available (not identity.user).
+        assert "source: alice/evolve-guidelines" in content
         entry = json.loads((temp_project_dir / ".evolve" / "audit.log").read_text().strip())
         assert entry["actor"] == "alice"
 
     def test_publish_fails_when_entity_not_found(self, temp_project_dir):
+        # No config needed — the entity-not-found check runs before repo selection.
         result = run_script(
             PUBLISH_SCRIPT,
             project_dir=temp_project_dir,
@@ -198,10 +235,12 @@ class TestCodexSharingScripts:
         assert result.returncode != 0
         assert "not found" in result.stderr
 
-    def test_publish_succeeds_without_user_flag(self, temp_project_dir):
+    def test_publish_succeeds_without_user_flag(self, temp_project_dir, local_repo):
         guideline_dir = temp_project_dir / ".evolve" / "entities" / "guideline"
         guideline_dir.mkdir(parents=True)
         (guideline_dir / "my-guideline.md").write_text("---\ntype: guideline\n---\n\nPrefer composition.\n")
+        (temp_project_dir / "evolve.config.yaml").write_text(_WRITE_REPO_CONFIG)
+        _clone_write_target(temp_project_dir, local_repo)
 
         run_script(
             PUBLISH_SCRIPT,
@@ -209,19 +248,21 @@ class TestCodexSharingScripts:
             args=["--entity", "my-guideline.md"],
             evolve_dir=temp_project_dir / ".evolve",
         )
-        content = (temp_project_dir / ".evolve" / "public" / "guideline" / "my-guideline.md").read_text()
+        content = _published_path(temp_project_dir, "my-guideline.md").read_text()
         assert "visibility: public" in content
 
-    def test_publish_fails_when_public_entity_already_exists(self, temp_project_dir):
+    def test_publish_fails_when_entity_already_published(self, temp_project_dir, local_repo):
         guideline_dir = temp_project_dir / ".evolve" / "entities" / "guideline"
         guideline_dir.mkdir(parents=True)
         source = guideline_dir / "my-guideline.md"
         source.write_text("---\ntype: guideline\n---\n\nPrefer composition.\n")
+        (temp_project_dir / "evolve.config.yaml").write_text(_WRITE_REPO_CONFIG)
+        _clone_write_target(temp_project_dir, local_repo)
 
-        public_path = temp_project_dir / ".evolve" / "public" / "guideline" / "my-guideline.md"
-        public_path.parent.mkdir(parents=True)
+        dest_path = _published_path(temp_project_dir, "my-guideline.md")
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
         existing_content = "---\ntype: guideline\nvisibility: public\n---\n\nExisting public content.\n"
-        public_path.write_text(existing_content)
+        dest_path.write_text(existing_content)
 
         result = run_script(
             PUBLISH_SCRIPT,
@@ -233,8 +274,23 @@ class TestCodexSharingScripts:
 
         assert result.returncode != 0
         assert "already published" in result.stderr
-        assert public_path.read_text() == existing_content
+        assert dest_path.read_text() == existing_content
         assert source.exists()
+
+    def test_publish_errors_without_write_scope_repo(self, temp_project_dir):
+        guideline_dir = temp_project_dir / ".evolve" / "entities" / "guideline"
+        guideline_dir.mkdir(parents=True)
+        (guideline_dir / "my-guideline.md").write_text("---\ntype: guideline\n---\n\nContent.\n")
+
+        result = run_script(
+            PUBLISH_SCRIPT,
+            project_dir=temp_project_dir,
+            args=["--entity", "my-guideline.md"],
+            evolve_dir=temp_project_dir / ".evolve",
+            expect_success=False,
+        )
+        assert result.returncode != 0
+        assert "no write-scope repo" in result.stderr
 
     @pytest.mark.parametrize("entity_name", ["../../etc/passwd", "subdir/guideline.md", ".", ".."])
     def test_publish_rejects_invalid_entity_name(self, temp_project_dir, entity_name):
@@ -261,7 +317,6 @@ class TestCodexSharingScripts:
             evolve_dir=evolve_dir,
         )
         assert (evolve_dir / "entities" / "subscribed" / "alice").is_dir()
-        assert not (evolve_dir / "subscribed" / "alice").exists()
 
         run_script(SYNC_SCRIPT, project_dir=temp_project_dir, evolve_dir=evolve_dir)
         synced = evolve_dir / "entities" / "subscribed" / "alice" / "guideline" / "guideline-one.md"
@@ -274,7 +329,6 @@ class TestCodexSharingScripts:
             args=["--name", "alice"],
             evolve_dir=evolve_dir,
         )
-        assert not (evolve_dir / "subscribed" / "alice").exists()
         assert not (evolve_dir / "entities" / "subscribed" / "alice").exists()
 
     def test_subscribe_updates_config_and_rejects_duplicate(self, temp_project_dir, local_repo):
@@ -450,7 +504,7 @@ class TestCodexSharingScripts:
     def test_sync_skips_invalid_subscription_name(self, temp_project_dir):
         evolve_dir = temp_project_dir / ".evolve"
         (temp_project_dir / "evolve.config.yaml").write_text(
-            'subscriptions:\n  - name: "."\n    remote: "https://example.com/repo.git"\n    branch: "main"\n'
+            'repos:\n  - name: "."\n    scope: "read"\n    remote: "https://example.com/repo.git"\n    branch: "main"\n'
         )
 
         result = run_script(
@@ -474,7 +528,9 @@ class TestCodexSharingScripts:
             env=local_repo["env"],
         )
         (temp_project_dir / "evolve.config.yaml").write_text(
-            f'identity:\n  user: "alice"\nsubscriptions:\n  - name: "alice"\n    remote: "{local_repo["bare"]}"\n    branch: "main"\n'
+            f'identity:\n  user: "alice"\n'
+            f'repos:\n  - name: "alice"\n    scope: "read"\n'
+            f'    remote: "{local_repo["bare"]}"\n    branch: "main"\n'
         )
 
         result = run_script(
@@ -502,7 +558,9 @@ class TestCodexSharingScripts:
             evolve_dir=evolve_dir,
         )
         (temp_project_dir / "evolve.config.yaml").write_text(
-            f'subscriptions:\n  - name: "alice"\n    remote: "{local_repo["bare"]}"\n    branch: "main"\nsync:\n  on_session_start: false\n'
+            f'repos:\n  - name: "alice"\n    scope: "read"\n'
+            f'    remote: "{local_repo["bare"]}"\n    branch: "main"\n'
+            f"sync:\n  on_session_start: false\n"
         )
 
         result = run_script(
@@ -530,7 +588,9 @@ class TestCodexSharingScripts:
         subprocess.run(["git", "-C", str(local_repo["work"]), "commit", "-m", "add guideline-two"], check=True, env=git_env)
         subprocess.run(["git", "-C", str(local_repo["work"]), "push", "origin", "main"], check=True, env=git_env)
         (temp_project_dir / "evolve.config.yaml").write_text(
-            f'subscriptions:\n  - name: "alice"\n    remote: "{local_repo["bare"]}"\n    branch: "main"\nsync:\n  on_session_start: false\n'
+            f'repos:\n  - name: "alice"\n    scope: "read"\n'
+            f'    remote: "{local_repo["bare"]}"\n    branch: "main"\n'
+            f"sync:\n  on_session_start: false\n"
         )
 
         result = run_script(
@@ -635,29 +695,3 @@ class TestCodexSharingScripts:
 
         run_script(SYNC_SCRIPT, project_dir=temp_project_dir, evolve_dir=evolve_dir)
         assert not guideline_one.exists()
-
-    def test_sync_migrates_legacy_subscribed_repo(self, temp_project_dir, local_repo):
-        evolve_dir = temp_project_dir / ".evolve"
-        legacy_dir = evolve_dir / "subscribed"
-        legacy_dir.mkdir(parents=True)
-        subprocess.run(
-            ["git", "clone", "--branch", "main", "--depth", "1", str(local_repo["bare"]), str(legacy_dir / "alice")],
-            check=True,
-            env=local_repo["env"],
-        )
-        (temp_project_dir / "evolve.config.yaml").write_text(
-            f'subscriptions:\n  - name: "alice"\n    remote: "{local_repo["bare"]}"\n    branch: "main"\n'
-        )
-
-        result = run_script(
-            SYNC_SCRIPT,
-            project_dir=temp_project_dir,
-            evolve_dir=evolve_dir,
-            expect_success=False,
-        )
-
-        assert result.returncode == 0
-        migrated_repo = evolve_dir / "entities" / "subscribed" / "alice"
-        assert migrated_repo.is_dir()
-        assert not (evolve_dir / "subscribed" / "alice").exists()
-        assert (migrated_repo / "guideline" / "guideline-one.md").exists()

--- a/tests/platform_integrations/test_config.py
+++ b/tests/platform_integrations/test_config.py
@@ -81,26 +81,24 @@ class TestParseYaml:
         assert result["sync"]["on_session_start"] is True
 
     def test_list_of_dicts(self):
-        text = "subscriptions:\n  - name: bob\n    remote: git@github.com:bob/evolve.git\n    branch: main\n"
+        text = "repos:\n  - name: bob\n    scope: read\n    remote: git@github.com:bob/evolve.git\n    branch: main\n"
         result = cfg_module._parse_yaml(text)
-        subs = result["subscriptions"]
-        assert isinstance(subs, list)
-        assert len(subs) == 1
-        assert subs[0]["name"] == "bob"
-        assert subs[0]["branch"] == "main"
+        repos = result["repos"]
+        assert isinstance(repos, list)
+        assert len(repos) == 1
+        assert repos[0]["name"] == "bob"
+        assert repos[0]["branch"] == "main"
 
-    def test_multiple_subscriptions(self):
+    def test_multiple_repos(self):
         text = (
-            "subscriptions:\n"
-            "  - name: alice\n"
-            "    remote: git@github.com:alice/evolve.git\n"
-            "    branch: main\n"
-            "  - name: bob\n"
-            "    remote: git@github.com:bob/evolve.git\n"
-            "    branch: main\n"
+            "repos:\n"
+            "  - name: alice\n    scope: read\n"
+            "    remote: git@github.com:alice/evolve.git\n    branch: main\n"
+            "  - name: bob\n    scope: read\n"
+            "    remote: git@github.com:bob/evolve.git\n    branch: main\n"
         )
         result = cfg_module._parse_yaml(text)
-        assert len(result["subscriptions"]) == 2
+        assert len(result["repos"]) == 2
 
     def test_empty_input(self):
         assert cfg_module._parse_yaml("") == {}
@@ -135,19 +133,175 @@ class TestRoundtrip:
     def test_full_config_roundtrip(self, tmp_path):
         original = {
             "identity": {"user": "alice"},
-            "public_repo": {"remote": "git@github.com:alice/evolve.git", "branch": "main"},
-            "subscriptions": [{"name": "bob", "remote": "git@github.com:bob/evolve.git", "branch": "main"}],
+            "repos": [
+                {
+                    "name": "memory",
+                    "scope": "write",
+                    "remote": "git@github.com:alice/evolve.git",
+                    "branch": "main",
+                    "notes": "public memory",
+                },
+                {
+                    "name": "bob",
+                    "scope": "read",
+                    "remote": "git@github.com:bob/evolve.git",
+                    "branch": "main",
+                    "notes": "",
+                },
+            ],
             "sync": {"on_session_start": True},
         }
         cfg_module.save_config(original, str(tmp_path))
         loaded = cfg_module.load_config(str(tmp_path))
 
         assert loaded["identity"]["user"] == "alice"
-        assert loaded["public_repo"]["branch"] == "main"
         assert loaded["sync"]["on_session_start"] is True
-        assert loaded["subscriptions"][0]["name"] == "bob"
+        repos = loaded["repos"]
+        assert repos[0]["scope"] == "write"
+        assert repos[0]["notes"] == "public memory"
+        assert repos[1]["name"] == "bob"
 
-    def test_empty_subscriptions_roundtrip(self, tmp_path):
-        cfg_module.save_config({"subscriptions": []}, str(tmp_path))
-        loaded = cfg_module.load_config(str(tmp_path))
-        assert loaded["subscriptions"] == []
+    def test_empty_repos_roundtrip(self, temp_project_dir):
+        cfg_module.save_config({"repos": []}, str(temp_project_dir))
+        loaded = cfg_module.load_config(str(temp_project_dir))
+        assert loaded["repos"] == []
+
+
+class TestNormalizeRepos:
+    def test_modern_config_pass_through(self):
+        cfg = {
+            "repos": [
+                {
+                    "name": "memory",
+                    "scope": "write",
+                    "remote": "git@github.com:alice/evolve.git",
+                    "branch": "main",
+                    "notes": "shared",
+                },
+            ]
+        }
+        repos = cfg_module.normalize_repos(cfg)
+        assert len(repos) == 1
+        assert repos[0]["scope"] == "write"
+        assert repos[0]["notes"] == "shared"
+
+    def test_invalid_scope_entries_dropped(self, capsys):
+        cfg = {
+            "repos": [
+                {"name": "x", "scope": "weird", "remote": "git@x:y/z.git"},
+                {"name": "y", "scope": "write", "remote": "git@x:y/y.git"},
+            ]
+        }
+        repos = cfg_module.normalize_repos(cfg)
+        assert [r["name"] for r in repos] == ["y"]
+        assert "unknown scope" in capsys.readouterr().err
+
+    def test_scope_whitespace_tolerated(self):
+        cfg = {"repos": [{"name": "x", "scope": " write ", "remote": "git@x:y/z.git"}]}
+        repos = cfg_module.normalize_repos(cfg)
+        assert len(repos) == 1
+        assert repos[0]["scope"] == "write"
+
+    def test_missing_scope_defaults_to_read(self):
+        cfg = {"repos": [{"name": "x", "remote": "git@x:y/z.git"}]}
+        repos = cfg_module.normalize_repos(cfg)
+        assert len(repos) == 1
+        assert repos[0]["scope"] == "read"
+        assert repos[0]["name"] == "x"
+        assert repos[0]["remote"] == "git@x:y/z.git"
+
+    def test_returns_empty_for_missing_or_non_list_repos(self):
+        assert cfg_module.normalize_repos({}) == []
+        assert cfg_module.normalize_repos({"repos": "not a list"}) == []
+        assert cfg_module.normalize_repos(None) == []
+
+    def test_entries_missing_required_fields_dropped(self):
+        cfg = {
+            "repos": [
+                {"name": "ok", "remote": "git@x:y/z.git"},
+                {"name": "", "remote": "git@x:y/z.git"},
+                {"name": "no-remote"},
+                "garbage",
+            ]
+        }
+        repos = cfg_module.normalize_repos(cfg)
+        assert [r["name"] for r in repos] == ["ok"]
+
+    def test_duplicate_names_deduplicated(self):
+        cfg = {
+            "repos": [
+                {"name": "same", "remote": "git@x:y/a.git"},
+                {"name": "same", "remote": "git@x:y/b.git"},
+            ]
+        }
+        repos = cfg_module.normalize_repos(cfg)
+        assert len(repos) == 1
+        assert repos[0]["remote"] == "git@x:y/a.git"
+
+
+class TestSetRepos:
+    def test_replaces_repos_list(self):
+        cfg = {"repos": [{"name": "old", "scope": "read", "remote": "git@x:y/o.git"}]}
+        cfg_module.set_repos(cfg, [{"name": "new", "scope": "write", "remote": "git@x:y/n.git"}])
+        assert [r["name"] for r in cfg["repos"]] == ["new"]
+
+    def test_sanitizes_and_dedupes(self):
+        cfg = {}
+        cfg_module.set_repos(
+            cfg,
+            [
+                {"name": "bad"},  # missing remote → dropped
+                {"name": "ok", "remote": "git@x:y/a.git"},
+                {"name": "ok", "remote": "git@x:y/b.git"},  # duplicate → dropped
+            ],
+        )
+        assert len(cfg["repos"]) == 1
+        assert cfg["repos"][0]["name"] == "ok"
+
+
+class TestWriteAndReadRepos:
+    def test_write_and_read_split(self):
+        cfg = {
+            "repos": [
+                {"name": "a", "scope": "write", "remote": "git@x:y/a.git"},
+                {"name": "b", "scope": "read", "remote": "git@x:y/b.git"},
+                {"name": "c", "scope": "write", "remote": "git@x:y/c.git"},
+            ]
+        }
+        assert [r["name"] for r in cfg_module.write_repos(cfg)] == ["a", "c"]
+        assert [r["name"] for r in cfg_module.read_repos(cfg)] == ["b"]
+
+
+class TestGetRepo:
+    def test_returns_repo_by_name(self):
+        cfg = {"repos": [{"name": "bob", "scope": "read", "remote": "git@x:y/z.git"}]}
+        repo = cfg_module.get_repo(cfg, "bob")
+        assert repo is not None
+        assert repo["name"] == "bob"
+
+    def test_returns_none_when_missing(self):
+        assert cfg_module.get_repo({"repos": []}, "missing") is None
+        assert cfg_module.get_repo({}, "missing") is None
+
+
+class TestIsValidRepoName:
+    def test_accepts_safe_names(self):
+        for name in ["alice", "alice-bob", "alice_bob", "alice.bob", "a1", "AB_C"]:
+            assert cfg_module.is_valid_repo_name(name)
+
+    def test_rejects_unsafe_names(self):
+        for name in [
+            "",
+            ".",
+            "..",
+            "alice/bob",
+            "alice bob",
+            "alice:bob",
+            "../evil",
+            "-rf",
+            "alice\\bob",
+            None,
+            0,
+            [],
+        ]:
+            assert not cfg_module.is_valid_repo_name(name)

--- a/tests/platform_integrations/test_entity_io.py
+++ b/tests/platform_integrations/test_entity_io.py
@@ -64,23 +64,20 @@ def test_find_entities_dir_env_missing_subdir_returns_none(monkeypatch, tmp_path
 
 
 @pytest.mark.unit
-def test_find_recall_entity_dirs_includes_entities_and_public(monkeypatch, temp_project_dir):
+def test_find_recall_entity_dirs_returns_entities_dir(monkeypatch, temp_project_dir):
     custom = temp_project_dir / "custom-evolve"
     entities = custom / "entities"
-    public = custom / "public"
     entities.mkdir(parents=True)
-    public.mkdir(parents=True)
     monkeypatch.setenv("EVOLVE_DIR", str(custom))
-    assert entity_io.find_recall_entity_dirs() == [entities, public]
+    assert entity_io.find_recall_entity_dirs() == [entities]
 
 
 @pytest.mark.unit
-def test_find_recall_entity_dirs_skips_missing_locations(monkeypatch, temp_project_dir):
+def test_find_recall_entity_dirs_empty_when_entities_dir_missing(monkeypatch, temp_project_dir):
     custom = temp_project_dir / "custom-evolve"
-    public = custom / "public"
-    public.mkdir(parents=True)
+    custom.mkdir(parents=True)
     monkeypatch.setenv("EVOLVE_DIR", str(custom))
-    assert entity_io.find_recall_entity_dirs() == [public]
+    assert entity_io.find_recall_entity_dirs() == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/platform_integrations/test_publish.py
+++ b/tests/platform_integrations/test_publish.py
@@ -19,13 +19,32 @@ PUBLISH_SCRIPT_VARIANTS = [
     ("codex", CODEX_PUBLISH_SCRIPT),
 ]
 
+# All publish flows require a configured write-scope repo. Tests that need a
+# valid config use this constant.
+_DEFAULT_WRITE_REPO = "memory"
+_DEFAULT_CONFIG = (
+    "repos:\n"
+    f'  - name: "{_DEFAULT_WRITE_REPO}"\n'
+    '    scope: "write"\n'
+    '    remote: "git@github.com:alice/evolve-guidelines.git"\n'
+    '    branch: "main"\n'
+)
+
+
+def _init_fake_clone(project_dir, repo_name):
+    """Create the bare-minimum directory shape the publish script expects for a clone."""
+    clone_root = project_dir / ".evolve" / "entities" / "subscribed" / repo_name
+    (clone_root / ".git").mkdir(parents=True, exist_ok=True)
+
 
 @pytest.fixture
 def project_dir(temp_project_dir):
-    """A temp project with one private guideline entity."""
+    """A temp project with one private guideline entity and a write-scope repo configured."""
     guideline_dir = temp_project_dir / ".evolve" / "entities" / "guideline"
     guideline_dir.mkdir(parents=True)
     (guideline_dir / "my-guideline.md").write_text("---\ntype: guideline\n---\n\nPrefer composition over inheritance.\n")
+    (temp_project_dir / "evolve.config.yaml").write_text(_DEFAULT_CONFIG)
+    _init_fake_clone(temp_project_dir, _DEFAULT_WRITE_REPO)
     return temp_project_dir
 
 
@@ -53,34 +72,41 @@ def run_publish_script(script_path, project_dir, args, expect_success=True):
     )
 
 
+def _dest_path(project_dir, filename, repo=_DEFAULT_WRITE_REPO):
+    return project_dir / ".evolve" / "entities" / "subscribed" / repo / "guideline" / filename
+
+
 class TestPublish:
-    def test_copies_entity_to_public_dir(self, project_dir):
+    def test_moves_entity_to_target_repo_clone(self, project_dir):
+        source = project_dir / ".evolve" / "entities" / "guideline" / "my-guideline.md"
         run_publish(project_dir, ["--entity", "my-guideline.md"])
-        assert (project_dir / ".evolve" / "public" / "guideline" / "my-guideline.md").exists()
+        assert _dest_path(project_dir, "my-guideline.md").exists()
+        assert not source.exists()
 
     def test_sets_visibility_public(self, project_dir):
         run_publish(project_dir, ["--entity", "my-guideline.md"])
-        content = (project_dir / ".evolve" / "public" / "guideline" / "my-guideline.md").read_text()
+        content = _dest_path(project_dir, "my-guideline.md").read_text()
         assert "visibility: public" in content
 
     def test_stamps_published_at_timestamp(self, project_dir):
         run_publish(project_dir, ["--entity", "my-guideline.md"])
-        content = (project_dir / ".evolve" / "public" / "guideline" / "my-guideline.md").read_text()
+        content = _dest_path(project_dir, "my-guideline.md").read_text()
         assert "published_at:" in content
 
     def test_stamps_owner_when_user_flag_given(self, project_dir):
         run_publish(project_dir, ["--entity", "my-guideline.md", "--user", "alice"])
-        content = (project_dir / ".evolve" / "public" / "guideline" / "my-guideline.md").read_text()
+        content = _dest_path(project_dir, "my-guideline.md").read_text()
         assert "owner: alice" in content
 
-    def test_stamps_source_from_user_when_user_flag_given(self, project_dir):
+    def test_stamps_source_from_remote_when_resolvable(self, project_dir):
         run_publish(project_dir, ["--entity", "my-guideline.md", "--user", "alice"])
-        content = (project_dir / ".evolve" / "public" / "guideline" / "my-guideline.md").read_text()
-        assert "source: alice" in content
+        content = _dest_path(project_dir, "my-guideline.md").read_text()
+        # Remote in _DEFAULT_CONFIG is alice/evolve-guidelines — stamped as-is.
+        assert "source: alice/evolve-guidelines" in content
 
     def test_preserves_original_content(self, project_dir):
         run_publish(project_dir, ["--entity", "my-guideline.md"])
-        content = (project_dir / ".evolve" / "public" / "guideline" / "my-guideline.md").read_text()
+        content = _dest_path(project_dir, "my-guideline.md").read_text()
         assert "Prefer composition over inheritance." in content
 
     def test_writes_audit_log(self, project_dir):
@@ -91,6 +117,7 @@ class TestPublish:
         assert entry["action"] == "publish"
         assert entry["actor"] == "alice"
         assert entry["entity"] == "my-guideline.md"
+        assert entry["repo"] == _DEFAULT_WRITE_REPO
 
     def test_exits_nonzero_when_entity_not_found(self, project_dir):
         result = run_publish(project_dir, ["--entity", "nonexistent.md"], expect_success=False)
@@ -99,25 +126,95 @@ class TestPublish:
 
     def test_succeeds_without_user_flag(self, project_dir):
         run_publish(project_dir, ["--entity", "my-guideline.md"])
-        content = (project_dir / ".evolve" / "public" / "guideline" / "my-guideline.md").read_text()
+        content = _dest_path(project_dir, "my-guideline.md").read_text()
         assert "visibility: public" in content
 
-    def test_exits_nonzero_when_public_entity_already_exists(self, project_dir):
-        public_path = project_dir / ".evolve" / "public" / "guideline" / "my-guideline.md"
-        public_path.parent.mkdir(parents=True)
-        public_path.write_text("---\ntype: guideline\nvisibility: public\n---\n\nExisting public content.\n")
+    def test_exits_nonzero_when_already_published(self, project_dir):
+        dest = _dest_path(project_dir, "my-guideline.md")
+        dest.parent.mkdir(parents=True)
+        dest.write_text("---\ntype: guideline\nvisibility: public\n---\n\nExisting public content.\n")
 
         result = run_publish(project_dir, ["--entity", "my-guideline.md"], expect_success=False)
 
         assert result.returncode != 0
         assert "already published" in result.stderr
-        assert public_path.read_text() == "---\ntype: guideline\nvisibility: public\n---\n\nExisting public content.\n"
+        assert dest.read_text() == "---\ntype: guideline\nvisibility: public\n---\n\nExisting public content.\n"
         assert (project_dir / ".evolve" / "entities" / "guideline" / "my-guideline.md").exists()
 
     def test_rejects_path_traversal_in_entity_name(self, project_dir):
         result = run_publish(project_dir, ["--entity", "../../etc/passwd"], expect_success=False)
         assert result.returncode != 0
         assert "invalid entity name" in result.stderr
+
+    def test_errors_when_no_write_repo_configured(self, temp_project_dir):
+        guideline_dir = temp_project_dir / ".evolve" / "entities" / "guideline"
+        guideline_dir.mkdir(parents=True)
+        (guideline_dir / "my-guideline.md").write_text("---\ntype: guideline\n---\n\nContent.\n")
+        # No config file at all → no write-scope repo available.
+        result = run_publish(temp_project_dir, ["--entity", "my-guideline.md"], expect_success=False)
+        assert result.returncode != 0
+        assert "no write-scope repo" in result.stderr
+
+    def test_errors_when_repo_flag_points_to_read_scope(self, temp_project_dir):
+        guideline_dir = temp_project_dir / ".evolve" / "entities" / "guideline"
+        guideline_dir.mkdir(parents=True)
+        (guideline_dir / "my-guideline.md").write_text("---\ntype: guideline\n---\n\nContent.\n")
+        (temp_project_dir / "evolve.config.yaml").write_text(
+            'repos:\n  - name: "readonly"\n    scope: "read"\n    remote: "git@github.com:bob/evolve.git"\n    branch: "main"\n'
+        )
+        result = run_publish(temp_project_dir, ["--entity", "my-guideline.md", "--repo", "readonly"], expect_success=False)
+        assert result.returncode != 0
+        assert "requires scope=write" in result.stderr
+
+    def test_errors_when_multiple_write_repos_and_no_flag(self, temp_project_dir):
+        guideline_dir = temp_project_dir / ".evolve" / "entities" / "guideline"
+        guideline_dir.mkdir(parents=True)
+        (guideline_dir / "my-guideline.md").write_text("---\ntype: guideline\n---\n\nContent.\n")
+        (temp_project_dir / "evolve.config.yaml").write_text(
+            "repos:\n"
+            '  - name: "memory"\n    scope: "write"\n'
+            '    remote: "git@github.com:alice/memory.git"\n    branch: "main"\n'
+            '  - name: "work"\n    scope: "write"\n'
+            '    remote: "git@github.com:acme/work.git"\n    branch: "main"\n'
+        )
+        result = run_publish(temp_project_dir, ["--entity", "my-guideline.md"], expect_success=False)
+        assert result.returncode != 0
+        assert "multiple write-scope repos" in result.stderr
+        assert "memory" in result.stderr and "work" in result.stderr
+
+    def test_selects_named_repo_when_multiple_write_repos_exist(self, temp_project_dir):
+        guideline_dir = temp_project_dir / ".evolve" / "entities" / "guideline"
+        guideline_dir.mkdir(parents=True)
+        (guideline_dir / "my-guideline.md").write_text("---\ntype: guideline\n---\n\nContent.\n")
+        (temp_project_dir / "evolve.config.yaml").write_text(
+            "repos:\n"
+            '  - name: "memory"\n    scope: "write"\n'
+            '    remote: "git@github.com:alice/memory.git"\n    branch: "main"\n'
+            '  - name: "work"\n    scope: "write"\n'
+            '    remote: "git@github.com:acme/work.git"\n    branch: "main"\n'
+        )
+        _init_fake_clone(temp_project_dir, "memory")
+        _init_fake_clone(temp_project_dir, "work")
+        run_publish(temp_project_dir, ["--entity", "my-guideline.md", "--repo", "work"])
+        assert _dest_path(temp_project_dir, "my-guideline.md", repo="work").exists()
+        assert not _dest_path(temp_project_dir, "my-guideline.md", repo="memory").exists()
+
+
+@pytest.mark.parametrize(("platform_name", "publish_script"), PUBLISH_SCRIPT_VARIANTS)
+def test_publish_errors_when_target_clone_missing(temp_project_dir, publish_script, platform_name):
+    """Publish must refuse to move the source entity if the target clone isn't a git repo."""
+    guideline_dir = temp_project_dir / ".evolve" / "entities" / "guideline"
+    guideline_dir.mkdir(parents=True)
+    source = guideline_dir / "my-guideline.md"
+    source.write_text("---\ntype: guideline\n---\n\nContent.\n")
+    (temp_project_dir / "evolve.config.yaml").write_text(_DEFAULT_CONFIG)
+    # Note: no .git dir created under .evolve/entities/subscribed/memory/.
+
+    result = run_publish_script(publish_script, temp_project_dir, ["--entity", "my-guideline.md"], expect_success=False)
+    assert result.returncode != 0
+    assert "clone not found" in result.stderr
+    # Source entity must still be intact — no data loss.
+    assert source.exists()
 
 
 @pytest.mark.parametrize(("platform_name", "publish_script"), PUBLISH_SCRIPT_VARIANTS)

--- a/tests/platform_integrations/test_retrieve.py
+++ b/tests/platform_integrations/test_retrieve.py
@@ -99,31 +99,6 @@ class TestRetrieve:
         assert expected_header in result.stdout
 
     @pytest.mark.parametrize(("platform_name", "retrieve_script", "expected_header"), SCRIPT_VARIANTS)
-    def test_public_entities_included_in_recall(self, temp_project_dir, retrieve_script, expected_header, platform_name, file_assertions):
-        d = temp_project_dir / ".evolve"
-        file_assertions.write_text(
-            d / "public" / "guideline" / "pub.md",
-            "---\ntype: guideline\nvisibility: public\n---\n\nPrefer immutable data structures.\n",
-        )
-        result = run_retrieve(retrieve_script, evolve_dir=d)
-        assert result.returncode == 0
-        assert "Prefer immutable data structures." in result.stdout
-
-    @pytest.mark.parametrize(("platform_name", "retrieve_script", "expected_header"), SCRIPT_VARIANTS)
-    def test_public_entities_not_annotated_with_from(
-        self, temp_project_dir, retrieve_script, expected_header, platform_name, file_assertions
-    ):
-        d = temp_project_dir / ".evolve"
-        file_assertions.write_text(
-            d / "public" / "guideline" / "pub.md",
-            "---\ntype: guideline\nvisibility: public\n---\n\nPrefer immutable data structures.\n",
-        )
-        result = run_retrieve(retrieve_script, evolve_dir=d)
-        pub_lines = [line for line in result.stdout.splitlines() if "Prefer immutable data structures." in line]
-        assert pub_lines
-        assert not any("[from:" in line for line in pub_lines)
-
-    @pytest.mark.parametrize(("platform_name", "retrieve_script", "expected_header"), SCRIPT_VARIANTS)
     def test_entities_with_trigger_include_when_line(
         self, temp_project_dir, retrieve_script, expected_header, platform_name, file_assertions
     ):

--- a/tests/platform_integrations/test_subscribe.py
+++ b/tests/platform_integrations/test_subscribe.py
@@ -85,11 +85,37 @@ class TestSubscribe:
             evolve_dir=evolve_dir,
         )
         cfg = cfg_module.load_config(str(temp_project_dir))
-        subs = cfg.get("subscriptions", [])
-        assert len(subs) == 1
-        assert subs[0]["name"] == "alice"
-        assert subs[0]["branch"] == "main"
-        assert str(local_repo["bare"]) in subs[0]["remote"]
+        repos = cfg_module.normalize_repos(cfg)
+        assert len(repos) == 1
+        assert repos[0]["name"] == "alice"
+        assert repos[0]["branch"] == "main"
+        assert repos[0]["scope"] == "read"
+        assert str(local_repo["bare"]) in repos[0]["remote"]
+
+    def test_write_scope_recorded_in_repos_list(self, temp_project_dir, local_repo):
+        evolve_dir = temp_project_dir / ".evolve"
+        run_script(
+            SUBSCRIBE_SCRIPT,
+            temp_project_dir,
+            [
+                "--name",
+                "memory",
+                "--remote",
+                str(local_repo["bare"]),
+                "--branch",
+                "main",
+                "--scope",
+                "write",
+                "--notes",
+                "shared project memory",
+            ],
+            evolve_dir=evolve_dir,
+        )
+        cfg = cfg_module.load_config(str(temp_project_dir))
+        write = cfg_module.write_repos(cfg)
+        assert len(write) == 1
+        assert write[0]["name"] == "memory"
+        assert write[0]["notes"] == "shared project memory"
 
     def test_writes_audit_log(self, temp_project_dir, local_repo):
         evolve_dir = temp_project_dir / ".evolve"
@@ -101,13 +127,10 @@ class TestSubscribe:
         )
         log_path = temp_project_dir / ".evolve" / "audit.log"
         assert log_path.exists()
-        # Parse JSONL format (one JSON object per line)
         entries = [json.loads(line) for line in log_path.read_text().splitlines() if line.strip()]
-        actions = [e["action"] for e in entries]
-        assert "subscribe" in actions
-        # Find the subscribe entry and verify its details
         subscribe_entry = next(e for e in entries if e["action"] == "subscribe")
         assert subscribe_entry["name"] == "alice"
+        assert subscribe_entry["scope"] == "read"
 
     def test_fails_on_duplicate_name(self, temp_project_dir, local_repo):
         evolve_dir = temp_project_dir / ".evolve"
@@ -143,7 +166,7 @@ class TestSubscribe:
         assert result.returncode != 0
         assert "already exists" in result.stderr
         cfg = cfg_module.load_config(str(temp_project_dir))
-        assert cfg.get("subscriptions", []) == []
+        assert cfg_module.normalize_repos(cfg) == []
 
     def test_rejects_empty_or_dot_name(self, temp_project_dir, local_repo):
         evolve_dir = temp_project_dir / ".evolve"
@@ -238,7 +261,7 @@ class TestUnsubscribe:
         evolve_dir = self._subscribe(temp_project_dir, local_repo)
         run_script(UNSUBSCRIBE_SCRIPT, temp_project_dir, ["--name", "alice"], evolve_dir=evolve_dir)
         cfg = cfg_module.load_config(str(temp_project_dir))
-        assert cfg.get("subscriptions", []) == []
+        assert cfg_module.normalize_repos(cfg) == []
 
     def test_list_flag_prints_subscriptions_as_json(self, temp_project_dir, local_repo):
         evolve_dir = self._subscribe(temp_project_dir, local_repo)

--- a/tests/platform_integrations/test_sync.py
+++ b/tests/platform_integrations/test_sync.py
@@ -41,20 +41,21 @@ def run_script(script, project_dir, args=None, evolve_dir=None, stdin_data=None,
 @pytest.mark.parametrize(
     "config_text",
     [
-        "subscriptions:\n  - name: 123\n    remote: git@github.com:x/y.git\n    branch: main\n",
-        "subscriptions:\n  - name: alice\n    remote: git@github.com:x/y.git\n    branch: 123\n",
-        'subscriptions:\n  - name: "   "\n    remote: git@github.com:x/y.git\n    branch: main\n',
-        'subscriptions:\n  - name: alice\n    remote: git@github.com:x/y.git\n    branch: "   "\n',
+        "repos:\n  - name: 123\n    scope: read\n    remote: git@github.com:x/y.git\n    branch: main\n",
+        'repos:\n  - name: "   "\n    scope: read\n    remote: git@github.com:x/y.git\n    branch: main\n',
+        "repos:\n  - name: alice\n    scope: read\n    branch: main\n",  # missing remote
     ],
 )
-def test_sync_skips_malformed_subscription_entries(temp_project_dir, sync_script, platform_name, config_text):
+def test_sync_handles_malformed_repo_entries(temp_project_dir, sync_script, platform_name, config_text):
+    """The sync script must never crash on a malformed config entry; invalid
+    entries are silently dropped by ``normalize_repos`` so sync falls through
+    to the "no repos configured" branch."""
     evolve_dir = temp_project_dir / ".evolve"
     cfg_path = temp_project_dir / "evolve.config.yaml"
     cfg_path.write_text(config_text)
 
     result = run_script(sync_script, temp_project_dir, evolve_dir=evolve_dir)
     assert result.returncode == 0
-    assert "skipped" in result.stdout
     assert "Traceback" not in result.stderr
     assert not (evolve_dir / "entities" / "subscribed" / "alice").exists()
 
@@ -141,9 +142,11 @@ class TestSync:
         assert "sync" in actions
 
     def test_sync_preserves_symlinks_in_clone(self, subscribed_project):
+        """Sync just keeps the clone in sync with the remote — symlinks land on
+        disk as-is. Filtering symlinked entities is the recall script's job
+        (see retrieve_entities.py) and is covered by the recall tests."""
         p = subscribed_project
         lr = p["local_repo"]
-        # Create a real file and a symlink pointing at it in the subscribed clone
         real_file = lr["work"] / "guideline" / "real.md"
         real_file.write_text("---\ntype: guideline\n---\n\nReal content.\n")
         symlink_file = lr["work"] / "guideline" / "link.md"
@@ -162,7 +165,8 @@ class TestSync:
         )
         run_script(SYNC_SCRIPT, p["project_dir"], evolve_dir=p["evolve_dir"])
         mirrored = p["evolve_dir"] / "entities" / "subscribed" / "alice" / "guideline"
-        assert (mirrored / "link.md").exists()
+        assert (mirrored / "real.md").exists()
+        assert (mirrored / "link.md").is_symlink()
 
         env = {**os.environ, "EVOLVE_DIR": str(p["evolve_dir"])}
         result = subprocess.run(
@@ -183,16 +187,16 @@ class TestSync:
         evolve_dir = temp_project_dir / ".evolve"
         # Write config manually with an unsafe name
         cfg_path = temp_project_dir / "evolve.config.yaml"
-        cfg_path.write_text("subscriptions:\n  - name: ../outside\n    remote: git@github.com:x/y.git\n    branch: main\n")
+        cfg_path.write_text("repos:\n  - name: ../evil\n    scope: read\n    remote: git@github.com:x/y.git\n    branch: main\n")
         result = run_script(SYNC_SCRIPT, temp_project_dir, evolve_dir=evolve_dir)
         assert result.returncode == 0
         assert "invalid subscription name" in result.stdout
-        assert not (evolve_dir / "entities" / "outside").exists()
+        assert not (evolve_dir / "entities" / "evil").exists()
 
     def test_manual_run_ignores_on_session_start_false(self, subscribed_project):
         p = subscribed_project
         cfg_path = p["project_dir"] / "evolve.config.yaml"
-        cfg_path.write_text("sync:\n  on_session_start: false\nsubscriptions:\n  - name: alice\n    remote: x\n    branch: main\n")
+        cfg_path.write_text("sync:\n  on_session_start: false\nrepos:\n  - name: alice\n    scope: read\n    remote: x\n    branch: main\n")
         # Manual run (no --quiet) must still execute even with on_session_start: false
         result = run_script(SYNC_SCRIPT, p["project_dir"], evolve_dir=p["evolve_dir"])
         assert result.returncode == 0


### PR DESCRIPTION
## Summary
- Collapse `public_repo` + `subscriptions` into a single `repos:` list where each entry has `scope: read` (subscribe only) or `scope: write` (publish target, also synced) — closes #217.
- Update publish / subscribe / sync / unsubscribe / recall skills for both Claude and Codex plugins to operate on the unified model; write-scope repos double as publish targets and sync sources so co-writers see each other's publishes.
- Add helpers in `lib/config.py` (`normalize_repos`, `read_repos`, `write_repos`, `set_repos`, `get_repo`, `is_valid_repo_name`) and broaden tests across `tests/platform_integrations/`.

## Test plan
- [x] `pytest tests/platform_integrations/` passes locally
- [x] `/evolve-lite:subscribe` with scope=read clones into `.evolve/entities/subscribed/<name>/` and recall picks it up
- [x] `/evolve-lite:subscribe` with scope=write then `/evolve-lite:publish` moves guideline into the clone, commits, and pushes
- [x] `/evolve-lite:sync` pulls read-scope repos (fetch + reset --hard) and rebases write-scope repos without losing unpushed publishes
- [x] `/evolve-lite:unsubscribe` warns before removing a write-scope repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified repos: configure multiple repos with explicit scope (read/write).
  * Publish now targets a selected write-scope repo, stamps metadata, and reports the repo.
  * Subscribe/clone honors scope (read = shallow, write = full).

* **Bug Fixes / Behavior Changes**
  * Sync is scope-aware: read = fetch+hard-reset, write = fetch+rebase to preserve local publishes.
  * Recall/load now only inspects the canonical entities area (no separate public dir).
  * Unsubscribe/remove warns for write-scope removals and deletes only the local clone.

* **Documentation**
  * Storage layout and workflows updated to reflect the repos model (public dir removed).

* **Tests**
  * Tests updated to the repos schema and new publish/sync/recall behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->