### PR TITLE
fix(learn): read session transcript in forked execution context

### DIFF
--- a/platform-integrations/claude/plugins/evolve-lite/skills/learn/SKILL.md
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/learn/SKILL.md
@@ -25,9 +25,21 @@ This skill analyzes the current conversation to extract guidelines that **correc
 
 ## Workflow
 
+### Step 0: Load the Conversation
+
+This skill runs in a forked context with no access to the parent conversation. The stop hook message includes the path to the session transcript file (JSONL format). **You must read this file to analyze the conversation.**
+
+```bash
+cat <transcript_path>
+```
+
+Each line is a JSON object. Focus on lines where `"type": "assistant"` or `"type": "human"` to reconstruct the conversation flow. Look for tool calls, errors in tool results, and user corrections.
+
+If no transcript path was provided, check for the most recent file in `.evolve/trajectories/`. If no transcript is available at all, output zero entities.
+
 ### Step 1: Analyze the Conversation
 
-Review the conversation and identify:
+Review the conversation (loaded from the transcript) and identify:
 
 - **Wasted steps**: Where did the agent go down a path that turned out to be unnecessary? What would have been the direct route?
 - **Errors hit**: What errors occurred? What knowledge would have prevented them?

--- a/platform-integrations/claude/plugins/evolve-lite/skills/learn/SKILL.md
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/learn/SKILL.md
@@ -33,9 +33,14 @@ This skill runs in a forked context with no access to the parent conversation. T
 cat <transcript_path>
 ```
 
-Each line is a JSON object. Focus on lines where `"type": "assistant"` or `"type": "human"` to reconstruct the conversation flow. Look for tool calls, errors in tool results, and user corrections.
+The transcript is JSONL: each line is a separate JSON object. Focus on lines where `"type": "assistant"` or `"type": "human"` to reconstruct the conversation flow. Look for tool calls, errors in tool results, and user corrections.
 
-If no transcript path was provided, check for the most recent file in `.evolve/trajectories/`. If no transcript is available at all, output zero entities.
+If no transcript path was provided, fall back to `.evolve/trajectories/`, which may contain either format:
+
+- **`trajectory_*.json`** — a single JSON object with `messages: [{role, content}, …]`. Prefer the most recent one; parse with `json.load`.
+- **`claude-transcript_*.jsonl`** — raw Claude JSONL (same format as the primary `transcript_path`). Parse line-by-line.
+
+If no transcript is available at all, output zero entities.
 
 ### Step 1: Analyze the Conversation
 

--- a/platform-integrations/claude/plugins/evolve-lite/skills/learn/SKILL.md
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/learn/SKILL.md
@@ -27,11 +27,13 @@ This skill analyzes the current conversation to extract guidelines that **correc
 
 ### Step 0: Load the Conversation
 
-This skill runs in a forked context with no access to the parent conversation. The stop hook message includes the path to the session transcript file (JSONL format). **You must read this file to analyze the conversation.**
+This skill runs in a forked context with no access to the parent conversation. The stop hook message (produced by `on_stop.py`) contains the literal marker `The session transcript is at: <path>` — find that exact phrase, take everything after the colon, strip surrounding whitespace and quotes, and use the result as `transcript_path`. Then read it:
 
 ```bash
 cat <transcript_path>
 ```
+
+**You must read this file to analyze the conversation** — the forked context has no other access to it.
 
 The transcript is JSONL: each line is a separate JSON object. Focus on lines where `"type": "assistant"` or `"type": "human"` to reconstruct the conversation flow. Look for tool calls, errors in tool results, and user corrections.
 

--- a/platform-integrations/claude/plugins/evolve-lite/skills/learn/scripts/on_stop.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/learn/scripts/on_stop.py
@@ -14,11 +14,16 @@ def main():
     if input_data.get("stop_hook_active") is True:
         return
 
+    transcript_path = input_data.get("transcript_path", "")
+    reason = "Run the /evolve-lite:learn skill."
+    if transcript_path:
+        reason += f" The session transcript is at: {transcript_path}"
+
     print(
         json.dumps(
             {
                 "decision": "block",
-                "reason": "Run the /evolve-lite:learn skill to extract guidelines from this conversation.",
+                "reason": reason,
                 "suppressOutput": True,
                 "systemMessage": "Running the evolve-lite learn skill...",
             }


### PR DESCRIPTION
Relates to #186 (unit/regression tests for the agent harnesses) — without this fix, the `learn` skill cannot actually extract guidelines from a completed session, which blocks end-to-end testing of the learn + recall loop.

## Summary

- Pass `transcript_path` from the Stop hook stdin through to the skill invocation (as part of the block `reason`).
- Add **Step 0: Load the Conversation** to `SKILL.md` instructing the forked agent to `cat` the transcript JSONL file and reconstruct the conversation from there.

## Why

The `learn` skill declares `context: fork` in its SKILL.md frontmatter. Claude Code treats that as a subagent invocation with a **blank conversation context** — the forked agent's entire history is just the SKILL.md content injected as its first user message. It has no access to the parent session, so the existing instruction "Review the conversation and identify…" cannot work: the forked agent correctly reports "this appears to be the very start of a session" and produces zero entities every time.

Claude Code already passes `transcript_path` to every Stop hook (pointing to the raw session transcript in `.claude/projects/`). This change forwards that path into the skill's invocation so the forked agent has a concrete file to analyze.

## Test plan

- [x] Run a Claude session in the sandbox that hits dead ends (e.g. EXIF extraction with `exiftool`/`PIL` unavailable), let the Stop hook fire, and confirm `learn` now produces a `.md` file under `.evolve/entities/`
- [x] Run a follow-up session; confirm the guideline is recalled and Claude skips the failed tools

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified learn-skill workflow to require loading a session transcript (JSONL) and detailed how transcripts are parsed and which message types are used for reconstructing conversation flow; also explains fallback behavior when no transcript is available and the resulting output.

* **Improvements**
  * Stop-hook messaging now dynamically includes the session transcript location when present, giving clearer feedback during learn-skill runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->