### PR TITLE
fix(learn): stop the learn-skill permission-prompt storm at Stop

### DIFF
--- a/platform-integrations/claude/plugins/evolve-lite/skills/learn/SKILL.md
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/learn/SKILL.md
@@ -27,27 +27,15 @@ This skill analyzes the current conversation to extract guidelines that **correc
 
 ### Step 0: Load the Conversation
 
-This skill runs in a forked context with no access to the parent conversation. The stop hook message (produced by `on_stop.py`) contains two literal markers:
+This skill runs in a forked context with no access to the parent conversation. The stop-hook message (produced by `on_stop.py`) contains one literal marker:
 
-- `The session transcript is at: <path>` — the live session transcript. Take everything between that marker and the next marker (or end of message), strip whitespace and quotes, and use the result as `transcript_path`.
-- `The saved trajectory path is: <path>` — the relative path of the saved trajectory copy under `.evolve/trajectories/`. Extract this the same way and remember it as `saved_trajectory_path` — you will attach it to each entity in Step 3.
+- `The saved trajectory path is: <path>` — a copy of the session transcript saved inside the project tree at `.evolve/trajectories/claude-transcript_<session-id>.jsonl`. Take everything after the colon, strip surrounding whitespace and quotes, and use the result as `saved_trajectory_path`. You will also attach this exact path to each entity's `trajectory` field in Step 3.
 
-Then read the session transcript:
+**Read this file with the `Read` tool — do NOT shell out.** `Read` pages large files natively (use its `offset` / `limit` parameters if needed). Do not use `cat`, `head`, `wc`, `find`, or `python3 -c` loops on the transcript — those trigger a permission prompt for every invocation and are unnecessary.
 
-```bash
-cat <transcript_path>
-```
-
-**You must read this file to analyze the conversation** — the forked context has no other access to it.
+If the saved trajectory file does not exist (e.g., the save-trajectory hook did not run, or no marker was provided), output zero entities and exit. Do NOT fall back to reading the live session transcript under `~/.claude/projects/` — that path is outside the project tree, triggers permission prompts, and may be larger than the fork can consume.
 
 The transcript is JSONL: each line is a separate JSON object. Focus on lines where `"type": "assistant"` or `"type": "human"` to reconstruct the conversation flow. Look for tool calls, errors in tool results, and user corrections.
-
-If no transcript path was provided, fall back to `.evolve/trajectories/`, which may contain either format:
-
-- **`trajectory_*.json`** — a single JSON object with `messages: [{role, content}, …]`. Prefer the most recent one; parse with `json.load`.
-- **`claude-transcript_*.jsonl`** — raw Claude JSONL (same format as the primary `transcript_path`). Parse line-by-line.
-
-If no transcript is available at all, output zero entities.
 
 ### Step 1: Analyze the Conversation
 

--- a/platform-integrations/claude/plugins/evolve-lite/skills/learn/SKILL.md
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/learn/SKILL.md
@@ -29,7 +29,7 @@ This skill analyzes the current conversation to extract guidelines that **correc
 
 This skill runs in a forked context with no access to the parent conversation. The stop-hook message (produced by `on_stop.py`) contains one literal marker:
 
-- `The saved trajectory path is: <path>` — a copy of the session transcript saved inside the project tree at `.evolve/trajectories/claude-transcript_<session-id>.jsonl`. Take everything after the colon, strip surrounding whitespace and quotes, and use the result as `saved_trajectory_path`. You will also attach this exact path to each entity's `trajectory` field in Step 3.
+- `The saved trajectory path is: <path>` — a copy of the session transcript saved inside the project tree at `.evolve/trajectories/claude-transcript_<session-id>.jsonl`. Take everything after the colon, strip surrounding whitespace and quotes, and use the result as `saved_trajectory_path`. You will also attach this exact path to each entity's `trajectory` field in Step 4.
 
 **Read this file with the `Read` tool — do NOT shell out.** `Read` pages large files natively (use its `offset` / `limit` parameters if needed). Do not use `cat`, `head`, `wc`, `find`, or `python3 -c` loops on the transcript — those trigger a permission prompt for every invocation and are unnecessary.
 
@@ -47,7 +47,19 @@ Review the conversation (loaded from the transcript) and identify:
 
 If none of these occurred, **output zero entities**. Not every conversation produces guidelines.
 
