### PR TITLE
feat(memory): support-conserving guideline consolidation

### DIFF
--- a/altk_evolve/config/evolve.py
+++ b/altk_evolve/config/evolve.py
@@ -9,6 +9,14 @@ class EvolveConfig(BaseSettings):
     settings: BaseSettings | None = None
     clustering_threshold: float = 0.80
     segmentation_enabled: bool = True
+    # Consolidation dosage knobs (see docs: capability-dependent dosage).
+    #   none     - skip consolidation entirely
+    #   lossless - merge only equivalent guidelines; conserve support (default)
+    #   lossy    - merge more aggressively (fewer, broader guidelines); support still conserved
+    # Support-threshold *filtering* (sup2/sup3) is applied non-destructively at selection
+    # time, not by deleting entities here.
+    consolidation_mode: Literal["none", "lossless", "lossy"] = "lossless"
+    lossy_target_num_guidelines: int = 12
 
 
 # to reload settings call evolve_config.__init__()

--- a/altk_evolve/frontend/client/evolve_client.py
+++ b/altk_evolve/frontend/client/evolve_client.py
@@ -151,27 +151,42 @@ class EvolveClient:
             )
         return cluster_entities(entities, threshold=threshold)
 
-    def consolidate_guidelines(self, namespace_id: str, threshold: float | None = None) -> ConsolidationResult:
+    def consolidate_guidelines(self, namespace_id: str, threshold: float | None = None, mode: str | None = None) -> ConsolidationResult:
         """Cluster similar guidelines and combine each cluster into consolidated guidelines.
+
+        Consolidation is support-conserving: each consolidated guideline records how many
+        source guidelines it merges (``support``) and their merged ``evidence`` polarity,
+        and the total support is preserved (no advice is dropped).
 
         Args:
             namespace_id: Namespace to consolidate entities in.
             threshold: Cosine similarity threshold (0-1). Defaults to config value.
+            mode: Consolidation mode — ``"none"`` (skip), ``"lossless"`` (default) or
+                ``"lossy"`` (merge more aggressively). Defaults to ``config.consolidation_mode``.
 
         Returns:
-            ConsolidationResult with counts of clusters, guidelines before, and guidelines after.
+            ConsolidationResult with cluster/guideline counts and total support before/after.
         """
         from altk_evolve.llm.guidelines.clustering import combine_cluster
 
+        if mode is None:
+            mode = getattr(self.config, "consolidation_mode", "lossless")
+        if mode == "none":
+            logger.info("consolidation_mode='none'; skipping consolidation for namespace %s.", namespace_id)
+            return ConsolidationResult(clusters_found=0, guidelines_before=0, guidelines_after=0)
+
+        combine_mode = "lossy" if mode == "lossy" else "lossless"
         clusters = self.cluster_guidelines(namespace_id, threshold=threshold)
         clusters_found = 0
         guidelines_before = 0
         guidelines_after = 0
+        support_before = 0
+        support_after = 0
 
         for cluster in clusters:
             # Phase 1: combine + insert (skip cluster on failure)
             try:
-                consolidated_guidelines = combine_cluster(cluster)
+                consolidated_guidelines = combine_cluster(cluster, mode=combine_mode)
 
                 task_description = (cluster[0].metadata or {}).get("task_description", "")
                 new_entities = [
@@ -184,6 +199,8 @@ class EvolveClient:
                             "category": guideline.category,
                             "trigger": guideline.trigger,
                             "implementation_steps": guideline.implementation_steps,
+                            "support": guideline.support,
+                            "evidence": guideline.evidence,
                         },
                     )
                     for guideline in consolidated_guidelines
@@ -207,6 +224,8 @@ class EvolveClient:
             clusters_found += 1
             guidelines_before += len(cluster)
             guidelines_after += len(consolidated_guidelines)
+            support_before += sum(int((e.metadata or {}).get("support", 1) or 1) for e in cluster)
+            support_after += sum(g.support for g in consolidated_guidelines)
 
             # Phase 2: delete originals (log errors but don't roll back insert)
             for entity in cluster:
@@ -223,6 +242,8 @@ class EvolveClient:
             clusters_found=clusters_found,
             guidelines_before=guidelines_before,
             guidelines_after=guidelines_after,
+            support_before=support_before,
+            support_after=support_after,
         )
 
     # Convenience methods for common patterns

--- a/altk_evolve/frontend/mcp/mcp_server.py
+++ b/altk_evolve/frontend/mcp/mcp_server.py
@@ -535,6 +535,7 @@ def save_trajectory(
                 "rationale": guideline.rationale,
                 "trigger": guideline.trigger,
                 "implementation_steps": guideline.implementation_steps,
+                "support": 1,
             },
         )
         for result in results

