### PR TITLE
feat(claude-plugin): add stop hook to save session transcript

### DIFF
--- a/platform-integrations/claude/plugins/evolve-lite/hooks/hooks.json
+++ b/platform-integrations/claude/plugins/evolve-lite/hooks/hooks.json
@@ -28,6 +28,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/skills/save-trajectory/scripts/on_stop.py"
+          },
+          {
+            "type": "command",
             "command": "python3 ${CLAUDE_PLUGIN_ROOT}/skills/learn/scripts/on_stop.py"
           }
         ]

--- a/platform-integrations/claude/plugins/evolve-lite/skills/save-trajectory/scripts/on_stop.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/save-trajectory/scripts/on_stop.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Stop hook that copies the session transcript to .evolve/trajectories/."""
+
+import datetime
+import getpass
+import json
+import os
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+
+_log_file = None
+
+
+def _get_log_file():
+    global _log_file
+    if _log_file is None:
+        try:
+            uid = os.getuid()
+        except AttributeError:
+            uid = getpass.getuser()
+        log_dir = os.path.join(tempfile.gettempdir(), f"evolve-{uid}")
+        os.makedirs(log_dir, mode=0o700, exist_ok=True)
+        _log_file = os.path.join(log_dir, "evolve-plugin.log")
+    return _log_file
+
+
+def log(message):
+    if not os.environ.get("EVOLVE_DEBUG"):
+        return
+    try:
+        timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        with open(_get_log_file(), "a", encoding="utf-8") as f:
+            f.write(f"[{timestamp}] [save-trajectory-stop] {message}\n")
+    except Exception:
+        pass
+
+
+def get_trajectories_dir():
+    project_root = os.environ.get("CLAUDE_PROJECT_ROOT", "")
+    if project_root:
+        base = Path(project_root) / ".evolve" / "trajectories"
+    else:
+        base = Path(".evolve") / "trajectories"
+    base.mkdir(parents=True, exist_ok=True, mode=0o700)
+    return base.resolve()
+
+
+def main():
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        input_data = {}
+
+    log(f"Stop hook input keys: {list(input_data.keys())}")
+    log(f"Stop hook input: {json.dumps(input_data, default=str)[:2000]}")
+
+    transcript_path = input_data.get("transcript_path")
+    if not transcript_path:
+        log("No transcript_path in stop hook input")
+        return
+
+    src = Path(transcript_path)
+    if not src.is_file():
+        log(f"Transcript file not found: {src}")
+        return
+
+    session_id = src.stem
+    trajectories_dir = get_trajectories_dir()
+    dst = trajectories_dir / f"claude-transcript_{session_id}.jsonl"
+
+    shutil.copy2(str(src), str(dst))
+    log(f"Copied transcript {src} -> {dst}")
+    print(f"Trajectory saved: {dst}")
+
+
+if __name__ == "__main__":
+    main()

--- a/platform-integrations/claude/plugins/evolve-lite/skills/save-trajectory/scripts/on_stop.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/save-trajectory/scripts/on_stop.py
@@ -39,11 +39,15 @@ def log(message):
 
 
 def get_trajectories_dir():
-    project_root = os.environ.get("CLAUDE_PROJECT_ROOT", "")
-    if project_root:
-        base = Path(project_root) / ".evolve" / "trajectories"
+    evolve_dir = os.environ.get("EVOLVE_DIR")
+    if evolve_dir:
+        base = Path(evolve_dir) / "trajectories"
     else:
-        base = Path(".evolve") / "trajectories"
+        project_root = os.environ.get("CLAUDE_PROJECT_ROOT", "")
+        if project_root:
+            base = Path(project_root) / ".evolve" / "trajectories"
+        else:
+            base = Path(".evolve") / "trajectories"
     base.mkdir(parents=True, exist_ok=True, mode=0o700)
     return base.resolve()
 


### PR DESCRIPTION
Relates to #186 (unit/regression tests for the agent harnesses) — this is a prerequisite for end-to-end testing of the Claude Code plugin: downstream skills (e.g. `learn` running in a forked execution context) need a stable on-disk reference to the session conversation.

## Summary

- Adds `skills/save-trajectory/scripts/on_stop.py` that reads `transcript_path` from the Stop hook input and copies the raw Claude session transcript to `.evolve/trajectories/claude-transcript_<session_id>.jsonl`.
- Wires it in `hooks/hooks.json` so it runs on every Stop, before the `learn` hook.

## Why

The plugin had no durable record of the session conversation. Saving the raw Claude JSONL transcript gives downstream skills (and users) a stable, predictable path to inspect what happened in a session. Using the session ID as the filename means repeated Stops within a session overwrite rather than accumulate.

## Test plan

- [x] Run a Claude session with the plugin loaded (`--plugin-dir /plugins/evolve-lite/`) and confirm a `.jsonl` file appears under `.evolve/trajectories/`
- [x] Run the same session multiple times and confirm only one file per session ID exists

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically saves session transcripts to a local trajectories store when a session stops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->