-### Step 2: Extract Entities
+### Step 2: Review Existing Guidelines
+
+Before extracting, look at what has already been saved for this project. Earlier Stop hooks in the same session (or prior sessions) may have recorded guidelines that cover the same ground — re-extracting them is wasteful and pollutes the library.
+
+Use the **Glob tool** to enumerate existing guideline files: `.evolve/entities/**/*.md`. Then use the **Read tool** to open each match and skim the content + trigger.
+
+**Do NOT use `cat`, `head`, `find`, a `for` loop, or an inline `python3 -c` script for this.** Each shell invocation triggers a permission prompt, and Glob + Read cover the same need without any prompting.
+
+If there are no existing guidelines, skip this step.
+
+With the existing-guideline set in mind, when you proceed to Step 3 you should pick only *complementary* findings — new angles, new failure modes, or finer-grained detail — and drop candidates that restate or near-duplicate anything already saved. (`save_entities.py` will also drop exact-match duplicates at write time, but it cannot catch re-wordings.)
+
+### Step 3: Extract Entities
 
 For each identified shortcut, error, or user correction, create one entity — up to 5 entities; output 0 when none qualify. If more candidates exist, keep only the highest-impact ones.
 
@@ -65,7 +77,7 @@ Principles:
 
 4. **For user corrections, use the user's own words** — preserve the specific preference rather than generalizing it
 
-### Step 3: Save Entities
+### Step 4: Save Entities
 
 Output entities as JSON and pipe to the save script. The `type` field must always be `"guideline"` — no other types are accepted. Include a `trajectory` field on every entity, set to the `saved_trajectory_path` extracted in Step 0 — this records which session produced the guideline.
 

--- a/platform-integrations/claude/plugins/evolve-lite/skills/learn/scripts/on_stop.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/learn/scripts/on_stop.py
@@ -18,7 +18,6 @@ def main():
     transcript_path = input_data.get("transcript_path", "")
     reason = "Run the /evolve-lite:learn skill."
     if transcript_path:
-        reason += f" The session transcript is at: {transcript_path}"
         session_id = Path(transcript_path).stem.removeprefix("claude-transcript_")
         if session_id:
             saved_trajectory = f".evolve/trajectories/claude-transcript_{session_id}.jsonl"


### PR DESCRIPTION
## Summary

Fixes #242. The forked `learn` skill triggered a permission prompt for every Bash invocation it ran at Stop — once per Stop × several commands per run. Two paths were responsible:

1. **Reading the session transcript.** SKILL.md Step 0 said `cat <transcript_path>`, where `transcript_path` pointed at the live session file under `~/.claude/projects/` — outside the project tree, so each read prompts. The file is also megabytes of JSONL, so the agent improvised with `head` / `wc -l` / inline `python3 -c` parse loops, each prompting again.
2. **Reviewing existing guidelines.** SKILL.md said nothing about this step, but the agent self-directed to avoid near-duplicate extractions and defaulted to `for f in .evolve/entities/guideline/*.md; do cat "$f"; done` — one prompt per file.

### Changes

- `skills/learn/SKILL.md` Step 0: read the saved trajectory at `.evolve/trajectories/claude-transcript_<session>.jsonl` (already copied there by `save-trajectory/on_stop.py` before `learn/on_stop.py` fires) via the **Read tool**. No fallback to `~/.claude/projects/` — if the saved copy is missing, output zero entities and exit.
- `skills/learn/SKILL.md` new Step 2 ("Review Existing Guidelines"): enumerate with the **Glob tool** (`.evolve/entities/**/*.md`), open each with the **Read tool**. Extract/save steps renumbered to 3/4. Explicitly forbids `cat`, `head`, `find`, `for` loops, and `python3 -c` on the entity or transcript trees.
- `skills/learn/scripts/on_stop.py`: drop the `The session transcript is at: <path>` marker from the stop-hook reason. Only the saved-path marker remains, so the forked skill literally cannot be tempted to read the live file.

### Why save_entities.py dedup alone isn't enough

`save_entities.py` drops exact-content matches only (normalized whitespace/case). It does not catch near-duplicates with different wording, which is why the agent legitimately wants to skim existing guidelines before extracting. The skill now supports that intent — but through prompt-free tools.

## Test plan

- [x] The sandbox learn+recall e2e test still passes — the change is a documentation rewrite plus a marker-emission tweak. No assertion changes needed.
- [ ] Manual: start a Claude Code session in a project with the plugin installed, drive it through a realistic multi-turn workflow that would normally pile up permission prompts at Stop. With this PR applied, the learn fork should use Read/Glob only (observable in the fork's subagent transcript under `~/.claude/projects/<proj>/<session>/subagents/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor
- Modified trajectory loading workflow to extract saved trajectory paths from stop-hook messages instead of live parsing
- Added step to review existing saved guidelines and prevent duplicate findings in subsequent analyses
- Reorganized workflow step numbering and path source references
- Updated saved trajectory file handling to gracefully handle missing files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->