### PR TITLE
feat(claude-plugin): stamp source trajectory path on extracted guidelines

### DIFF
--- a/platform-integrations/claude/plugins/evolve-lite/skills/learn/SKILL.md
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/learn/SKILL.md
@@ -27,7 +27,12 @@ This skill analyzes the current conversation to extract guidelines that **correc
 
 ### Step 0: Load the Conversation
 
-This skill runs in a forked context with no access to the parent conversation. The stop hook message (produced by `on_stop.py`) contains the literal marker `The session transcript is at: <path>` — find that exact phrase, take everything after the colon, strip surrounding whitespace and quotes, and use the result as `transcript_path`. Then read it:
+This skill runs in a forked context with no access to the parent conversation. The stop hook message (produced by `on_stop.py`) contains two literal markers:
+
+- `The session transcript is at: <path>` — the live session transcript. Take everything between that marker and the next marker (or end of message), strip whitespace and quotes, and use the result as `transcript_path`.
+- `The saved trajectory path is: <path>` — the relative path of the saved trajectory copy under `.evolve/trajectories/`. Extract this the same way and remember it as `saved_trajectory_path` — you will attach it to each entity in Step 3.
+
+Then read the session transcript:
 
 ```bash
 cat <transcript_path>
@@ -74,7 +79,7 @@ Principles:
 
 ### Step 3: Save Entities
 
-Output entities as JSON and pipe to the save script. The `type` field must always be `"guideline"` — no other types are accepted.
+Output entities as JSON and pipe to the save script. The `type` field must always be `"guideline"` — no other types are accepted. Include a `trajectory` field on every entity, set to the `saved_trajectory_path` extracted in Step 0 — this records which session produced the guideline.
 
 #### Method 1: Direct Pipe (Recommended)
 
@@ -85,7 +90,8 @@ echo '{
       "content": "Proactive entity stating what TO DO",
       "rationale": "Why this approach works better",
       "type": "guideline",
-      "trigger": "Situational context when this applies"
+      "trigger": "Situational context when this applies",
+      "trajectory": ".evolve/trajectories/claude-transcript_<session-id>.jsonl"
     }
   ]
 }' | python3 ${CLAUDE_PLUGIN_ROOT}/skills/learn/scripts/save_entities.py

--- a/platform-integrations/claude/plugins/evolve-lite/skills/learn/scripts/on_stop.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/learn/scripts/on_stop.py
@@ -19,7 +19,7 @@ def main():
     reason = "Run the /evolve-lite:learn skill."
     if transcript_path:
         reason += f" The session transcript is at: {transcript_path}"
-        session_id = Path(transcript_path).stem
+        session_id = Path(transcript_path).stem.removeprefix("claude-transcript_")
         if session_id:
             saved_trajectory = f".evolve/trajectories/claude-transcript_{session_id}.jsonl"
             reason += f" The saved trajectory path is: {saved_trajectory}"

--- a/platform-integrations/claude/plugins/evolve-lite/skills/learn/scripts/on_stop.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/learn/scripts/on_stop.py
@@ -3,6 +3,7 @@
 
 import json
 import sys
+from pathlib import Path
 
 
 def main():
@@ -18,6 +19,10 @@ def main():
     reason = "Run the /evolve-lite:learn skill."
     if transcript_path:
         reason += f" The session transcript is at: {transcript_path}"
+        session_id = Path(transcript_path).stem
+        if session_id:
+            saved_trajectory = f".evolve/trajectories/claude-transcript_{session_id}.jsonl"
+            reason += f" The saved trajectory path is: {saved_trajectory}"
 
     print(
         json.dumps(


### PR DESCRIPTION
## Summary

- Learn stop-hook now derives the saved trajectory's relative path from the session_id and surfaces it to the forked learn skill via a new marker (`The saved trajectory path is: ...`) in the stop-hook reason.
- `SKILL.md` instructs the agent to attach that path to every entity's `trajectory` field.
- `entity_io.py` already serializes `trajectory` into the YAML frontmatter (`_FRONTMATTER_KEYS`), so no change needed there — generated guidelines now carry a back-reference to the session transcript that produced them.

First concrete step toward #180 (*Explainability & Provenance*), specifically the "Add source trajectory metadata to each entity" approach and the "trace any entity back to the conversation it was learned from" success criterion.

## Test plan

- [x] End-to-end: `pytest tests/e2e/test_sandbox_learn_recall.py -m e2e` passes on macOS with the claude-sandbox image (1 passed in 2:48).
- [x] Confirmed the generated guideline file contains the `trajectory:` field in its frontmatter, pointing to an actual `.evolve/trajectories/claude-transcript_<session-id>.jsonl` file produced in the same session.
- [ ] Spot-check in another platform integration if/when that integration adopts the same stop-hook pattern (bob already instructs its agent similarly).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced guideline entities to include trajectory field information, providing better trajectory reference tracking.
  * Improved trajectory data path extraction and handling within the learning system, enabling more precise session and trajectory linkage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->