--- a/altk_evolve/llm/guidelines/clustering.py
+++ b/altk_evolve/llm/guidelines/clustering.py
@@ -171,7 +171,14 @@ def _attribute_support(
     out: list[Guideline] = []
 
     for cg in consolidated:
-        idxs = [i for i in cg.source_indices if isinstance(i, int) and 0 <= i < n and not assigned[i]]
+        # Dedupe within a single guideline's source_indices so a repeated index (e.g.
+        # [0, 0, 1]) can't double-count its member's support.
+        seen: set[int] = set()
+        idxs: list[int] = []
+        for i in cg.source_indices:
+            if isinstance(i, int) and 0 <= i < n and not assigned[i] and i not in seen:
+                seen.add(i)
+                idxs.append(i)
         if not idxs:
             continue
         for i in idxs:

--- a/altk_evolve/llm/guidelines/clustering.py
+++ b/altk_evolve/llm/guidelines/clustering.py
@@ -13,15 +13,17 @@ from jinja2 import Template
 from litellm import completion, get_supported_openai_params, supports_response_schema
 from sentence_transformers import SentenceTransformer
 
+from altk_evolve.config.evolve import evolve_config
 from altk_evolve.config.llm import llm_settings
 from altk_evolve.schema.core import RecordedEntity
 from altk_evolve.schema.exceptions import EvolveException
-from altk_evolve.schema.guidelines import Guideline, GuidelineGenerationResponse
+from altk_evolve.schema.guidelines import ConsolidatedGuideline, ConsolidatedGuidelineResponse, Evidence, Guideline
 from altk_evolve.utils.utils import clean_llm_response
 
 logger = logging.getLogger(__name__)
 
 MAX_CLUSTER_ENTITIES = 5000
+_VALID_CATEGORIES = {"strategy", "recovery", "optimization"}
 
 _COMBINE_GUIDELINES_TEMPLATE = Template((Path(__file__).parent / "prompts/combine_guidelines.jinja2").read_text())
 
@@ -127,16 +129,102 @@ def cluster_entities(
     return clusters
 
 
-def combine_cluster(entities: list[RecordedEntity]) -> list[Guideline]:
+def _normalize_steps(raw: object) -> list[str]:
+    if raw is None or raw == []:
+        return []
+    if isinstance(raw, str):
+        return [raw]
+    if isinstance(raw, list):
+        return [str(x) for x in raw]
+    return [str(raw)]
+
+
+def _merge_evidence(evidences: list[Evidence | None]) -> Evidence | None:
+    """Merge evidence markers: any success+failure (or an existing 'both') -> 'both'."""
+    present = {e for e in evidences if e}
+    if not present:
+        return None
+    if "both" in present or ("success" in present and "failure" in present):
+        return "both"
+    return "success" if "success" in present else "failure"
+
+
+def _coerce_category(value: object) -> str:
+    return str(value) if value in _VALID_CATEGORIES else "strategy"
+
+
+def _attribute_support(
+    entities: list[RecordedEntity],
+    consolidated: list[ConsolidatedGuideline],
+    member_support: list[int],
+    member_evidence: list[Evidence | None],
+) -> list[Guideline]:
+    """Map consolidated guidelines back to their source members, conserving total support.
+
+    Each input index is attributed to exactly one output guideline (the first that claims
+    it via ``source_indices``). Any index the model failed to cover is carried through
+    unchanged as its own guideline, so no advice is ever dropped and ``sum(support)`` is
+    preserved.
+    """
+    n = len(entities)
+    assigned = [False] * n
+    out: list[Guideline] = []
+
+    for cg in consolidated:
+        idxs = [i for i in cg.source_indices if isinstance(i, int) and 0 <= i < n and not assigned[i]]
+        if not idxs:
+            continue
+        for i in idxs:
+            assigned[i] = True
+        out.append(
+            Guideline(
+                content=cg.content,
+                rationale=cg.rationale,
+                category=cg.category,
+                trigger=cg.trigger,
+                implementation_steps=cg.implementation_steps,
+                support=sum(member_support[i] for i in idxs),
+                evidence=_merge_evidence([member_evidence[i] for i in idxs]),
+            )
+        )
+
+    # Fail-safe: any uncovered member survives unchanged as its own guideline (lossless).
+    for i in range(n):
+        if assigned[i]:
+            continue
+        md = entities[i].metadata or {}
+        out.append(
+            Guideline(
+                content=str(entities[i].content),
+                rationale=str(md.get("rationale", "")),
+                category=_coerce_category(md.get("category")),  # type: ignore[arg-type]
+                trigger=str(md.get("trigger", "")),
+                implementation_steps=_normalize_steps(md.get("implementation_steps")),
+                support=member_support[i],
+                evidence=member_evidence[i],
+            )
+        )
+
+    total_in, total_out = sum(member_support), sum(g.support for g in out)
+    if total_out != total_in:
+        logger.warning("Support not conserved during consolidation (in=%d, out=%d).", total_in, total_out)
+    return out
+
+
+def combine_cluster(entities: list[RecordedEntity], mode: str = "lossless") -> list[Guideline]:
     """Combine guidelines from a cluster of related entities into consolidated guidelines.
 
-    Uses an LLM to merge overlapping guidelines into fewer, non-redundant guidelines.
+    Uses an LLM to merge related guidelines while conserving each guideline's ``support``
+    count (number of source guidelines behind it) and merging ``evidence`` polarity.
 
     Args:
         entities: Cluster of related entities to combine.
+        mode: Merge style — ``"lossless"`` (merge only equivalent advice; default) or
+            ``"lossy"`` (merge more aggressively). Support is conserved either way; no
+            advice is dropped in this step.
 
     Returns:
-        Consolidated list of guidelines.
+        Consolidated list of guidelines with ``support``/``evidence`` populated.
 
     Raises:
         EvolveException: If the LLM call fails after 3 attempts.
@@ -158,14 +246,9 @@ def combine_cluster(entities: list[RecordedEntity]) -> list[Guideline]:
         dict.fromkeys((e.metadata or {}).get("task_description", "") for e in entities if (e.metadata or {}).get("task_description"))
     )
 
-    def _normalize_steps(raw: object) -> list[str]:
-        if raw is None or raw == []:
-            return []
-        if isinstance(raw, str):
-            return [raw]
-        if isinstance(raw, list):
-            return [str(x) for x in raw]
-        return [str(raw)]
+    # Per-member support/evidence carried in metadata (defaults: support 1, evidence unknown).
+    member_support = [max(1, int((e.metadata or {}).get("support", 1) or 1)) for e in entities]
+    member_evidence: list[Evidence | None] = [(e.metadata or {}).get("evidence") for e in entities]
 
     guidelines = [
         {
@@ -182,6 +265,8 @@ def combine_cluster(entities: list[RecordedEntity]) -> list[Guideline]:
         task_descriptions=task_descriptions,
         guidelines=guidelines,
         constrained_decoding_supported=constrained_decoding_supported,
+        merge_style="aggressive" if mode == "lossy" else "conservative",
+        target_count=evolve_config.lossy_target_num_guidelines,
     )
 
     litellm.enable_json_schema_validation = constrained_decoding_supported
@@ -194,7 +279,7 @@ def combine_cluster(entities: list[RecordedEntity]) -> list[Guideline]:
                     completion(
                         model=llm_settings.guidelines_model,
                         messages=[{"role": "user", "content": prompt}],
-                        response_format=GuidelineGenerationResponse,
+                        response_format=ConsolidatedGuidelineResponse,
                         custom_llm_provider=llm_settings.custom_llm_provider,
                     )
                     .choices[0]
@@ -217,7 +302,8 @@ def combine_cluster(entities: list[RecordedEntity]) -> list[Guideline]:
                     raise EvolveException("LLM returned None content for combine_cluster")
                 clean_response = clean_llm_response(content)
 
-            return GuidelineGenerationResponse.model_validate(json.loads(clean_response)).guidelines
+            consolidated = ConsolidatedGuidelineResponse.model_validate(json.loads(clean_response)).guidelines
+            return _attribute_support(entities, consolidated, member_support, member_evidence)
         except Exception as e:
             last_error = e
             if attempt < 2:

--- a/altk_evolve/llm/guidelines/prompts/combine_guidelines.jinja2
+++ b/altk_evolve/llm/guidelines/prompts/combine_guidelines.jinja2
@@ -7,8 +7,9 @@ These guidelines came from tasks like:
 {% endfor %}
 
 # Existing Guidelines
+Each guideline is labelled with a 0-based index; refer to those indices in `source_indices`.
 {% for guideline in guidelines %}
-## Guideline {{ loop.index }}
+## Guideline {{ loop.index0 }}
 - **Content:** {{ guideline.content }}
 - **Rationale:** {{ guideline.rationale }}
 - **Category:** {{ guideline.category }}
@@ -18,14 +19,19 @@ These guidelines came from tasks like:
 {% endfor %}
 
 # Your Task
-Combine the above guidelines into a smaller set of HIGH-QUALITY, CONSOLIDATED, NON-REDUNDANT guidelines. Merge overlapping advice, remove duplicates, and preserve any unique insights.
+{% if merge_style == "aggressive" %}
+Combine the above guidelines into a SMALL set (aim for about {{ target_count }}) of HIGH-QUALITY, CONSOLIDATED guidelines. Merge liberally: group guidelines that address related actions or the same phase of work, even if the wording differs.
+{% else %}
+Combine the above guidelines LOSSLESSLY into a smaller set of HIGH-QUALITY, CONSOLIDATED, NON-REDUNDANT guidelines. Merge two guidelines ONLY when following one is equivalent to following the other (same action, same trigger); differences in wording or examples are fine to merge. If two guidelines address DIFFERENT actions, triggers, APIs, or edge cases, KEEP THEM SEPARATE — when in doubt, do not merge.
+{% endif %}
 
 **Things to Remember:**
-1. Each consolidated guideline should be self-contained, clear and actionable
-2. Preserve important nuances from different source guidelines. Preserve specific technical details (API names, parameter names, etc.)
-3. Use the most specific and helpful phrasing
-4. Remove guidelines that are too generic or obvious.
-5. Reduce the total count while retaining all valuable information
+1. Each consolidated guideline must be self-contained, clear and actionable.
+2. Preserve important nuances and specific technical details (API names, parameter names, etc.).
+3. Use the most specific and helpful phrasing (you may adopt the clearest source guideline's wording).
+4. Do NOT invent advice that is not present in the sources.
+5. For each consolidated guideline, set `source_indices` to the 0-based indices of the input guidelines it merges.
+6. Every input guideline index must appear in exactly one consolidated guideline's `source_indices`.
 
 {% if not constrained_decoding_supported %}
 **Output Format (JSON):**
@@ -37,7 +43,8 @@ Combine the above guidelines into a smaller set of HIGH-QUALITY, CONSOLIDATED, N
             "rationale": "Why this guideline helps",
             "category": "strategy|recovery|optimization",
             "trigger": "When to apply this guideline",
-            "implementation_steps": ["step 1", "step 2"]
+            "implementation_steps": ["step 1", "step 2"],
+            "source_indices": [0, 2]
         }
     ]
 }

--- a/altk_evolve/schema/guidelines.py
+++ b/altk_evolve/schema/guidelines.py
@@ -91,9 +91,9 @@ class ConsolidationResult:
     """Summary of a guideline consolidation run.
 
     ``support_before``/``support_after`` track the total support (sum of ``support`` over
-    the affected guidelines) before and after consolidation. For lossless/lossy modes they
-    are equal (support is conserved); for the ``support`` mode ``support_after`` is smaller
-    because low-support guidelines are pruned.
+    the affected guidelines) before and after consolidation. For the current lossless/lossy
+    modes they are equal (support is conserved). A future support-threshold filtering step
+    (not yet implemented) may reduce ``support_after`` by pruning low-support guidelines.
     """
 
     clusters_found: int

--- a/altk_evolve/schema/guidelines.py
+++ b/altk_evolve/schema/guidelines.py
@@ -5,16 +5,46 @@ from typing import Literal
 DEFAULT_TASK_DESCRIPTION = "Task description unknown"
 
 
+Evidence = Literal["success", "failure", "both"]
+
+
 class Guideline(BaseModel):
     content: str = Field(description="Clear, actionable guideline")
     rationale: str = Field(description="Why this guideline helps")
     category: Literal["strategy", "recovery", "optimization"]
     trigger: str = Field(description="When to apply this guideline")
     implementation_steps: list[str] = Field(default_factory=list, description="Specific steps to implement this guideline")
+    support: int = Field(
+        default=1,
+        ge=1,
+        description="Number of source guidelines merged into this one. Conserved across consolidation (dosage signal).",
+    )
+    evidence: Evidence | None = Field(
+        default=None,
+        description="Whether the backing trajectories succeeded, failed, or both. None when unknown.",
+    )
 
 
 class GuidelineGenerationResponse(BaseModel):
     guidelines: list[Guideline]
+
+
+class ConsolidatedGuideline(Guideline):
+    """A consolidated guideline that records which input guidelines it subsumes.
+
+    ``source_indices`` are 0-based indices into the list of input guidelines shown to
+    the model. They let consolidation attribute (and conserve) support exactly, rather
+    than trusting the model to report counts.
+    """
+
+    source_indices: list[int] = Field(
+        default_factory=list,
+        description="0-based indices of the input guidelines this consolidated guideline merges.",
+    )
+
+
+class ConsolidatedGuidelineResponse(BaseModel):
+    guidelines: list[ConsolidatedGuideline]
 
 
 class SubtaskSegment(BaseModel):
@@ -58,8 +88,16 @@ class GuidelineGenerationResult:
 
 @dataclass(frozen=True)
 class ConsolidationResult:
-    """Summary of a guideline consolidation run."""
+    """Summary of a guideline consolidation run.
+
+    ``support_before``/``support_after`` track the total support (sum of ``support`` over
+    the affected guidelines) before and after consolidation. For lossless/lossy modes they
+    are equal (support is conserved); for the ``support`` mode ``support_after`` is smaller
+    because low-support guidelines are pruned.
+    """
 
     clusters_found: int
     guidelines_before: int
     guidelines_after: int
+    support_before: int = 0
+    support_after: int = 0

--- a/altk_evolve/sync/phoenix_sync.py
+++ b/altk_evolve/sync/phoenix_sync.py
@@ -820,6 +820,7 @@ class PhoenixSync:
                     "rationale": guideline.rationale,
                     "trigger": guideline.trigger,
                     "implementation_steps": guideline.implementation_steps,
+                    "support": 1,
                     "source_task_id": trajectory["trace_id"],
                     "source_span_id": trajectory["span_id"],
                     "task_description": result.task_description,

--- a/tests/unit/test_combine_guidelines.py
+++ b/tests/unit/test_combine_guidelines.py
@@ -130,6 +130,25 @@ class TestCombineCluster:
     @patch("altk_evolve.llm.guidelines.clustering.completion")
     @patch("altk_evolve.llm.guidelines.clustering.supports_response_schema", return_value=False)
     @patch("altk_evolve.llm.guidelines.clustering.get_supported_openai_params", return_value=[])
+    def test_combine_cluster_dedupes_repeated_source_indices(self, _mock_params, _mock_schema, mock_completion):
+        # A repeated index within one guideline's source_indices must not double-count support.
+        mock_completion.return_value = _mock_completion_response([_cg("Merged rule", "strategy", [0, 0, 1])])
+
+        entities = [
+            _make_entity("1", "Rule A", support=2),
+            _make_entity("2", "Rule B", support=3),
+        ]
+
+        result = combine_cluster(entities)
+
+        assert len(result) == 1
+        # 2 + 3 == 5, NOT 2 + 2 + 3.
+        assert result[0].support == 5
+        assert sum(g.support for g in result) == 5
+
+    @patch("altk_evolve.llm.guidelines.clustering.completion")
+    @patch("altk_evolve.llm.guidelines.clustering.supports_response_schema", return_value=False)
+    @patch("altk_evolve.llm.guidelines.clustering.get_supported_openai_params", return_value=[])
     def test_combine_cluster_lossy_uses_aggressive_prompt(self, _mock_params, _mock_schema, mock_completion):
         mock_completion.return_value = _mock_completion_response([_cg("Merged", "strategy", [0, 1])])
 

--- a/tests/unit/test_combine_guidelines.py
+++ b/tests/unit/test_combine_guidelines.py
@@ -13,42 +13,52 @@ from altk_evolve.schema.exceptions import EvolveException
 from altk_evolve.schema.guidelines import ConsolidationResult, Guideline
 
 
-def _make_entity(entity_id: str, content: str, task_description: str = "do a task") -> RecordedEntity:
+def _make_entity(
+    entity_id: str,
+    content: str,
+    task_description: str = "do a task",
+    support: int = 1,
+    evidence: str | None = None,
+) -> RecordedEntity:
+    metadata: dict = {
+        "task_description": task_description,
+        "rationale": "some rationale",
+        "category": "strategy",
+        "trigger": "when needed",
+        "support": support,
+    }
+    if evidence is not None:
+        metadata["evidence"] = evidence
     return RecordedEntity(
         id=entity_id,
         content=content,
         type="guideline",
-        metadata={
-            "task_description": task_description,
-            "rationale": "some rationale",
-            "category": "strategy",
-            "trigger": "when needed",
-        },
+        metadata=metadata,
         created_at=datetime(2025, 1, 1),
     )
 
 
 def _mock_completion_response(guidelines: list[dict]) -> MagicMock:
-    """Build a mock litellm completion response."""
+    """Build a mock litellm completion response (guidelines must carry source_indices)."""
     response = MagicMock()
     response.choices = [MagicMock()]
     response.choices[0].message.content = json.dumps({"guidelines": guidelines})
     return response
 
 
+def _cg(content: str, category: str, source_indices: list[int]) -> dict:
+    return {
+        "content": content,
+        "rationale": "why",
+        "category": category,
+        "trigger": "when",
+        "source_indices": source_indices,
+    }
+
+
 SAMPLE_GUIDELINES = [
-    {
-        "content": "Use retry logic for flaky APIs",
-        "rationale": "APIs can fail transiently",
-        "category": "recovery",
-        "trigger": "When calling external APIs",
-    },
-    {
-        "content": "Log errors with context",
-        "rationale": "Easier debugging",
-        "category": "optimization",
-        "trigger": "When handling exceptions",
-    },
+    _cg("Use retry logic for flaky APIs", "recovery", [0]),
+    _cg("Log errors with context", "optimization", [1]),
 ]
 
 
@@ -81,11 +91,63 @@ class TestCombineCluster:
     @patch("altk_evolve.llm.guidelines.clustering.completion")
     @patch("altk_evolve.llm.guidelines.clustering.supports_response_schema", return_value=False)
     @patch("altk_evolve.llm.guidelines.clustering.get_supported_openai_params", return_value=[])
+    def test_combine_cluster_sums_support_and_merges_evidence(self, _mock_params, _mock_schema, mock_completion):
+        # One consolidated guideline subsumes both inputs -> support 2+3=5, evidence success+failure=both.
+        mock_completion.return_value = _mock_completion_response([_cg("Merged rule", "strategy", [0, 1])])
+
+        entities = [
+            _make_entity("1", "Rule A", support=2, evidence="success"),
+            _make_entity("2", "Rule B", support=3, evidence="failure"),
+        ]
+
+        result = combine_cluster(entities)
+
+        assert len(result) == 1
+        assert result[0].support == 5
+        assert result[0].evidence == "both"
+
+    @patch("altk_evolve.llm.guidelines.clustering.completion")
+    @patch("altk_evolve.llm.guidelines.clustering.supports_response_schema", return_value=False)
+    @patch("altk_evolve.llm.guidelines.clustering.get_supported_openai_params", return_value=[])
+    def test_combine_cluster_carries_uncovered_members(self, _mock_params, _mock_schema, mock_completion):
+        # Model only covers index 0; index 1 must survive as its own guideline (lossless fail-safe).
+        mock_completion.return_value = _mock_completion_response([_cg("Merged rule", "strategy", [0])])
+
+        entities = [
+            _make_entity("1", "Rule A", support=2, evidence="success"),
+            _make_entity("2", "Rule B is unique", support=1, evidence="failure"),
+        ]
+
+        result = combine_cluster(entities)
+
+        assert len(result) == 2
+        # Total support is conserved regardless of what the model covered.
+        assert sum(g.support for g in result) == 3
+        carried = next(g for g in result if g.content == "Rule B is unique")
+        assert carried.support == 1
+        assert carried.evidence == "failure"
+
+    @patch("altk_evolve.llm.guidelines.clustering.completion")
+    @patch("altk_evolve.llm.guidelines.clustering.supports_response_schema", return_value=False)
+    @patch("altk_evolve.llm.guidelines.clustering.get_supported_openai_params", return_value=[])
+    def test_combine_cluster_lossy_uses_aggressive_prompt(self, _mock_params, _mock_schema, mock_completion):
+        mock_completion.return_value = _mock_completion_response([_cg("Merged", "strategy", [0, 1])])
+
+        entities = [_make_entity("1", "A"), _make_entity("2", "B")]
+        combine_cluster(entities, mode="lossy")
+
+        _, kwargs = mock_completion.call_args
+        prompt = kwargs["messages"][0]["content"]
+        assert "Merge liberally" in prompt
+
+    @patch("altk_evolve.llm.guidelines.clustering.completion")
+    @patch("altk_evolve.llm.guidelines.clustering.supports_response_schema", return_value=False)
+    @patch("altk_evolve.llm.guidelines.clustering.get_supported_openai_params", return_value=[])
     def test_combine_cluster_retries_on_failure(self, _mock_params, _mock_schema, mock_completion):
         mock_completion.side_effect = [
             ValueError("bad json"),
             ValueError("bad json again"),
-            _mock_completion_response(SAMPLE_GUIDELINES[:1]),
+            _mock_completion_response([_cg("Use retry logic for flaky APIs", "recovery", [0, 1])]),
         ]
 
         entities = [_make_entity("1", "Guideline A"), _make_entity("2", "Guideline B")]
@@ -114,7 +176,7 @@ class TestCombineCluster:
     def test_combine_cluster_uses_structured_output(self, _mock_params, _mock_schema, mock_completion, monkeypatch):
         monkeypatch.setattr(clustering_module.llm_settings, "guidelines_model", "gpt-4o")
         monkeypatch.setattr(clustering_module.llm_settings, "custom_llm_provider", "openai")
-        mock_completion.return_value = _mock_completion_response(SAMPLE_GUIDELINES[:1])
+        mock_completion.return_value = _mock_completion_response([_cg("Merged", "strategy", [0, 1])])
 
         entities = [_make_entity("1", "Guideline A"), _make_entity("2", "Guideline B")]
         result = combine_cluster(entities)
@@ -136,7 +198,7 @@ class TestCombineCluster:
     ):
         monkeypatch.setattr(clustering_module.llm_settings, "guidelines_model", "groq/openai/gpt-oss-120b")
         monkeypatch.setattr(clustering_module.llm_settings, "custom_llm_provider", "groq")
-        mock_completion.return_value = _mock_completion_response(SAMPLE_GUIDELINES[:1])
+        mock_completion.return_value = _mock_completion_response([_cg("Merged", "strategy", [0, 1])])
 
         entities = [_make_entity("1", "Guideline A"), _make_entity("2", "Guideline B")]
         result = combine_cluster(entities)
@@ -153,12 +215,23 @@ class TestCombineCluster:
 # ---------------------------------------------------------------------------
 
 
+def _make_client(mock_backend, mode: str = "lossless"):
+    from altk_evolve.frontend.client.evolve_client import EvolveClient
+
+    client = EvolveClient.__new__(EvolveClient)
+    client.backend = mock_backend
+    client.config = MagicMock()
+    client.config.clustering_threshold = 0.80
+    client.config.consolidation_mode = mode
+    return client
+
+
 @pytest.mark.unit
 class TestConsolidateGuidelines:
     @patch("altk_evolve.llm.guidelines.clustering.combine_cluster")
     def test_consolidate_guidelines_deletes_originals_and_inserts_new(self, mock_combine):
         consolidated = [
-            Guideline(content="Combined guideline", rationale="Merged", category="strategy", trigger="Always"),
+            Guideline(content="Combined guideline", rationale="Merged", category="strategy", trigger="Always", support=2),
         ]
         mock_combine.return_value = consolidated
 
@@ -169,15 +242,8 @@ class TestConsolidateGuidelines:
 
         mock_backend = MagicMock()
         mock_backend.search_entities.return_value = entities_cluster
+        client = _make_client(mock_backend)
 
-        from altk_evolve.frontend.client.evolve_client import EvolveClient
-
-        client = EvolveClient.__new__(EvolveClient)
-        client.backend = mock_backend
-        client.config = MagicMock()
-        client.config.clustering_threshold = 0.80
-
-        # Mock cluster_guidelines to return our cluster
         with patch.object(client, "cluster_guidelines", return_value=[entities_cluster]):
             client.consolidate_guidelines("test-ns")
 
@@ -189,6 +255,7 @@ class TestConsolidateGuidelines:
         assert len(new_entities) == 1
         assert new_entities[0].content == "Combined guideline"
         assert new_entities[0].metadata["task_description"] == "error handling"
+        assert new_entities[0].metadata["support"] == 2
         assert enable_cr is False
 
         # Verify deletes were called for each original entity
@@ -203,28 +270,21 @@ class TestConsolidateGuidelines:
         assert insert_idx < first_delete_idx
 
     @patch("altk_evolve.llm.guidelines.clustering.combine_cluster")
-    def test_consolidate_guidelines_returns_correct_counts(self, mock_combine):
-        # Cluster 1: 3 entities -> 1 consolidated guideline
-        # Cluster 2: 2 entities -> 2 consolidated guidelines
+    def test_consolidate_guidelines_returns_correct_counts_and_conserves_support(self, mock_combine):
+        # Cluster 1: 3 entities -> 1 consolidated guideline (support 3)
+        # Cluster 2: 2 entities -> 2 consolidated guidelines (support 1 + 1)
         mock_combine.side_effect = [
-            [Guideline(content="C1", rationale="R", category="strategy", trigger="T")],
+            [Guideline(content="C1", rationale="R", category="strategy", trigger="T", support=3)],
             [
-                Guideline(content="C2a", rationale="R", category="strategy", trigger="T"),
-                Guideline(content="C2b", rationale="R", category="optimization", trigger="T"),
+                Guideline(content="C2a", rationale="R", category="strategy", trigger="T", support=1),
+                Guideline(content="C2b", rationale="R", category="optimization", trigger="T", support=1),
             ],
         ]
 
         cluster1 = [_make_entity(f"c1-{i}", f"Guideline {i}", "task A") for i in range(3)]
         cluster2 = [_make_entity(f"c2-{i}", f"Guideline {i}", "task B") for i in range(2)]
 
-        mock_backend = MagicMock()
-
-        from altk_evolve.frontend.client.evolve_client import EvolveClient
-
-        client = EvolveClient.__new__(EvolveClient)
-        client.backend = mock_backend
-        client.config = MagicMock()
-        client.config.clustering_threshold = 0.80
+        client = _make_client(MagicMock())
 
         with patch.object(client, "cluster_guidelines", return_value=[cluster1, cluster2]):
             result = client.consolidate_guidelines("test-ns")
@@ -233,3 +293,16 @@ class TestConsolidateGuidelines:
         assert result.clusters_found == 2
         assert result.guidelines_before == 5
         assert result.guidelines_after == 3
+        # 5 originals (support 1 each) -> support conserved at 5 (3 + 1 + 1).
+        assert result.support_before == 5
+        assert result.support_after == 5
+
+    def test_consolidate_guidelines_none_mode_is_noop(self):
+        mock_backend = MagicMock()
+        client = _make_client(mock_backend, mode="none")
+
+        result = client.consolidate_guidelines("test-ns")
+
+        assert result == ConsolidationResult(clusters_found=0, guidelines_before=0, guidelines_after=0)
+        mock_backend.update_entities.assert_not_called()
+        mock_backend.delete_entity_by_id.assert_not_called()


### PR DESCRIPTION
## What & why

Consolidation currently merges clustered guidelines but **discards how many source guidelines back each one and whether they came from successes or failures**. That signal is what's needed to *dose* memory per model — the capability-dependent dosage finding from AppWorld experiments (DeepSeek-V3.2, gpt-oss-120b): strong models absorb the full playbook, weaker models need a small, selective dose. This PR makes consolidation **support-conserving** so that signal survives.

This is **PR 1 of a staged pair**. A follow-up adds dosage-aware retrieval (core + top-k selection) that consumes the `support` signal introduced here.

## Changes

- **schema** (`schema/guidelines.py`): add `support: int (>=1)` and `evidence: success|failure|both|None` to `Guideline`; add `ConsolidatedGuideline`/`ConsolidatedGuidelineResponse` carrying `source_indices` so consolidation attributes support **exactly** rather than trusting the model to report counts.
- **consolidation** (`llm/guidelines/clustering.py`): `combine_cluster` now sums member support and merges evidence (`success`+`failure` → `both`) per output guideline via `source_indices`, and **carries any uncovered member through unchanged** (lossless fail-safe) so `sum(support)` is conserved and no advice is ever dropped. New `mode` arg (`lossless` default / `lossy`) selects conservative vs aggressive merging.
- **prompt** (`combine_guidelines.jinja2`): asks for 0-based `source_indices` with lossless framing; adds an aggressive variant for `lossy`.
- **config** (`config/evolve.py`): `consolidation_mode` (`none`|`lossless`|`lossy`) and `lossy_target_num_guidelines`. Support-threshold *filtering* (sup2/sup3) is deliberately left to **non-destructive selection** in the follow-up, not deletion here.
- **client** (`consolidate_guidelines`): passes `mode` through, short-circuits on `none`, persists `support`/`evidence`, and reports `support_before`/`support_after` on `ConsolidationResult` so conservation is observable.
- **generation sites** (`phoenix_sync`, `mcp_server`): stamp `support=1` on freshly mined guidelines.

## Tests

Extended `tests/unit/test_combine_guidelines.py`: support summed, evidence merged, uncovered members carried through (fail-safe), `none`-mode no-op, and support conserved through `consolidate_guidelines`. Full unit suite green (395 passed); `ruff`, `ruff format`, `mypy`, and pre-commit all pass. Also verified end-to-end on the filesystem backend (3 originals → 2 consolidated, support 3→3, evidence merged to `both`).

## Compatibility

Backward compatible: `support`/`evidence` default to `1`/`None`, `ConsolidationResult` gains fields with defaults, and `consolidate_guidelines(mode=...)` is optional (defaults to config). Existing guidelines without the new metadata are treated as `support=1`, `evidence=None`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable guideline consolidation modes: none, lossless, and lossy (with a lossy target guideline count).
  * Consolidated guidelines now carry source tracking plus `support` and `evidence`; consolidation results report `support_before` and `support_after`.
* **Bug Fixes**
  * Consolidation preserves uncovered guidance instead of dropping it.
  * Support/evidence attribution is now correctly aggregated, including deduping repeated source references.
* **Tests**
  * Updated and expanded unit tests to cover the new consolidation modes and metadata behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->