### PR TITLE
fix(docs): point repo card Stars link to repo home

### DIFF
--- a/docs/components/github-repo-card.js
+++ b/docs/components/github-repo-card.js
@@ -1015,7 +1015,8 @@ class GitHubRepoCard extends HTMLElement {
     link.textContent = data.full_name;
     link.href = data.html_url;
     githubLink.href = data.html_url;
-    stars.href = `${data.html_url}/stargazers`;
+    // GitHub's /stargazers page 404s for logged-out users, so link to the repo home instead.
+    stars.href = data.html_url;
     forks.href = `${data.html_url}/forks`;
     contributorsEl.href = `${data.html_url}/graphs/contributors`;
     issues.href = `${data.html_url}/issues`;


### PR DESCRIPTION
## Problem

The GitHub Pages repo card (linked from https://agenttoolkit.github.io/altk-evolve/) has a **Stars** stat that links to `/stargazers`. GitHub gates that page behind login — logged-out visitors get a **404**, so the link is dead for anyone browsing the public site while signed out.

## Fix

Point the Stars stat at the repo home page (`data.html_url`) instead. There is no anonymous stargazers view to link to.

Verified against the live repo while logged out:

| Path | Status |
|------|--------|
| `/stargazers` | 404 |
| `/forks` | 200 |
| `/graphs/contributors` | 200 |
| `/issues` | 200 |

The other three stat links already work anonymously and are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated repository star links to open the repository’s main page, avoiding unavailable pages for signed-out visitors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->