### PR TITLE
chore(sandbox): add jless to sandbox image

### DIFF
--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -42,6 +42,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && JLESS_URL=$(curl -fsSL https://api.github.com/repos/PaulJuliusMartinez/jless/releases/latest \
        | grep -o '"browser_download_url": *"[^"]*x86_64-unknown-linux-gnu.zip"' \
        | cut -d'"' -f4) \
+    && if [ -z "$JLESS_URL" ]; then echo "ERROR: failed to resolve jless download URL from GitHub API" >&2; exit 1; fi \
     && curl -fsSL "$JLESS_URL" -o /tmp/jless.zip \
     && unzip -o /tmp/jless.zip -d /usr/local/bin \
     && chmod +x /usr/local/bin/jless \

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -38,7 +38,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     jq \
     openssh-client \
     ripgrep \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && JLESS_URL=$(curl -fsSL https://api.github.com/repos/PaulJuliusMartinez/jless/releases/latest \
+       | grep -o '"browser_download_url": *"[^"]*x86_64-unknown-linux-gnu.zip"' \
+       | cut -d'"' -f4) \
+    && curl -fsSL "$JLESS_URL" -o /tmp/jless.zip \
+    && unzip -o /tmp/jless.zip -d /usr/local/bin \
+    && chmod +x /usr/local/bin/jless \
+    && rm /tmp/jless.zip
 
 RUN groupadd sandbox && useradd -m -g sandbox sandbox \
     && mkdir -p /workspace && chown sandbox:sandbox /workspace


### PR DESCRIPTION
## Summary

Install [`jless`](https://github.com/PaulJuliusMartinez/jless) (a pager/viewer for JSON and JSONL) into the base sandbox Docker image. Fetches the latest release from the GitHub API dynamically so we're not pinned to a specific version.

## Why

The sandbox is increasingly used to inspect saved session transcripts (`.evolve/trajectories/*.jsonl`) and API responses. `jless` makes browsing those files tractable without leaving the container — `cat | less` on a multi-MB JSONL is painful.

## Test plan

- [x] `just sandbox-build claude` succeeds
- [x] Inside the container: `jless --version` returns a version
- [x] Inside the container: `jless /workspace/.evolve/trajectories/claude-transcript_*.jsonl` opens an interactive viewer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated sandbox environment to automatically install the latest `jless` tool from GitHub releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->