### PR TITLE
feat(retention): policy-driven data retention for entities (#275)

### DIFF
--- a/altk_evolve/cli/cli.py
+++ b/altk_evolve/cli/cli.py
@@ -24,12 +24,14 @@ entities_app = typer.Typer(help="Entity management commands")
 sync_app = typer.Typer(help="Sync commands")
 skills_app = typer.Typer(help="Skill management commands")
 viz_app = typer.Typer(help="Visualization commands")
+retention_app = typer.Typer(help="Data retention commands")
 
 app.add_typer(namespaces_app, name="namespaces")
 app.add_typer(entities_app, name="entities")
 app.add_typer(sync_app, name="sync")
 app.add_typer(skills_app, name="skills")
 app.add_typer(viz_app, name="viz")
+app.add_typer(retention_app, name="retention")
 
 console = Console()
 
@@ -37,6 +39,73 @@ console = Console()
 def get_client() -> EvolveClient:
     """Get a EvolveClient instance."""
     return EvolveClient()
+
+
+# =============================================================================
+# Retention Commands
+# =============================================================================
+
+
+@retention_app.command("run")
+def run_retention(
+    policy_file: Annotated[str, typer.Option("--policy", "-p", help="Path to a retention policy file (YAML or JSON).")],
+    namespace: Annotated[Optional[str], typer.Argument(help="Namespace to sweep. Defaults to the configured namespace.")] = None,
+    apply: Annotated[bool, typer.Option("--apply", help="Actually flag/delete. Without this flag the run is a dry run.")] = False,
+):
+    """Apply a data-retention policy to a namespace.
+
+    Dry run by default - pass --apply to mutate. Reports what was (or would be)
+    flagged or deleted, why, and which rule decided it - including memories
+    cascade-deleted via session provenance.
+    """
+    from altk_evolve.retention import RetentionEngine, RetentionPolicy
+
+    client = get_client()
+    namespace_id = namespace or client.config.namespace_id
+
+    try:
+        policy = RetentionPolicy.from_file(policy_file)
+    except FileNotFoundError:
+        console.print(f"[red]Policy file not found:[/red] {policy_file}")
+        raise typer.Exit(1)
+    except Exception as exc:
+        console.print(f"[red]Failed to load policy:[/red] {exc}")
+        raise typer.Exit(1)
+
+    if not policy.rules:
+        console.print(f"[yellow]Policy {policy_file} has no rules; nothing to do.[/yellow]")
+        return
+
+    report = RetentionEngine(client).apply(namespace_id, policy, dry_run=not apply)
+
+    mode = "[yellow]DRY RUN[/yellow]" if report.dry_run else "[green]APPLIED[/green]"
+    console.print(f"Retention {mode} on namespace [cyan]{namespace_id}[/cyan] - {report.summary()}")
+
+    if report.flagged or report.deleted:
+        table = Table(title="Retention actions")
+        table.add_column("Action", style="bold")
+        table.add_column("Entity ID", style="cyan")
+        table.add_column("Type")
+        table.add_column("Reason", style="dim")
+        table.add_column("Rule", style="dim")
+        table.add_column("Why", style="dim")
+        for item in [*report.deleted, *report.flagged]:
+            verb = "[red]delete[/red]" if item.action == "delete" else "[yellow]flag[/yellow]"
+            table.add_row(verb, item.entity_id, item.entity_type, item.reason, item.rule, item.detail)
+        console.print(table)
+    else:
+        console.print("[dim]No entities matched any rule.[/dim]")
+
+    for warning in report.warnings:
+        console.print(f"[yellow]warning:[/yellow] {warning}")
+    for err in report.errors:
+        console.print(f"[red]error:[/red] {err}")
+
+    if report.dry_run and (report.flagged or report.deleted):
+        console.print("[dim]Dry run - nothing was changed. Re-run with --apply to enforce.[/dim]")
+
+    if report.errors:
+        raise typer.Exit(1)
 
 
 # =============================================================================

--- a/altk_evolve/cli/cli.py
+++ b/altk_evolve/cli/cli.py
@@ -96,6 +96,17 @@ def run_retention(
     else:
         console.print("[dim]No entities matched any rule.[/dim]")
 
+    if report.skipped:
+        skipped_table = Table(title="Skipped (degraded signal — not acted on)")
+        skipped_table.add_column("Entity ID", style="cyan")
+        skipped_table.add_column("Type")
+        skipped_table.add_column("Reason", style="dim")
+        skipped_table.add_column("Rule", style="dim")
+        skipped_table.add_column("Why", style="dim")
+        for item in report.skipped:
+            skipped_table.add_row(item.entity_id, item.entity_type, item.reason, item.rule, item.detail)
+        console.print(skipped_table)
+
     for warning in report.warnings:
         console.print(f"[yellow]warning:[/yellow] {warning}")
     for err in report.errors:

--- a/altk_evolve/frontend/client/evolve_client.py
+++ b/altk_evolve/frontend/client/evolve_client.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 from typing import TYPE_CHECKING, cast
 
@@ -122,6 +123,36 @@ class EvolveClient:
     def patch_entity_metadata(self, namespace_id: str, entity_id: str, metadata_updates: dict) -> RecordedEntity:
         """Merge metadata_updates into an entity without touching content or ID."""
         return self.backend.update_entity_metadata(namespace_id, entity_id, metadata_updates)
+
+    def record_access(self, namespace_id: str, entity_ids: list[str], when: datetime.datetime | None = None) -> None:
+        """Stamp ``metadata.last_accessed`` (ISO-8601 UTC) on the given entities.
+
+        This is the *explicit* half of the access-stamping story and the signal
+        the retention engine's ``max_unused_days`` rules read (issue #275).
+
+        Relationship to ``AccessStampPlugin``: the plugin is the automatic path
+        — with hooks enabled it stamps every entity returned by a public read,
+        on ``memory_post_read``. ``record_access`` is the manual path, for
+        callers that do not run hooks or that want to record a *use* that was
+        not a store read (for example, a memory recalled from a cache and
+        actually acted on). Both funnel through the same core,
+        :func:`~altk_evolve.hooks.plugins.access_stamp.build_access_stamps`, so
+        the key and timestamp format are identical and one batch shares one
+        stamp; enabling both is harmless (last writer wins).
+
+        Failures on individual ids are logged and skipped rather than raised —
+        recording an access must never break the flow it rode in on.
+        """
+        # Imported here (not at module scope) to keep the client import cheap;
+        # build_access_stamps is a pure function with no cpex dependency.
+        from altk_evolve.hooks.plugins.access_stamp import build_access_stamps
+
+        moment = when if when is not None else datetime.datetime.now(datetime.UTC)
+        for entity_id, patch in build_access_stamps([{"id": eid} for eid in entity_ids], now=lambda: moment):
+            try:
+                self.patch_entity_metadata(namespace_id, entity_id, patch)
+            except Exception:
+                logger.warning("record_access: failed to stamp entity %s", entity_id, exc_info=True)
 
     def get_public_entities(
         self,

--- a/altk_evolve/retention/__init__.py
+++ b/altk_evolve/retention/__init__.py
@@ -1,0 +1,23 @@
+"""Data retention for altk-evolve (issue #275).
+
+Age- and disuse-based retention of entities, plus session (trajectory)
+retention with provenance-based cascade deletion of the memories derived from
+a session. See ``docs/guides/retention.md``.
+"""
+
+from altk_evolve.retention.engine import (
+    NO_ACCESS_SIGNAL_HINT,
+    RetentionEngine,
+    RetentionItem,
+    RetentionReport,
+)
+from altk_evolve.retention.policy import RetentionPolicy, RetentionRule
+
+__all__ = [
+    "NO_ACCESS_SIGNAL_HINT",
+    "RetentionEngine",
+    "RetentionItem",
+    "RetentionPolicy",
+    "RetentionReport",
+    "RetentionRule",
+]

--- a/altk_evolve/retention/engine.py
+++ b/altk_evolve/retention/engine.py
@@ -110,6 +110,12 @@ class RetentionEngine:
     TRACE_KEYS = ("trace_id", "task_id")
     #: Derived-entity metadata key linking back to a session's trace id.
     SOURCE_KEY = "source_task_id"
+    #: Entity type whose deletion may cascade to derived entities. Only a
+    #: trajectory (session) owns a provenance tree; a cascade_derived delete of
+    #: any other entity type must NOT fan out along source_task_id, or a rule
+    #: with entity_type=None matching a non-trajectory carrier would mass-delete
+    #: everything sharing its trace id. Matches the plugin side's TRAJECTORY_TYPE.
+    TRAJECTORY_TYPE = "trajectory"
     #: How many entities to scan per namespace.
     FETCH_LIMIT = 100_000
 
@@ -274,7 +280,7 @@ class RetentionEngine:
 
             record(RetentionItem(e.id, e.type, action, reason, rule.name, detail))
 
-            if action == "delete" and rule.cascade_derived:
+            if action == "delete" and rule.cascade_derived and e.type == self.TRAJECTORY_TYPE:
                 trace = self._trace_id(e)
                 if not trace:
                     continue

--- a/altk_evolve/retention/engine.py
+++ b/altk_evolve/retention/engine.py
@@ -1,0 +1,272 @@
+"""Retention engine (issue #275).
+
+Evaluates a :class:`~altk_evolve.retention.policy.RetentionPolicy` against the
+entities in a namespace and either flags or deletes the matches. It drives the
+:class:`~altk_evolve.frontend.client.evolve_client.EvolveClient` public API, so
+it is backend-agnostic (filesystem / postgres / milvus) and every delete it
+issues flows through the ``memory_pre_delete`` hook — a legal-hold plugin can
+veto a retention delete.
+
+Signals:
+
+- **age** — ``RecordedEntity.created_at``.
+- **unused** — ``metadata.last_accessed``. That key is stamped automatically by
+  ``altk_evolve.hooks.plugins.access_stamp.AccessStampPlugin`` on every public
+  read, and explicitly by ``EvolveClient.record_access``. Entities carrying no
+  stamp fall back to ``created_at`` — the engine records that fallback on the
+  item's ``detail`` and in ``RetentionReport.warnings`` rather than silently
+  pretending it measured disuse. **Without an access-stamping mechanism enabled
+  an unused rule degrades into an age rule.**
+- **provenance** — a session entity carries ``metadata.trace_id``; entities
+  derived from it carry ``metadata.source_task_id == trace_id``. A delete rule
+  with ``cascade_derived`` removes those derived memories alongside the session.
+  The MCP server historically wrote ``task_id`` where Phoenix sync wrote
+  ``trace_id``; ``MetadataNormalizerPlugin`` now copies one into the other at
+  write time, and this engine additionally falls back to ``task_id`` at read
+  time so sessions written before the normalizer still cascade.
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from altk_evolve.retention.policy import RetentionPolicy, RetentionRule
+from altk_evolve.schema.core import RecordedEntity
+
+logger = logging.getLogger(__name__)
+
+#: Hint appended to items whose "unused" verdict had no real recall signal.
+NO_ACCESS_SIGNAL_HINT = (
+    "no metadata.last_accessed on this entity, so disuse was measured from created_at; "
+    "enable AccessStampPlugin (or call EvolveClient.record_access) for a real recall signal"
+)
+
+
+@dataclass
+class RetentionItem:
+    """One entity the engine decided to act on."""
+
+    entity_id: str
+    entity_type: str
+    action: str  # "flag" | "delete"
+    reason: str  # "age" | "unused" | "cascade:<trace_id>"
+    rule: str
+    #: Human-readable "why", including which signal was used and any fallback.
+    detail: str = ""
+
+
+@dataclass
+class RetentionReport:
+    dry_run: bool
+    flagged: list[RetentionItem] = field(default_factory=list)
+    deleted: list[RetentionItem] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+    #: Non-fatal caveats about the run (e.g. degraded "unused" signal).
+    warnings: list[str] = field(default_factory=list)
+
+    def summary(self) -> str:
+        verb = "would flag/delete" if self.dry_run else "flagged/deleted"
+        return f"{verb}: {len(self.flagged)} flagged, {len(self.deleted)} deleted, {len(self.errors)} errors"
+
+
+def _as_aware(dt: datetime.datetime) -> datetime.datetime:
+    """Treat naive datetimes as UTC so comparisons never raise."""
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=datetime.UTC)
+    return dt
+
+
+def _parse_iso(value: Any) -> datetime.datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return _as_aware(datetime.datetime.fromisoformat(value.replace("Z", "+00:00")))
+    except ValueError:
+        return None
+
+
+class RetentionEngine:
+    """Applies a retention policy to a namespace."""
+
+    #: Session metadata keys holding the trace/session identifier, in priority
+    #: order. ``task_id`` is the MCP server's spelling; MetadataNormalizerPlugin
+    #: copies it to ``trace_id`` on write, and this fallback covers entities
+    #: written before that plugin existed.
+    TRACE_KEYS = ("trace_id", "task_id")
+    #: Derived-entity metadata key linking back to a session's trace id.
+    SOURCE_KEY = "source_task_id"
+    #: How many entities to scan per namespace.
+    FETCH_LIMIT = 100_000
+
+    def __init__(self, client: Any) -> None:
+        self.client = client
+
+    # ── signal helpers ────────────────────────────────────────────────
+
+    def _age_days(self, entity: RecordedEntity, now: datetime.datetime) -> float:
+        return (now - _as_aware(entity.created_at)).total_seconds() / 86400.0
+
+    def _unused_days(self, entity: RecordedEntity, now: datetime.datetime) -> tuple[float, bool]:
+        """Return ``(days_since_last_read, had_access_stamp)``.
+
+        ``had_access_stamp`` is False when the entity carried no usable
+        ``metadata.last_accessed`` and ``created_at`` was used instead.
+        """
+        last = _parse_iso((entity.metadata or {}).get("last_accessed"))
+        stamped = last is not None
+        if last is None:
+            last = _as_aware(entity.created_at)
+        return (now - last).total_seconds() / 86400.0, stamped
+
+    def _trace_id(self, entity: RecordedEntity) -> str | None:
+        metadata = entity.metadata or {}
+        for key in self.TRACE_KEYS:
+            value = metadata.get(key)
+            if value is not None:
+                return str(value)
+        return None
+
+    def _match(self, entity: RecordedEntity, rule: RetentionRule, now: datetime.datetime) -> tuple[str, str] | None:
+        """Return ``(reason, detail)`` if *rule* matches *entity*, else ``None``."""
+        if rule.entity_type is not None and entity.type != rule.entity_type:
+            return None
+        if rule.max_age_days is not None:
+            age = self._age_days(entity, now)
+            if age > rule.max_age_days:
+                return "age", f"created {age:.1f}d ago > max_age_days={rule.max_age_days}"
+        if rule.max_unused_days is not None:
+            idle, stamped = self._unused_days(entity, now)
+            if idle > rule.max_unused_days:
+                detail = f"not read for {idle:.1f}d > max_unused_days={rule.max_unused_days}"
+                detail += " (from metadata.last_accessed)" if stamped else f" — {NO_ACCESS_SIGNAL_HINT}"
+                return "unused", detail
+        return None
+
+    def _first_match(
+        self, entity: RecordedEntity, rules: list[RetentionRule], now: datetime.datetime
+    ) -> tuple[RetentionRule, str, str] | None:
+        for rule in rules:
+            matched = self._match(entity, rule, now)
+            if matched is not None:
+                return rule, matched[0], matched[1]
+        return None
+
+    # ── evaluation ────────────────────────────────────────────────────
+
+    def evaluate(
+        self,
+        namespace_id: str,
+        policy: RetentionPolicy,
+        now: datetime.datetime | None = None,
+        warnings: list[str] | None = None,
+    ) -> list[RetentionItem]:
+        """Compute the actions a policy implies, without mutating anything.
+
+        When *warnings* is passed, non-fatal caveats about the run are appended
+        to it (``apply`` uses this to populate ``RetentionReport.warnings``).
+        """
+        now = _as_aware(now) if now else datetime.datetime.now(datetime.UTC)
+        entities = self.client.get_all_entities(namespace_id, limit=self.FETCH_LIMIT)
+        by_id: dict[str, RecordedEntity] = {e.id: e for e in entities}
+
+        # Provenance index: trace id -> derived entity ids.
+        derived_by_trace: dict[str, list[str]] = {}
+        for e in entities:
+            src = (e.metadata or {}).get(self.SOURCE_KEY)
+            if src is not None:
+                derived_by_trace.setdefault(str(src), []).append(e.id)
+
+        # delete supersedes flag for the same entity; first writer otherwise wins.
+        actions: dict[str, RetentionItem] = {}
+
+        def record(item: RetentionItem) -> None:
+            existing = actions.get(item.entity_id)
+            if existing is not None and (existing.action == "delete" or item.action == "flag"):
+                return
+            actions[item.entity_id] = item
+
+        unstamped = 0
+        uses_unused_rule = any(r.max_unused_days is not None for r in policy.rules)
+
+        for e in entities:
+            if uses_unused_rule and "last_accessed" not in (e.metadata or {}):
+                unstamped += 1
+
+            match = self._first_match(e, policy.rules, now)
+            if match is None:
+                continue
+            rule, reason, detail = match
+            record(RetentionItem(e.id, e.type, rule.action, reason, rule.name, detail))
+
+            if rule.action == "delete" and rule.cascade_derived:
+                trace = self._trace_id(e)
+                if trace is None:
+                    continue
+                for did in derived_by_trace.get(trace, []):
+                    if did == e.id:
+                        continue
+                    record(
+                        RetentionItem(
+                            did,
+                            by_id[did].type,
+                            "delete",
+                            f"cascade:{trace}",
+                            rule.name,
+                            f"derived from session {e.id} (metadata.{self.SOURCE_KEY} == {trace}), which this rule deletes",
+                        )
+                    )
+
+        if warnings is not None and unstamped:
+            warnings.append(
+                f"{unstamped} of {len(entities)} entities carry no metadata.last_accessed, so their disuse was "
+                "measured from created_at — for those entities an unused rule behaves like an age rule. Enable "
+                "AccessStampPlugin (or call EvolveClient.record_access) for a real recall signal."
+            )
+
+        return list(actions.values())
+
+    # ── application ───────────────────────────────────────────────────
+
+    def apply(
+        self,
+        namespace_id: str,
+        policy: RetentionPolicy,
+        now: datetime.datetime | None = None,
+        dry_run: bool = True,
+    ) -> RetentionReport:
+        """Evaluate and — unless *dry_run* — flag/delete the matched entities.
+
+        Dry run is the default: nothing is mutated and the report describes what
+        *would* happen.
+        """
+        now = _as_aware(now) if now else datetime.datetime.now(datetime.UTC)
+        report = RetentionReport(dry_run=dry_run)
+        items = self.evaluate(namespace_id, policy, now, warnings=report.warnings)
+        flagged_at = now.isoformat()
+
+        for item in items:
+            try:
+                if item.action == "delete":
+                    if not dry_run:
+                        self.client.delete_entity_by_id(namespace_id, item.entity_id)
+                    report.deleted.append(item)
+                else:  # flag
+                    if not dry_run:
+                        self.client.patch_entity_metadata(
+                            namespace_id,
+                            item.entity_id,
+                            {
+                                "retention_flagged_at": flagged_at,
+                                "retention_reason": item.reason,
+                                "retention_rule": item.rule,
+                            },
+                        )
+                    report.flagged.append(item)
+            except Exception as exc:  # one bad entity must not abort the sweep
+                logger.warning("retention: failed to %s entity %s: %s", item.action, item.entity_id, exc)
+                report.errors.append(f"{item.action} {item.entity_id}: {exc}")
+
+        return report

--- a/altk_evolve/retention/engine.py
+++ b/altk_evolve/retention/engine.py
@@ -16,7 +16,11 @@ Signals:
   stamp fall back to ``created_at`` — the engine records that fallback on the
   item's ``detail`` and in ``RetentionReport.warnings`` rather than silently
   pretending it measured disuse. **Without an access-stamping mechanism enabled
-  an unused rule degrades into an age rule.**
+  an unused rule degrades into an age rule** — so a ``delete`` rule matching on
+  a missing stamp does NOT delete by default. The per-rule
+  ``on_missing_access_signal`` knob (``skip`` default / ``flag`` / ``delete``)
+  governs that; ``skip`` spares the entity and records it in
+  ``RetentionReport.skipped``.
 - **provenance** — a session entity carries ``metadata.trace_id``; entities
   derived from it carry ``metadata.source_task_id == trace_id``. A delete rule
   with ``cascade_derived`` removes those derived memories alongside the session.
@@ -63,13 +67,21 @@ class RetentionReport:
     dry_run: bool
     flagged: list[RetentionItem] = field(default_factory=list)
     deleted: list[RetentionItem] = field(default_factory=list)
+    #: Entities a rule matched but the engine declined to act on because the
+    #: signal was degraded (an ``unused`` DELETE with no real ``last_accessed``
+    #: stamp, under ``on_missing_access_signal: skip``). Recorded so a dry run /
+    #: CLI can show what was spared and why, rather than silently dropping it.
+    skipped: list[RetentionItem] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
     #: Non-fatal caveats about the run (e.g. degraded "unused" signal).
     warnings: list[str] = field(default_factory=list)
 
     def summary(self) -> str:
         verb = "would flag/delete" if self.dry_run else "flagged/deleted"
-        return f"{verb}: {len(self.flagged)} flagged, {len(self.deleted)} deleted, {len(self.errors)} errors"
+        summary = f"{verb}: {len(self.flagged)} flagged, {len(self.deleted)} deleted, {len(self.errors)} errors"
+        if self.skipped:
+            summary += f", {len(self.skipped)} skipped (degraded signal)"
+        return summary
 
 
 def _as_aware(dt: datetime.datetime) -> datetime.datetime:
@@ -125,33 +137,45 @@ class RetentionEngine:
         metadata = entity.metadata or {}
         for key in self.TRACE_KEYS:
             value = metadata.get(key)
-            if value is not None:
+            # A falsy id (None, "", 0, False) is not a real provenance link;
+            # coercing it would create a degenerate cascade bucket that swallows
+            # every entity sharing that non-link (an empty-string trace_id would
+            # cascade-delete everything with an empty-string source_task_id). We
+            # require a real value, then normalize to ``str`` so an int trace_id
+            # matches a str source_task_id of the same value and never an empty.
+            if value:
                 return str(value)
         return None
 
-    def _match(self, entity: RecordedEntity, rule: RetentionRule, now: datetime.datetime) -> tuple[str, str] | None:
-        """Return ``(reason, detail)`` if *rule* matches *entity*, else ``None``."""
+    def _match(self, entity: RecordedEntity, rule: RetentionRule, now: datetime.datetime) -> tuple[str, str, bool] | None:
+        """Return ``(reason, detail, degraded)`` if *rule* matches, else ``None``.
+
+        ``degraded`` is True only for an ``unused`` match whose disuse was
+        measured from ``created_at`` because the entity carried no real
+        ``metadata.last_accessed`` stamp. ``on_missing_access_signal`` governs
+        whether such a match is still allowed to delete.
+        """
         if rule.entity_type is not None and entity.type != rule.entity_type:
             return None
         if rule.max_age_days is not None:
             age = self._age_days(entity, now)
             if age > rule.max_age_days:
-                return "age", f"created {age:.1f}d ago > max_age_days={rule.max_age_days}"
+                return "age", f"created {age:.1f}d ago > max_age_days={rule.max_age_days}", False
         if rule.max_unused_days is not None:
             idle, stamped = self._unused_days(entity, now)
             if idle > rule.max_unused_days:
                 detail = f"not read for {idle:.1f}d > max_unused_days={rule.max_unused_days}"
                 detail += " (from metadata.last_accessed)" if stamped else f" — {NO_ACCESS_SIGNAL_HINT}"
-                return "unused", detail
+                return "unused", detail, not stamped
         return None
 
     def _first_match(
         self, entity: RecordedEntity, rules: list[RetentionRule], now: datetime.datetime
-    ) -> tuple[RetentionRule, str, str] | None:
+    ) -> tuple[RetentionRule, str, str, bool] | None:
         for rule in rules:
             matched = self._match(entity, rule, now)
             if matched is not None:
-                return rule, matched[0], matched[1]
+                return rule, matched[0], matched[1], matched[2]
         return None
 
     # ── evaluation ────────────────────────────────────────────────────
@@ -162,22 +186,44 @@ class RetentionEngine:
         policy: RetentionPolicy,
         now: datetime.datetime | None = None,
         warnings: list[str] | None = None,
+        skipped: list[RetentionItem] | None = None,
+        scan_limit: int | None = None,
     ) -> list[RetentionItem]:
         """Compute the actions a policy implies, without mutating anything.
 
         When *warnings* is passed, non-fatal caveats about the run are appended
         to it (``apply`` uses this to populate ``RetentionReport.warnings``).
+        When *skipped* is passed, entities a rule matched but the engine
+        declined to act on (degraded ``unused`` signal under
+        ``on_missing_access_signal: skip``) are appended to it.
+
+        *scan_limit* caps how many entities are fetched from the namespace in
+        one call; it defaults to :attr:`FETCH_LIMIT`. When the fetch returns
+        exactly the limit a warning is emitted, since entities beyond it were
+        not evaluated (and therefore not cascaded).
         """
         now = _as_aware(now) if now else datetime.datetime.now(datetime.UTC)
-        entities = self.client.get_all_entities(namespace_id, limit=self.FETCH_LIMIT)
+        limit = self.FETCH_LIMIT if scan_limit is None else scan_limit
+        entities = self.client.get_all_entities(namespace_id, limit=limit)
+        if warnings is not None and len(entities) >= limit:
+            warnings.append(
+                f"scan hit the fetch limit of {limit} entities in namespace {namespace_id!r}; entities beyond it "
+                "were not evaluated (and any memories they would have cascaded were not deleted). Raise scan_limit "
+                "or batch the namespace."
+            )
         by_id: dict[str, RecordedEntity] = {e.id: e for e in entities}
 
-        # Provenance index: trace id -> derived entity ids.
+        # Provenance index: trace id -> derived entity ids. A falsy
+        # source_task_id is not a real link (see ``_trace_id``), so those
+        # entities are skipped rather than bucketed under an empty/degenerate
+        # key — otherwise a session with a falsy trace id would cascade-delete
+        # every entity that merely lacks provenance.
         derived_by_trace: dict[str, list[str]] = {}
         for e in entities:
             src = (e.metadata or {}).get(self.SOURCE_KEY)
-            if src is not None:
-                derived_by_trace.setdefault(str(src), []).append(e.id)
+            if not src:
+                continue
+            derived_by_trace.setdefault(str(src), []).append(e.id)
 
         # delete supersedes flag for the same entity; first writer otherwise wins.
         actions: dict[str, RetentionItem] = {}
@@ -198,12 +244,39 @@ class RetentionEngine:
             match = self._first_match(e, policy.rules, now)
             if match is None:
                 continue
-            rule, reason, detail = match
-            record(RetentionItem(e.id, e.type, rule.action, reason, rule.name, detail))
+            rule, reason, detail, degraded = match
 
-            if rule.action == "delete" and rule.cascade_derived:
+            action = rule.action
+            # A degraded "unused" match (no real last_accessed stamp, disuse
+            # measured from created_at) only reaches a destructive action when
+            # the rule opts in. Default `skip` spares it; `flag` downgrades the
+            # delete to a non-destructive flag; `delete` keeps the old behavior.
+            # This only bites deletes — a flag action is not data loss, so a
+            # flag rule flags a never-stamped entity as usual.
+            if degraded and rule.action == "delete":
+                choice = rule.on_missing_access_signal
+                if choice == "skip":
+                    if skipped is not None:
+                        skipped.append(
+                            RetentionItem(
+                                e.id,
+                                e.type,
+                                "skip",
+                                reason,
+                                rule.name,
+                                f"matched but not deleted: {detail}; on_missing_access_signal=skip",
+                            )
+                        )
+                    continue
+                if choice == "flag":
+                    action = "flag"
+                    detail += "; downgraded delete->flag (on_missing_access_signal=flag)"
+
+            record(RetentionItem(e.id, e.type, action, reason, rule.name, detail))
+
+            if action == "delete" and rule.cascade_derived:
                 trace = self._trace_id(e)
-                if trace is None:
+                if not trace:
                     continue
                 for did in derived_by_trace.get(trace, []):
                     if did == e.id:
@@ -236,15 +309,25 @@ class RetentionEngine:
         policy: RetentionPolicy,
         now: datetime.datetime | None = None,
         dry_run: bool = True,
+        scan_limit: int | None = None,
     ) -> RetentionReport:
         """Evaluate and — unless *dry_run* — flag/delete the matched entities.
 
         Dry run is the default: nothing is mutated and the report describes what
-        *would* happen.
+        *would* happen. *scan_limit* caps how many entities are fetched per
+        namespace (defaults to :attr:`FETCH_LIMIT`); a boundary hit is surfaced
+        in ``report.warnings``.
         """
         now = _as_aware(now) if now else datetime.datetime.now(datetime.UTC)
         report = RetentionReport(dry_run=dry_run)
-        items = self.evaluate(namespace_id, policy, now, warnings=report.warnings)
+        items = self.evaluate(
+            namespace_id,
+            policy,
+            now,
+            warnings=report.warnings,
+            skipped=report.skipped,
+            scan_limit=scan_limit,
+        )
         flagged_at = now.isoformat()
 
         for item in items:

--- a/altk_evolve/retention/policy.py
+++ b/altk_evolve/retention/policy.py
@@ -1,0 +1,89 @@
+"""Retention policy schema (issue #275).
+
+A policy is an ordered list of rules. Each rule selects entities by type and by
+an age threshold, and either *flags* them (writes ``retention_flagged_at`` and
+friends into ``metadata`` — a non-destructive marker for review) or *deletes*
+them. A rule matching ``trajectory`` entities may additionally cascade-delete
+the memories derived from those sessions, found via provenance metadata.
+
+Rules are evaluated top-to-bottom and the first match wins per entity, so put
+the narrow rules first.
+
+Policies load from a YAML or JSON file::
+
+    rules:
+      - name: stale-guidelines
+        entity_type: guideline
+        max_age_days: 90
+        action: flag
+      - name: unused-guidelines
+        entity_type: guideline
+        max_unused_days: 180
+        action: delete
+      - name: old-sessions
+        entity_type: trajectory
+        max_age_days: 365
+        action: delete
+        cascade_derived: true
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+import yaml
+from pydantic import BaseModel, Field, model_validator
+
+RetentionAction = Literal["flag", "delete"]
+
+
+class RetentionRule(BaseModel):
+    """One retention rule. At least one of the age thresholds must be set."""
+
+    name: str = Field(description="Human-readable rule name, surfaced in reports.")
+    entity_type: str | None = Field(
+        default=None,
+        description="Only match this entity type (e.g. 'guideline', 'trajectory'). None matches every type.",
+    )
+    max_age_days: int | None = Field(
+        default=None,
+        description="Match entities whose created_at is older than this many days.",
+    )
+    max_unused_days: int | None = Field(
+        default=None,
+        description=(
+            "Match entities not read in this many days. Uses metadata.last_accessed, which "
+            "AccessStampPlugin (or EvolveClient.record_access) stamps; entities that carry no "
+            "such stamp fall back to created_at and are reported as such."
+        ),
+    )
+    action: RetentionAction = Field(default="flag", description="What to do with matched entities.")
+    cascade_derived: bool = Field(
+        default=False,
+        description="On delete of a session entity, also delete the entities derived from it (via provenance metadata).",
+    )
+
+    @model_validator(mode="after")
+    def _require_a_threshold(self) -> RetentionRule:
+        if self.max_age_days is None and self.max_unused_days is None:
+            raise ValueError(f"retention rule {self.name!r} must set max_age_days and/or max_unused_days")
+        return self
+
+
+class RetentionPolicy(BaseModel):
+    """An ordered list of retention rules."""
+
+    rules: list[RetentionRule] = Field(default_factory=list)
+
+    @classmethod
+    def from_mapping(cls, data: dict | None) -> RetentionPolicy:
+        return cls.model_validate(data or {})
+
+    @classmethod
+    def from_file(cls, path: str | Path) -> RetentionPolicy:
+        """Load a policy from a YAML or JSON file (JSON is a subset of YAML)."""
+        data = yaml.safe_load(Path(path).read_text(encoding="utf-8"))
+        if data is not None and not isinstance(data, dict):
+            raise ValueError(f"retention policy {path} must hold a mapping with a 'rules' list")
+        return cls.from_mapping(data)

--- a/altk_evolve/retention/policy.py
+++ b/altk_evolve/retention/policy.py
@@ -59,6 +59,16 @@ class RetentionRule(BaseModel):
         ),
     )
     action: RetentionAction = Field(default="flag", description="What to do with matched entities.")
+    on_missing_access_signal: Literal["skip", "flag", "delete"] = Field(
+        default="skip",
+        description=(
+            "What a delete rule does when an 'unused' match has NO real metadata.last_accessed stamp "
+            "(disuse fell back to created_at). 'skip' (default, fail-safe) spares the entity and reports it; "
+            "'flag' downgrades the delete to a non-destructive flag; 'delete' deletes on the created_at "
+            "fallback (the original behaviour). Only affects unused-driven deletes on unstamped entities; "
+            "age matches and stamped entities are unaffected."
+        ),
+    )
     cascade_derived: bool = Field(
         default=False,
         description="On delete of a session entity, also delete the entities derived from it (via provenance metadata).",

--- a/docs/guides/memory-hooks.md
+++ b/docs/guides/memory-hooks.md
@@ -101,7 +101,7 @@ Notes:
 | `AccessStampPlugin` | `memory_post_read` | fire_and_forget | Stamps `last_accessed` (ISO-8601 UTC) on read entities via the metadata-patch path |
 | `PIIFilterMemoryPlugin` | `memory_pre_write`, `llm_pre_call` | transform | Regex PII redaction (adapts the external `cpex-pii-filter` plugin onto Evolve's hook types); requires `pip install 'altk-evolve[pii]'` |
 
-Read-cost note for `AccessStampPlugin`: fire-and-forget tasks are awaited before the sync bridge returns (see [The CPEX engine](#the-cpex-engine)), so the stamp is **not** free for the reader — every public read pays one metadata write per returned entity before `search_entities` returns. Measured on the filesystem backend: ~3.7 ms vs ~0.1 ms for a 10-entity read; on milvus/postgres it adds N extra store round trips per read. Enable it only where access audit trails are worth that latency.
+Read-cost note for `AccessStampPlugin`: fire-and-forget tasks are awaited before the sync bridge returns (see [The CPEX engine](#the-cpex-engine)), so the stamp is **not** free for the reader — every public read pays one metadata write per returned entity before `search_entities` returns. Measured on the filesystem backend: ~3.7 ms vs ~0.1 ms for a 10-entity read; on milvus/postgres it adds N extra store round trips per read. Enable it only where access audit trails are worth that latency. Its stamp is what makes `max_unused_days` retention rules meaningful — `EvolveClient.record_access` is the explicit equivalent for callers not running hooks, and both share the same `build_access_stamps` core. See [Data Retention](retention.md).
 
 ## The CPEX engine
 
@@ -151,6 +151,6 @@ See [`examples/hooks_plugins.yaml`](https://github.com/AgentToolkit/altk-evolve/
 ## Deferred
 
 - READI / semantic recall filtering plugins (separate branch).
-- Lifecycle / retention policy hooks.
+- Lifecycle / retention policy *hooks*. Data retention itself now ships as a policy-driven sweep rather than a hook — see [Data Retention](retention.md), which consumes `AccessStampPlugin`'s `last_accessed` stamp and `MetadataNormalizerPlugin`'s `trace_id` normalization.
 - A first-class PII configuration surface on `EvolveConfig` (today PII is configured through the plugin's own `config` block).
 - Additional execution engines: only the CPEX integration exists today; the seam is engine-agnostic, but running plugins currently requires cpex.

--- a/docs/guides/retention.md
+++ b/docs/guides/retention.md
@@ -1,0 +1,162 @@
+# Data Retention
+
+Memories accumulate. Some go stale, some are never read again, and some — session transcripts especially — carry data you agreed to keep for a bounded time. `altk_evolve.retention` applies a declarative policy to a namespace: it selects entities by type and age, then either **flags** them for review or **deletes** them, and can cascade a session delete to the memories derived from that session.
+
+It is a sweep, not an interceptor: you run it (CLI, cron, or in code), it reports what it would do, and it only mutates when you say so. **Dry run is the default everywhere.**
+
+## Quick start
+
+```bash
+evolve retention run --policy examples/retention.example.yaml            # dry run: report only
+evolve retention run --policy examples/retention.example.yaml --apply    # enforce
+```
+
+Or in code:
+
+```python
+from altk_evolve.frontend.client.evolve_client import EvolveClient
+from altk_evolve.retention import RetentionEngine, RetentionPolicy
+
+policy = RetentionPolicy.from_file("retention.yaml")
+report = RetentionEngine(EvolveClient()).apply("my-namespace", policy)  # dry_run=True by default
+print(report.summary())
+for item in [*report.deleted, *report.flagged]:
+    print(item.action, item.entity_id, item.reason, "—", item.detail)
+```
+
+[`examples/retention_demo.py`](https://github.com/AgentToolkit/altk-evolve/blob/main/examples/retention_demo.py) is a runnable end-to-end walkthrough.
+
+## Policy format
+
+A policy is an ordered list of rules, in YAML or JSON:
+
+```yaml
+rules:
+  - name: stale-guidelines
+    entity_type: guideline
+    max_age_days: 90
+    action: flag
+
+  - name: unused-guidelines
+    entity_type: guideline
+    max_unused_days: 180
+    action: delete
+
+  - name: old-sessions
+    entity_type: trajectory
+    max_age_days: 365
+    action: delete
+    cascade_derived: true
+```
+
+| Field | Meaning |
+|---|---|
+| `name` | Required. Surfaced in every report line, so make it explain itself. |
+| `entity_type` | Only match this type (`guideline`, `trajectory`, …). Omit to match every type. |
+| `max_age_days` | Match entities whose `created_at` is older than this. |
+| `max_unused_days` | Match entities not read in this many days (see [The unused signal](#the-unused-signal)). |
+| `action` | `flag` (default) or `delete`. |
+| `cascade_derived` | On a `delete` of a session entity, also delete the memories derived from it. |
+
+Every rule must set `max_age_days` and/or `max_unused_days` — a rule with no threshold is a config error, not a match-everything rule.
+
+**Rules are evaluated top-to-bottom and the first match wins per entity**, so put narrow rules first. One exception, deliberately: a cascade `delete` supersedes a `flag` an earlier rule had already assigned to the same entity. Delete always wins over flag; otherwise the first writer wins.
+
+## Flag vs delete
+
+- **`flag`** is non-destructive. It merges three keys into the entity's metadata — `retention_flagged_at`, `retention_reason`, `retention_rule` — and leaves content untouched. Use it to build a review queue, or as a soft first stage before a later delete rule.
+- **`delete`** removes the entity through `EvolveClient.delete_entity_by_id`. There is no undo.
+
+Because deletes go through the client's public API, they flow through the `memory_pre_delete` hook — so a legal-hold plugin can veto a retention delete (see [Memory Hooks](memory-hooks.md)). A vetoed delete surfaces as an entry in `RetentionReport.errors`; the sweep continues with the remaining entities rather than aborting.
+
+## Dry run by default, and how to apply
+
+`RetentionEngine.apply()` defaults to `dry_run=True`, and the CLI requires an explicit `--apply`. A dry run reads the namespace, computes every decision, and mutates nothing; the returned `RetentionReport` is identical in shape to an enforced one, with `dry_run=True`.
+
+Each `RetentionItem` carries five things: `entity_id`, `entity_type`, `action`, `reason` (`age` / `unused` / `cascade:<trace_id>`) and `rule` — plus `detail`, a human-readable *why* that names the numbers the decision was made on:
+
+```
+DELETE  5   trajectory  reason=age         rule=old-sessions
+        why: created 400.0d ago > max_age_days=365
+DELETE  4   guideline   reason=cascade:T1  rule=old-sessions
+        why: derived from session 5 (metadata.source_task_id == T1), which this rule deletes
+FLAG    1   guideline   reason=unused      rule=unused-guidelines
+        why: not read for 200.0d > max_unused_days=90 — no metadata.last_accessed on this entity, …
+```
+
+Read the dry run before you apply. That is the whole point of it.
+
+## The unused signal
+
+`max_unused_days` measures time since the entity was last *read*, from `metadata.last_accessed`. Nothing in Evolve's core write path sets that key — something has to record the access:
+
+- **`AccessStampPlugin`** (shipped with the [hook seam](memory-hooks.md)) stamps `last_accessed` on every entity returned by a public `search_entities`, via `memory_post_read`. This is the automatic path, and **enabling it is what makes an unused rule mean anything**. Note its cost: fire-and-forget tasks are awaited before the read returns, so every public read pays one metadata write per returned entity (~3.7 ms vs ~0.1 ms for a 10-entity filesystem read).
+- **`EvolveClient.record_access(namespace_id, entity_ids)`** is the explicit path, for callers that do not run hooks, or that want to record a *use* that was not a store read — a memory pulled from a cache and actually acted on, say. It goes through the same core function as the plugin (`build_access_stamps`), so the key, the format, and the one-stamp-per-batch behaviour are identical. Running both is harmless.
+
+**If neither is in play, the signal does not exist.** The engine then falls back to `created_at` — and says so, rather than quietly pretending it measured disuse. Every affected item's `detail` names the fallback, and the report carries a run-level warning:
+
+```
+warning: 4 of 5 entities carry no metadata.last_accessed, so their disuse was measured from
+created_at — for those entities an unused rule behaves like an age rule. Enable
+AccessStampPlugin (or call EvolveClient.record_access) for a real recall signal.
+```
+
+This is a change from the original prototype, where the fallback was silent and — because nothing called `record_access` — universal.
+
+## The session cascade
+
+Deleting an old session transcript without deleting the memories extracted from it leaves the data behind under a different name. `cascade_derived: true` on a `delete` rule closes that: when a session entity is deleted, every entity whose `metadata.source_task_id` equals the session's trace id is deleted with it, with `reason="cascade:<trace_id>"`.
+
+Derived entities are deleted **regardless of their own age** — that is the point. A guideline extracted yesterday from a session that ages out today goes with it.
+
+There used to be a convention split here: the MCP server's `save_trajectory` wrote `metadata.task_id` while Phoenix sync wrote `metadata.trace_id`, and the cascade keyed on `trace_id` — so MCP-saved sessions silently never cascaded. Two things now fix that:
+
+1. **`MetadataNormalizerPlugin`** (hook seam) copies `task_id` → `trace_id` on `memory_pre_write`, making `trace_id` canonical for everything written through a backend with hooks enabled.
+2. The engine additionally **falls back to `task_id`** when reading a session's trace id, so sessions written *before* the normalizer existed still cascade. `trace_id` wins when both are present.
+
+Both paths are covered by tests in `tests/unit/test_retention.py`.
+
+## Plugin-side retention (evolve-lite)
+
+The `evolve-lite` plugin ships a `retention` skill with the same shape — same rule schema, same flag/delete actions, same dry-run default, same cascade concept — running over the plugin's `.evolve/` file store instead of a backend. It is stdlib-only (`plugin-source/lib/retention.py`), because plugin scripts run in whatever Python the host provides.
+
+```bash
+python3 <plugin>/skills/evolve-lite/retention/scripts/run_retention.py           # dry run
+python3 <plugin>/skills/evolve-lite/retention/scripts/run_retention.py --apply   # enforce
+```
+
+Rules live in a `retention:` block in `evolve.config.yaml`, or in a standalone file passed with `--policy`. Every applied action appends an `event: "retention"` row to `.evolve/audit.log`.
+
+### Where it is weaker than the package side
+
+The plugin store is markdown files with small frontmatter, not a backend with per-entity metadata, so each signal degrades. These gaps are real and worth knowing before you point a `delete` rule at the store:
+
+| Signal | Package | Plugin | Consequence |
+|---|---|---|---|
+| age | `created_at` on the entity | **file mtime** — there is no `created_at` in the store | mtime is a *modification* time: editing an entity resets its age clock. (Flagging deliberately restores the mtime, so the sweep itself never resets it.) |
+| unused | `metadata.last_accessed`, stamped automatically by `AccessStampPlugin` | latest `recall` row in `.evolve/audit.log` naming the entity id `<type>/<name>` | the recall audit is **model-invoked** (the agent runs `audit_recall.py` per `EVOLVE.md`), so a missing row means "no recorded recall", not "not used". A degraded-signal warning is emitted, same as package-side. |
+| cascade | `metadata.source_task_id == trace_id`, stamped by the writers | a `trajectory:` frontmatter key naming the session file | **nothing in the shipped plugin writes that key today.** `entity_io` supports and preserves it, but neither the save flow nor `adapt-memory` populates it — so `cascade_derived` is effectively inert plugin-side unless the link was set by hand or by a downstream tool. Deleting a session does *not* clean up its derived memories the way the package side does. |
+
+Trajectory files are opaque JSON with no frontmatter, so a `flag` on a trajectory is recorded in the audit log only, not on the file.
+
+### What is excluded from the plugin sweep
+
+- **`.evolve/entities/subscribed/`** — git clones owned by the `sync` skill. A local delete there would simply be restored by the next sync, so subscribed entities are skipped entirely.
+- **`.evolve/public/`** — the publish tree; retention does not touch published entities.
+- Symlinks and anything under a `.git` directory.
+
+In scope: private entities under `.evolve/entities/` and session files under `.evolve/trajectories/`.
+
+## Operational notes
+
+- The engine scans up to `RetentionEngine.FETCH_LIMIT` (100,000) entities per namespace in one call, and holds them in memory to build the provenance index. Very large namespaces will want batching; that is not implemented.
+- One failing entity does not abort the sweep — the failure is logged and recorded in `report.errors`, and the remaining entities are processed. The CLI exits non-zero when `errors` is non-empty.
+- Naive `created_at` values are treated as UTC.
+- Retention is not a hook: it is a periodic sweep you schedule. There is no automatic expiry on write or read.
+
+## Known limitations
+
+- **No per-namespace or global scheduling.** You run the sweep; nothing runs it for you.
+- **No restore.** `delete` is final. Use `flag` first if you want a review stage.
+- **`max_unused_days` is only as good as your access stamping** — see above. Without `AccessStampPlugin` or `record_access`, it is an age rule wearing a different name.
+- **The plugin-side cascade needs a link nothing writes yet** — see the table above.

--- a/docs/guides/retention.md
+++ b/docs/guides/retention.md
@@ -93,16 +93,22 @@ Because deletes go through the client's public API, they flow through the `memor
 
 `RetentionEngine.apply()` defaults to `dry_run=True`, and the CLI requires an explicit `--apply`. A dry run reads the namespace, computes every decision, and mutates nothing; the returned `RetentionReport` is identical in shape to an enforced one, with `dry_run=True`.
 
-Each `RetentionItem` carries five things: `entity_id`, `entity_type`, `action`, `reason` (`age` / `unused` / `cascade:<trace_id>`) and `rule` — plus `detail`, a human-readable *why* that names the numbers the decision was made on:
+Each `RetentionItem` carries five things: `entity_id`, `entity_type`, `action`, `reason` (`age` / `unused` / `cascade:<trace_id>`) and `rule` — plus `detail`, a human-readable *why* that names the numbers the decision was made on. Here is a real dry run of the [example policy above](#policy-format) over a small namespace — an old session, a memory derived from it, a stale-but-recently-read guideline, and an ancient never-recalled guideline:
 
 ```
-DELETE  5   trajectory  reason=age         rule=old-sessions
+DELETE  4   trajectory reason=age          rule=old-sessions
         why: created 400.0d ago > max_age_days=365
-DELETE  4   guideline   reason=cascade:T1  rule=old-sessions
-        why: derived from session 5 (metadata.source_task_id == T1), which this rule deletes
-FLAG    1   guideline   reason=unused      rule=unused-guidelines
-        why: not read for 200.0d > max_unused_days=90 — no metadata.last_accessed on this entity, …
+DELETE  3   guideline  reason=cascade:T1   rule=old-sessions
+        why: derived from session 4 (metadata.source_task_id == T1), which this rule deletes
+FLAG    1   guideline  reason=age          rule=stale-guidelines
+        why: created 200.0d ago > max_age_days=90
+SKIP    2   guideline  reason=unused       rule=unused-guidelines
+        why: matched but not deleted: not read for 400.0d > max_unused_days=180 — no metadata.last_accessed
+             on this entity, so disuse was measured from created_at; …; on_missing_access_signal=skip
+warning: 3 of 4 entities carry no metadata.last_accessed, so their disuse was measured from created_at …
 ```
+
+Note the last two lines. The stale guideline is **flagged** by the `age` rule (`stale-guidelines`), not by the delete rule. The ancient never-recalled guideline *matches* the `unused-guidelines` **delete** rule, but because it carries no `last_accessed` stamp its disuse was only inferred from `created_at`, so the rule's default `on_missing_access_signal: skip` **spares** it — it lands in `report.skipped` (the "Skipped" table), never deleted and never flagged. See [When the unused signal is missing](#when-the-unused-signal-is-missing).
 
 Read the dry run before you apply. That is the whole point of it.
 

--- a/docs/guides/retention.md
+++ b/docs/guides/retention.md
@@ -32,15 +32,16 @@ A policy is an ordered list of rules, in YAML or JSON:
 
 ```yaml
 rules:
-  - name: stale-guidelines
-    entity_type: guideline
-    max_age_days: 90
-    action: flag
-
   - name: unused-guidelines
     entity_type: guideline
     max_unused_days: 180
     action: delete
+    on_missing_access_signal: skip
+
+  - name: stale-guidelines
+    entity_type: guideline
+    max_age_days: 90
+    action: flag
 
   - name: old-sessions
     entity_type: trajectory
@@ -56,11 +57,30 @@ rules:
 | `max_age_days` | Match entities whose `created_at` is older than this. |
 | `max_unused_days` | Match entities not read in this many days (see [The unused signal](#the-unused-signal)). |
 | `action` | `flag` (default) or `delete`. |
+| `on_missing_access_signal` | For a `delete` rule: what to do when an `unused` match has no real `last_accessed` stamp. `skip` (default), `flag`, or `delete` — see [When the unused signal is missing](#when-the-unused-signal-is-missing). |
 | `cascade_derived` | On a `delete` of a session entity, also delete the memories derived from it. |
 
 Every rule must set `max_age_days` and/or `max_unused_days` — a rule with no threshold is a config error, not a match-everything rule.
 
 **Rules are evaluated top-to-bottom and the first match wins per entity**, so put narrow rules first. One exception, deliberately: a cascade `delete` supersedes a `flag` an earlier rule had already assigned to the same entity. Delete always wins over flag; otherwise the first writer wins.
+
+### First-match shadowing
+
+Because the first matching rule wins and never re-evaluates, an earlier broad rule can **shadow** a later one so it can never fire. The classic trap is ordering a short-threshold `flag` before a long-threshold `delete` on the same type:
+
+```yaml
+# WRONG — the delete is unreachable
+- name: stale-guidelines
+  entity_type: guideline
+  max_age_days: 90        # any 180-day-unused guideline is also >90 days old…
+  action: flag
+- name: unused-guidelines
+  entity_type: guideline
+  max_unused_days: 180    # …so this rule never wins: the flag above always matches first
+  action: delete
+```
+
+Any guideline unused for 180 days is necessarily more than 90 days old, so the `flag` rule always matches it first and the `delete` never runs. Order is **escalation, not accumulation**: put the more aggressive / longer-threshold rule first, so the safety-net `flag` catches only what the `delete` didn't. `examples/retention.example.yaml` ships the corrected ordering.
 
 ## Flag vs delete
 
@@ -102,6 +122,20 @@ AccessStampPlugin (or call EvolveClient.record_access) for a real recall signal.
 ```
 
 This is a change from the original prototype, where the fallback was silent and — because nothing called `record_access` — universal.
+
+### When the unused signal is missing
+
+Falling back to `created_at` is only *reporting* the degraded signal — it does not decide whether to act on it. That decision is a per-rule knob, `on_missing_access_signal`, which applies **only to `delete` rules matching on `unused` where the entity has no real `last_accessed` stamp**:
+
+| Value | Behaviour on an unstamped `unused` delete match |
+|---|---|
+| `skip` | **Default, fail-safe.** Do not act. The entity is recorded in `report.skipped` (and shown in the CLI's "Skipped" table) with the reason, so you can see what was spared. |
+| `flag` | Downgrade the delete to a non-destructive `flag`. |
+| `delete` | Delete on the `created_at` fallback — the original behaviour, now an explicit opt-in. |
+
+The default is `skip` because a `delete` rule whose signal is silently off (no `AccessStampPlugin`, no `record_access`) would otherwise delete every matched entity from its creation date — data loss with the safety mechanism disabled. `skip` **only bites deletes**: a `flag` rule still flags a never-stamped entity (that is not data loss), an entity *with* a real stamp is unaffected, and an `age`-driven match is unaffected (age from `created_at` is a legitimate signal). Turn a rule up to `delete` once you have confirmed access stamping is on, or to `flag` to build a review queue instead.
+
+The plugin-side skill exposes the same field with the same default, keyed off the recall audit log instead of `metadata.last_accessed`.
 
 ## The session cascade
 
@@ -149,7 +183,7 @@ In scope: private entities under `.evolve/entities/` and session files under `.e
 
 ## Operational notes
 
-- The engine scans up to `RetentionEngine.FETCH_LIMIT` (100,000) entities per namespace in one call, and holds them in memory to build the provenance index. Very large namespaces will want batching; that is not implemented.
+- The engine scans up to a fetch limit — `RetentionEngine.FETCH_LIMIT` (100,000) by default, overridable per call via the `scan_limit` argument to `apply()` / `evaluate()` — and holds the entities in memory to build the provenance index. When a scan comes back holding exactly the limit, the report carries a `warnings` entry saying entities beyond it were not evaluated (and so not cascaded); raise `scan_limit` or batch the namespace. Very large namespaces will want batching; that is not implemented.
 - One failing entity does not abort the sweep — the failure is logged and recorded in `report.errors`, and the remaining entities are processed. The CLI exits non-zero when `errors` is non-empty.
 - Naive `created_at` values are treated as UTC.
 - Retention is not a hook: it is a periodic sweep you schedule. There is no automatic expiry on write or read.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -62,6 +62,29 @@ evolve entities show my_namespace 12345
 evolve entities delete my_namespace 12345
 ```
 
+### Data Retention
+
+```bash
+# Dry run: report what the policy would flag or delete (nothing is mutated)
+evolve retention run --policy retention.yaml
+
+# Sweep a specific namespace
+evolve retention run --policy retention.yaml my_namespace
+
+# Enforce the policy
+evolve retention run --policy retention.yaml my_namespace --apply
+```
+
+**Options:**
+- `--policy, -p`: Path to a retention policy file (YAML or JSON). Required.
+- `--apply`: Actually flag/delete. Without it the run is a dry run.
+- Positional namespace argument defaults to the configured `namespace_id`.
+
+The report lists every action with its reason (`age`, `unused`, `cascade:<trace_id>`),
+the rule that decided it, and the evidence behind it. See the
+[Data Retention guide](../guides/retention.md) for the policy format and the
+`AccessStampPlugin` dependency of `max_unused_days` rules.
+
 ### Skill Management
 
 ```bash

--- a/examples/retention.example.yaml
+++ b/examples/retention.example.yaml
@@ -1,0 +1,35 @@
+# Example data-retention policy (issue #275). See docs/guides/retention.md.
+#
+# Dry run:  evolve retention run --policy examples/retention.example.yaml
+# Enforce:  evolve retention run --policy examples/retention.example.yaml --apply
+#
+# Rules are evaluated top-to-bottom; the first matching rule wins per entity,
+# so put narrow rules first. Each rule must set max_age_days and/or
+# max_unused_days.
+rules:
+  # Flag guidelines older than 90 days for review. Flagging is non-destructive:
+  # it writes retention_flagged_at / retention_reason / retention_rule into the
+  # entity's metadata and leaves the content alone.
+  - name: stale-guidelines
+    entity_type: guideline
+    max_age_days: 90
+    action: flag
+
+  # Delete guidelines not read in 180 days. This reads metadata.last_accessed,
+  # which AccessStampPlugin stamps on every public read (or which you stamp
+  # explicitly via EvolveClient.record_access). WITHOUT one of those enabled
+  # there is no recall signal and this rule silently degrades into an age rule
+  # — the dry-run report says so in its warnings.
+  - name: unused-guidelines
+    entity_type: guideline
+    max_unused_days: 180
+    action: delete
+
+  # Delete sessions (trajectories) older than a year, and cascade-delete the
+  # memories derived from them (linked by metadata.source_task_id == the
+  # session's trace_id).
+  - name: old-sessions
+    entity_type: trajectory
+    max_age_days: 365
+    action: delete
+    cascade_derived: true

--- a/examples/retention.example.yaml
+++ b/examples/retention.example.yaml
@@ -3,27 +3,40 @@
 # Dry run:  evolve retention run --policy examples/retention.example.yaml
 # Enforce:  evolve retention run --policy examples/retention.example.yaml --apply
 #
-# Rules are evaluated top-to-bottom; the first matching rule wins per entity,
-# so put narrow rules first. Each rule must set max_age_days and/or
-# max_unused_days.
+# Rules are evaluated top-to-bottom; the FIRST matching rule wins per entity, so
+# order is escalation, not accumulation. Put the more aggressive / longer-
+# threshold rule FIRST so it isn't shadowed by a broader earlier rule. Each rule
+# must set max_age_days and/or max_unused_days.
 rules:
-  # Flag guidelines older than 90 days for review. Flagging is non-destructive:
-  # it writes retention_flagged_at / retention_reason / retention_rule into the
-  # entity's metadata and leaves the content alone.
-  - name: stale-guidelines
-    entity_type: guideline
-    max_age_days: 90
-    action: flag
-
-  # Delete guidelines not read in 180 days. This reads metadata.last_accessed,
-  # which AccessStampPlugin stamps on every public read (or which you stamp
-  # explicitly via EvolveClient.record_access). WITHOUT one of those enabled
-  # there is no recall signal and this rule silently degrades into an age rule
-  # — the dry-run report says so in its warnings.
+  # Delete guidelines not read in 180 days. This must come BEFORE the 90-day
+  # flag rule below: any guideline unused for 180 days is necessarily >90 days
+  # old, so if the flag rule were first it would always match first and this
+  # delete could never fire (first-match-wins shadowing).
+  #
+  # The "unused" signal is metadata.last_accessed, stamped by AccessStampPlugin
+  # on every public read (or explicitly via EvolveClient.record_access). WITHOUT
+  # one of those enabled there is no recall signal. on_missing_access_signal
+  # controls what this delete does when an entity carries no stamp:
+  #   skip   (default, fail-safe) — do not delete; report it as skipped
+  #   flag   — downgrade the delete to a non-destructive flag
+  #   delete — delete on the created_at fallback (explicit opt-in)
+  # We keep the safe default explicit here: an unstamped guideline is spared,
+  # not silently deleted from its creation date.
   - name: unused-guidelines
     entity_type: guideline
     max_unused_days: 180
     action: delete
+    on_missing_access_signal: skip
+
+  # Flag guidelines older than 90 days for review. Reached by any guideline that
+  # did NOT match the delete rule above (i.e. read within the last 180 days but
+  # created more than 90 days ago). Flagging is non-destructive: it writes
+  # retention_flagged_at / retention_reason / retention_rule into the entity's
+  # metadata and leaves the content alone.
+  - name: stale-guidelines
+    entity_type: guideline
+    max_age_days: 90
+    action: flag
 
   # Delete sessions (trajectories) older than a year, and cascade-delete the
   # memories derived from them (linked by metadata.source_task_id == the

--- a/examples/retention_demo.py
+++ b/examples/retention_demo.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Demo: data-retention policies in action (issue #275).
+
+Seeds a throwaway Evolve namespace with a realistic mix of memories — a stale,
+never-recalled guideline; a fresh one; an old guideline that was recalled
+yesterday; an old session (trajectory) and a memory derived from it — then runs
+a retention policy against it. It shows:
+
+  * age- and disuse-based matching, with the *why* behind every decision
+  * how ``record_access`` (equivalently ``AccessStampPlugin`` on
+    ``memory_post_read``) supplies the ``last_accessed`` signal that makes an
+    unused rule mean something, and what the engine reports when it is missing
+  * session retention with a provenance cascade: deleting an old trajectory
+    also deletes the memories derived from it
+    (``metadata.source_task_id == trace_id``), including for MCP-shaped
+    sessions that only carry ``task_id``
+  * dry run vs ``--apply``
+
+Ages are simulated by backdating ``created_at`` in the on-disk store after
+seeding, so the demo needs no real waiting. Run:
+
+    uv run python examples/retention_demo.py
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import pathlib
+import tempfile
+
+from altk_evolve.backend.filesystem import FilesystemSettings
+from altk_evolve.config.evolve import EvolveConfig
+from altk_evolve.frontend.client.evolve_client import EvolveClient
+from altk_evolve.retention import RetentionEngine, RetentionPolicy, RetentionRule
+from altk_evolve.schema.core import Entity
+
+NOW = datetime.datetime.now(datetime.UTC)
+
+
+def _iso(days_ago: int) -> str:
+    return (NOW - datetime.timedelta(days=days_ago)).isoformat()
+
+
+def _backdate(data_dir: str, namespace: str, ages_days: dict[str, int]) -> None:
+    """Rewrite ``created_at`` in the on-disk namespace to fake entity ages."""
+    store = pathlib.Path(data_dir) / f"{namespace}.json"
+    data = json.loads(store.read_text())
+    for entity in data["entities"]:
+        for prefix, age in ages_days.items():
+            if str(entity["content"]).startswith(prefix):
+                entity["created_at"] = _iso(age)
+    store.write_text(json.dumps(data))
+
+
+def _print_report(report) -> None:
+    if not report.deleted and not report.flagged:
+        print("    (nothing matched)")
+    for item in [*report.deleted, *report.flagged]:
+        print(f"    {item.action.upper():<7} {item.entity_id:<3} {item.entity_type:<10} reason={item.reason:<12} rule={item.rule}")
+        print(f"            why: {item.detail}")
+    for warning in report.warnings:
+        print(f"    warning: {warning}")
+
+
+def _decision_table(engine, namespace, policy) -> None:
+    """Show each memory's decision (KEEP / FLAG / DELETE) and why."""
+    entities = sorted(engine.client.get_all_entities(namespace), key=lambda e: e.id)
+    acted = {it.entity_id: it for it in engine.evaluate(namespace, policy, NOW)}
+    print("Decision & why (how the engine derived each outcome):")
+    for e in entities:
+        src = (e.metadata or {}).get("source_task_id")
+        derived = f"  [derived from session {src}]" if src else ""
+        if e.id in acted:
+            item = acted[e.id]
+            decision, why = item.action.upper(), item.detail
+        else:
+            decision, why = "KEEP", "no rule matched (young enough, and recently read)"
+        print(f"    {decision:<6} {e.id} [{e.type}] {str(e.content)[:44]:<44}{derived}")
+        print(f"           why: {why}")
+    print()
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as data_dir:
+        client = EvolveClient(EvolveConfig(backend="filesystem", settings=FilesystemSettings(data_dir=data_dir)))
+        client.ensure_namespace("demo")
+
+        # update_entities takes one type per call, so seed by type.
+        client.update_entities(
+            "demo",
+            [
+                Entity(content="STALE: deploy only on Fridays", type="guideline"),
+                Entity(content="FRESH: prefer uv over pip for installs", type="guideline"),
+                Entity(content="USED: the flaky test needs a retry", type="guideline"),
+                Entity(content="DERIVED from the old session: always run ruff", type="guideline", metadata={"source_task_id": "T1"}),
+            ],
+            enable_conflict_resolution=False,
+        )
+        # An MCP-saved session carries task_id, not trace_id. MetadataNormalizerPlugin
+        # copies it across on write; the engine also falls back to it at read time,
+        # so the cascade below works for both conventions.
+        client.update_entities(
+            "demo",
+            [Entity(content="SESSION transcript of an old support chat", type="trajectory", metadata={"task_id": "T1"})],
+            enable_conflict_resolution=False,
+        )
+
+        # Simulate a real store: the stale + used guidelines are 200d old, the
+        # session is 400d old, the fresh + derived memories are recent.
+        _backdate(data_dir, "demo", ages_days={"STALE": 200, "USED": 200, "SESSION": 400})
+
+        by_content = {str(e.content).split(":")[0]: e.id for e in client.get_all_entities("demo")}
+
+        # This is the whole point of the hook seam for retention: something has
+        # to stamp last_accessed. AccessStampPlugin does it automatically on
+        # every public read; record_access is the explicit equivalent.
+        client.record_access("demo", [by_content["USED"]], when=NOW - datetime.timedelta(days=1))
+
+        policy = RetentionPolicy(
+            rules=[
+                RetentionRule(name="unused-guidelines", entity_type="guideline", max_unused_days=90, action="flag"),
+                RetentionRule(name="old-sessions", entity_type="trajectory", max_age_days=365, action="delete", cascade_derived=True),
+            ]
+        )
+        engine = RetentionEngine(client)
+
+        print("Seeded memories:")
+        for e in sorted(client.get_all_entities("demo"), key=lambda e: e.id):
+            seen = (e.metadata or {}).get("last_accessed")
+            print(f"    {e.id} [{e.type}] {e.content}" + (f"   (last read {seen})" if seen else ""))
+        print()
+
+        _decision_table(engine, "demo", policy)
+
+        print("DRY RUN (what the policy would do):")
+        _print_report(engine.apply("demo", policy, now=NOW, dry_run=True))
+        remaining_before = {e.id for e in client.get_all_entities("demo")}
+        print(f"    store still has {len(remaining_before)} entities (dry run mutates nothing)\n")
+
+        print("APPLY:")
+        _print_report(engine.apply("demo", policy, now=NOW, dry_run=False))
+        print()
+
+        print("Store after apply:")
+        for e in sorted(client.get_all_entities("demo"), key=lambda e: e.id):
+            flag = " <-- FLAGGED" if (e.metadata or {}).get("retention_flagged_at") else ""
+            print(f"    {e.id} [{e.type}] {e.content}{flag}")
+
+        print(
+            "\nResult: the stale, never-recalled guideline was flagged for review; the\n"
+            "guideline recalled yesterday survived the same rule because record_access\n"
+            "stamped last_accessed; the 400-day-old session and the memory derived from\n"
+            "it were deleted together (provenance cascade, matched via task_id); the\n"
+            "fresh guideline was untouched."
+        )
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/retention_demo.py
+++ b/examples/retention_demo.py
@@ -56,7 +56,7 @@ def _backdate(data_dir: str, namespace: str, ages_days: dict[str, int]) -> None:
 def _print_report(report) -> None:
     if not report.deleted and not report.flagged:
         print("    (nothing matched)")
-    for item in [*report.deleted, *report.flagged]:
+    for item in [*report.deleted, *report.flagged, *report.skipped]:
         print(f"    {item.action.upper():<7} {item.entity_id:<3} {item.entity_type:<10} reason={item.reason:<12} rule={item.rule}")
         print(f"            why: {item.detail}")
     for warning in report.warnings:

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -83,6 +83,8 @@ nav:
     - Phoenix Sync: guides/phoenix-sync.md
     - Extract Trajectories: guides/extract-trajectories.md
     - Low-Code Tracing: guides/low-code-tracing.md
+    - Memory Hooks: guides/memory-hooks.md
+    - Data Retention: guides/retention.md
   - Reference:
     - CLI: reference/cli.md
     - Policies: reference/policies.md

--- a/platform-integrations/bob/evolve-lite/commands/evolve-lite-retention.md
+++ b/platform-integrations/bob/evolve-lite/commands/evolve-lite-retention.md
@@ -1,0 +1,4 @@
+---
+description: Apply data-retention rules to the local evolve store — flag or delete stale and unused memories and expired sessions (dry-run by default)
+---
+Use the `evolve-lite-retention` skill on the current conversation. Follow the skill's instructions exactly.

--- a/platform-integrations/bob/evolve-lite/lib/evolve-lite/retention.py
+++ b/platform-integrations/bob/evolve-lite/lib/evolve-lite/retention.py
@@ -1,0 +1,525 @@
+"""Data retention for the evolve-lite plugin store (issue #275).
+
+Mirrors the ``altk_evolve/retention/`` semantics against the plugin's
+``.evolve/`` file store: age-based and unused-based rules that **flag** or
+**delete**, dry-run by default, and the session -> derived cascade. Stdlib-only,
+because plugin scripts run in the host's Python where nothing beyond the
+standard library is guaranteed.
+
+The plugin store is markdown files, not a backend with per-entity metadata, so
+the package's signals map onto what the files actually carry. Each mapping is
+weaker than its package-side counterpart — the gaps are called out here and in
+``docs/guides/retention.md``:
+
+- **age** — file mtime. Plugin entities carry no ``created_at`` frontmatter, so
+  mtime is the only available clock. It is a *modification* time, not a birth
+  time: editing an entity resets its age. (Flagging deliberately restores the
+  mtime so the sweep itself never resets the clock — see below.)
+- **unused** — the latest ``recall`` row in ``.evolve/audit.log`` naming the
+  entity id (``<type>/<name>``, the id scheme ``audit_recall.py`` logs and
+  ``EVOLVE.md`` instructs the agent to pass), falling back to file mtime when
+  an entity was never recalled. This is the plugin's answer to the package's
+  ``metadata.last_accessed``, and it has the same failure mode: it only exists
+  if something records the recall. Package-side that is ``AccessStampPlugin``
+  (automatic); plugin-side it is a model-invoked ``audit_recall.py`` call — so
+  the signal is only as complete as the agent's compliance with EVOLVE.md.
+- **cascade** — the package links a derived memory to its session via
+  ``metadata.source_task_id == trace_id``. Plugin-side the equivalent link is a
+  ``trajectory:`` frontmatter key naming the session file under
+  ``.evolve/trajectories/``; a ``cascade_derived`` delete of a trajectory also
+  deletes entities whose link resolves to it (matched by filename — trajectory
+  filenames embed a timestamp + session id and are unique by construction).
+  **Known gap: nothing in the shipped plugin writes that key today.**
+  ``entity_io._FRONTMATTER_KEYS`` supports it and it is preserved on round-trip,
+  but neither the save flow nor ``adapt-memory`` populates it, so in practice
+  the plugin-side cascade only fires for entities whose ``trajectory:`` key was
+  written by hand or by a downstream tool. Deleting a session therefore does
+  *not* by itself clean up the memories derived from it the way the package
+  side does.
+
+Actions:
+
+- **flag** — upsert ``retention_flagged_at`` / ``retention_reason`` /
+  ``retention_rule`` into the entity's frontmatter (non-destructive; the file's
+  mtime is preserved so the age clock does not reset). Trajectory files are
+  opaque JSON with no frontmatter, so their flag lives in the audit log only.
+- **delete** — unlink the file.
+
+Every applied (non-dry-run) action also appends an ``event: "retention"`` row
+to ``.evolve/audit.log`` for auditability.
+
+Scope: private entities under ``.evolve/entities/`` — excluding
+``entities/subscribed/`` (git clones managed by the sync skill; local deletes
+there would be clobbered by the next sync) — plus session files under
+``.evolve/trajectories/``.
+
+Rules load from a ``retention:`` block in ``evolve.config.yaml``::
+
+    retention:
+      rules:
+        - name: stale-guidelines
+          entity_type: guideline
+          max_age_days: 90
+          action: flag
+        - name: old-sessions
+          entity_type: trajectory
+          max_age_days: 365
+          action: delete
+          cascade_derived: true
+"""
+
+import datetime
+import json
+import os
+from pathlib import Path
+
+VALID_ACTIONS = ("flag", "delete")
+
+#: How the trajectory tree is typed in rules (matches the package's
+#: ``entity_type: trajectory`` convention).
+TRAJECTORY_TYPE = "trajectory"
+
+
+# ---------------------------------------------------------------------------
+# Rules
+# ---------------------------------------------------------------------------
+
+
+def validate_rules(raw_rules):
+    """Validate a raw ``rules`` list into normalized rule dicts.
+
+    Mirrors the package's ``RetentionRule`` schema: every rule needs a ``name``
+    and at least one of ``max_age_days`` / ``max_unused_days``; ``action``
+    defaults to ``flag``. Raises ``ValueError`` on the first invalid rule.
+    """
+    if raw_rules is None:
+        return []
+    if not isinstance(raw_rules, list):
+        raise ValueError("retention rules must be a list")
+    rules = []
+    for raw in raw_rules:
+        if not isinstance(raw, dict):
+            raise ValueError(f"retention rule must be a mapping, got {type(raw).__name__}")
+        name = raw.get("name")
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError("retention rule must have a non-empty string 'name'")
+        rule = {
+            "name": name.strip(),
+            "entity_type": None,
+            "max_age_days": _coerce_days(raw.get("max_age_days"), name, "max_age_days"),
+            "max_unused_days": _coerce_days(raw.get("max_unused_days"), name, "max_unused_days"),
+            "action": raw.get("action", "flag"),
+            "cascade_derived": bool(raw.get("cascade_derived", False)),
+        }
+        entity_type = raw.get("entity_type")
+        if entity_type is not None:
+            if not isinstance(entity_type, str) or not entity_type.strip():
+                raise ValueError(f"retention rule {name!r}: entity_type must be a non-empty string")
+            rule["entity_type"] = entity_type.strip()
+        if rule["max_age_days"] is None and rule["max_unused_days"] is None:
+            raise ValueError(f"retention rule {name!r} must set max_age_days and/or max_unused_days")
+        if rule["action"] not in VALID_ACTIONS:
+            raise ValueError(f"retention rule {name!r}: action must be one of {VALID_ACTIONS}, got {rule['action']!r}")
+        rules.append(rule)
+    return rules
+
+
+def _coerce_days(value, rule_name, key):
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"retention rule {rule_name!r}: {key} must be a number, got {value!r}")
+    if value < 0:
+        raise ValueError(f"retention rule {rule_name!r}: {key} must be >= 0")
+    return float(value)
+
+
+def load_rules(config):
+    """Return validated rules from an evolve config dict's ``retention:`` block.
+
+    Returns ``[]`` when no block / no rules are configured.
+    """
+    retention_cfg = (config or {}).get("retention") or {}
+    if not isinstance(retention_cfg, dict):
+        raise ValueError("'retention' config block must be a mapping")
+    return validate_rules(retention_cfg.get("rules"))
+
+
+def load_policy_file(path):
+    """Load rules from a standalone policy file (JSON, or the same minimal
+    YAML subset ``evolve.config.yaml`` uses). The file holds a top-level
+    ``rules:`` list, like the package's ``retention.example.yaml``."""
+    text = Path(path).read_text(encoding="utf-8")
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        from config import _parse_yaml  # sibling lib module; resolved via sys.path
+
+        data = _parse_yaml(text)
+    if not isinstance(data, dict):
+        raise ValueError(f"policy file {path} must hold a mapping with a 'rules' list")
+    return validate_rules(data.get("rules"))
+
+
+# ---------------------------------------------------------------------------
+# Store scan
+# ---------------------------------------------------------------------------
+
+
+def _utc(dt):
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=datetime.timezone.utc)
+    return dt
+
+
+def _parse_iso(value):
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return _utc(datetime.datetime.fromisoformat(value.replace("Z", "+00:00")))
+    except ValueError:
+        return None
+
+
+def _mtime(path):
+    return datetime.datetime.fromtimestamp(path.stat().st_mtime, tz=datetime.timezone.utc)
+
+
+def _frontmatter(path):
+    """Parse simple ``key: value`` frontmatter lines from a markdown file."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return {}
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}
+    out = {}
+    for line in lines[1:]:
+        if line.strip() == "---":
+            return out
+        key, _, value = line.partition(":")
+        key, value = key.strip(), value.strip()
+        if key and value:
+            out[key] = value
+    return {}
+
+
+def scan_store(evolve_dir):
+    """Return one item dict per retention-eligible file in the store.
+
+    Items are shaped ``{id, type, path, mtime, trajectory_link}`` where
+    ``trajectory_link`` is the filename of the session the entity was derived
+    from (via its ``trajectory:`` frontmatter), or ``None``.
+    """
+    evolve_dir = Path(evolve_dir)
+    items = []
+
+    entities_root = evolve_dir / "entities"
+    if entities_root.is_dir():
+        for md in sorted(entities_root.glob("**/*.md")):
+            rel = md.relative_to(entities_root)
+            # subscribed/ trees are git clones owned by the sync skill; local
+            # deletes there would be silently restored by the next sync.
+            if rel.parts and rel.parts[0] == "subscribed":
+                continue
+            if md.is_symlink() or ".git" in rel.parts:
+                continue
+            meta = _frontmatter(md)
+            link = meta.get("trajectory")
+            items.append(
+                {
+                    "id": rel.with_suffix("").as_posix(),
+                    "type": meta.get("type") or (rel.parts[0] if len(rel.parts) > 1 else "guideline"),
+                    "path": md,
+                    "mtime": _mtime(md),
+                    "trajectory_link": Path(link).name if link else None,
+                }
+            )
+
+    traj_root = evolve_dir / "trajectories"
+    if traj_root.is_dir():
+        for traj in sorted(traj_root.iterdir()):
+            if not traj.is_file() or traj.is_symlink():
+                continue
+            items.append(
+                {
+                    "id": f"trajectories/{traj.name}",
+                    "type": TRAJECTORY_TYPE,
+                    "path": traj,
+                    "mtime": _mtime(traj),
+                    "trajectory_link": None,
+                }
+            )
+
+    return items
+
+
+def last_access_index(evolve_dir):
+    """Map entity id -> latest ``recall`` timestamp from ``.evolve/audit.log``.
+
+    This is the plugin's "unused" signal: ``audit_recall.py`` appends a recall
+    row (with ``entities: ["<type>/<name>", ...]``) when the agent records the
+    memories it consulted, mirroring what ``AccessStampPlugin`` /
+    ``EvolveClient.record_access`` stamp as ``metadata.last_accessed``
+    package-side. Unlike the package's hook, this one is model-invoked, so an
+    entity's absence from the index means "no recorded recall", not "not used".
+    """
+    audit_log = Path(evolve_dir) / "audit.log"
+    index = {}
+    if not audit_log.is_file():
+        return index
+    for line in audit_log.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(row, dict) or row.get("event") != "recall":
+            continue
+        ts = _parse_iso(row.get("ts"))
+        if ts is None:
+            continue
+        for eid in row.get("entities") or []:
+            if isinstance(eid, str) and eid:
+                prev = index.get(eid)
+                if prev is None or ts > prev:
+                    index[eid] = ts
+    return index
+
+
+# ---------------------------------------------------------------------------
+# Evaluation (mirrors altk_evolve.retention.engine.RetentionEngine.evaluate)
+# ---------------------------------------------------------------------------
+
+
+#: Appended to the "why" of an unused-rule match with no recorded recall.
+NO_RECALL_SIGNAL_HINT = (
+    "no recall row in .evolve/audit.log for this entity, so disuse was measured from file mtime; "
+    "the recall audit is model-invoked, so treat a never-recalled verdict as 'never recorded'"
+)
+
+
+def _match(item, rule, now, last_access):
+    """Return ``(reason, detail)`` if *rule* matches *item*, else None.
+
+    ``reason`` is 'age' or 'unused'; ``detail`` is the human-readable why,
+    including which signal was used and whether it fell back.
+    """
+    if rule["entity_type"] is not None and item["type"] != rule["entity_type"]:
+        return None
+    age_days = (now - item["mtime"]).total_seconds() / 86400.0
+    if rule["max_age_days"] is not None and age_days > rule["max_age_days"]:
+        return "age", "modified {:.1f}d ago > max_age_days={} (from file mtime)".format(age_days, rule["max_age_days"])
+    if rule["max_unused_days"] is not None:
+        recorded = last_access.get(item["id"])
+        last = recorded or item["mtime"]
+        unused_days = (now - last).total_seconds() / 86400.0
+        if unused_days > rule["max_unused_days"]:
+            detail = "not recalled for {:.1f}d > max_unused_days={}".format(unused_days, rule["max_unused_days"])
+            detail += " (from the recall audit log)" if recorded else " — " + NO_RECALL_SIGNAL_HINT
+            return "unused", detail
+    return None
+
+
+def evaluate(evolve_dir, rules, now=None, warnings=None):
+    """Compute the actions the rules imply, without mutating anything.
+
+    Returns a list of ``{id, type, action, reason, rule, detail, path}`` dicts.
+    First matching rule wins per item; delete supersedes flag; a delete rule
+    with ``cascade_derived`` on a trajectory also deletes the entities whose
+    ``trajectory:`` frontmatter links back to it.
+
+    When *warnings* is a list, non-fatal caveats about the run (e.g. a degraded
+    "unused" signal) are appended to it.
+    """
+    now = _utc(now) if now else datetime.datetime.now(datetime.timezone.utc)
+    items = scan_store(evolve_dir)
+    last_access = last_access_index(evolve_dir)
+
+    # Provenance index: trajectory filename -> [derived items]
+    derived_by_name = {}
+    for item in items:
+        link = item["trajectory_link"]
+        if link:
+            derived_by_name.setdefault(link, []).append(item)
+
+    # delete supersedes flag for the same item; first writer otherwise wins.
+    actions = {}
+
+    def record(item, action, reason, rule_name, detail):
+        existing = actions.get(item["id"])
+        if existing is not None and (existing["action"] == "delete" or action == "flag"):
+            return
+        actions[item["id"]] = {
+            "id": item["id"],
+            "type": item["type"],
+            "action": action,
+            "reason": reason,
+            "rule": rule_name,
+            "detail": detail,
+            "path": item["path"],
+        }
+
+    unrecalled = 0
+    uses_unused_rule = any(r["max_unused_days"] is not None for r in rules)
+
+    for item in items:
+        if uses_unused_rule and item["id"] not in last_access:
+            unrecalled += 1
+
+        matched = None
+        for rule in rules:
+            hit = _match(item, rule, now, last_access)
+            if hit is not None:
+                matched = (rule, hit[0], hit[1])
+                break
+        if matched is None:
+            continue
+        rule, reason, detail = matched
+        record(item, rule["action"], reason, rule["name"], detail)
+
+        if rule["action"] == "delete" and rule["cascade_derived"] and item["type"] == TRAJECTORY_TYPE:
+            for derived in derived_by_name.get(item["path"].name, []):
+                if derived["id"] == item["id"]:
+                    continue
+                record(
+                    derived,
+                    "delete",
+                    f"cascade:{item['path'].name}",
+                    rule["name"],
+                    f"trajectory: frontmatter links it to session {item['path'].name}, which this rule deletes",
+                )
+
+    if warnings is not None and unrecalled:
+        warnings.append(
+            f"{unrecalled} of {len(items)} store entries have no recall row in .evolve/audit.log, so their "
+            "disuse was measured from file mtime — for those, an unused rule behaves like an age rule."
+        )
+
+    return list(actions.values())
+
+
+# ---------------------------------------------------------------------------
+# Application
+# ---------------------------------------------------------------------------
+
+
+def _flag_entity_file(path, flagged_at, reason, rule_name):
+    """Upsert retention_* markers into an entity file's frontmatter.
+
+    Preserves the file's mtime so flagging does not reset the age clock.
+    """
+    path = Path(path)
+    st = path.stat()
+    text = path.read_text(encoding="utf-8")
+    marker = [
+        f"retention_flagged_at: {flagged_at}",
+        f"retention_reason: {reason}",
+        f"retention_rule: {rule_name}",
+    ]
+    lines = text.splitlines()
+    closing = None
+    if lines and lines[0].strip() == "---":
+        for i in range(1, len(lines)):
+            if lines[i].strip() == "---":
+                closing = i
+                break
+    if closing is not None:
+        head = [ln for ln in lines[1:closing] if not ln.strip().startswith("retention_")]
+        new_lines = [lines[0], *head, *marker, *lines[closing:]]
+    else:
+        # No frontmatter (shouldn't happen for entities we wrote) — prepend one.
+        new_lines = ["---", *marker, "---", "", *lines]
+    new_text = "\n".join(new_lines)
+    if text.endswith("\n"):
+        new_text += "\n"
+    path.write_text(new_text, encoding="utf-8")
+    os.utime(path, (st.st_atime, st.st_mtime))
+
+
+def apply_actions(evolve_dir, actions, dry_run=True, now=None, warnings=None):
+    """Apply (or, on dry run, merely report) a list of evaluated actions.
+
+    Returns ``{dry_run, flagged, deleted, errors, warnings}`` where
+    flagged/deleted hold the action dicts and errors/warnings hold strings.
+    Non-dry-run actions each append an ``event: "retention"`` row to the audit
+    log.
+    """
+    now = _utc(now) if now else datetime.datetime.now(datetime.timezone.utc)
+    flagged_at = now.isoformat()
+    report = {"dry_run": dry_run, "flagged": [], "deleted": [], "errors": [], "warnings": list(warnings or [])}
+
+    for action in actions:
+        try:
+            if action["action"] == "delete":
+                if not dry_run:
+                    Path(action["path"]).unlink(missing_ok=True)
+                    _audit(evolve_dir, action)
+                report["deleted"].append(action)
+            else:  # flag
+                if not dry_run:
+                    if action["type"] != TRAJECTORY_TYPE:
+                        _flag_entity_file(action["path"], flagged_at, action["reason"], action["rule"])
+                    # Trajectory files are opaque JSON — no frontmatter to mark;
+                    # the audit row below is their durable flag record.
+                    _audit(evolve_dir, action)
+                report["flagged"].append(action)
+        except OSError as exc:  # don't let one bad file abort the sweep
+            report["errors"].append(f"{action['action']} {action['id']}: {exc}")
+
+    return report
+
+
+def _audit(evolve_dir, action):
+    import audit  # sibling lib module; resolved via sys.path
+
+    audit.append(
+        evolve_dir=str(evolve_dir),
+        event="retention",
+        action=action["action"],
+        entity=action["id"],
+        reason=action["reason"],
+        rule=action["rule"],
+    )
+
+
+def run(evolve_dir, rules, dry_run=True, now=None):
+    """Evaluate the rules against the store and apply (or dry-run) the result."""
+    warnings = []
+    actions = evaluate(evolve_dir, rules, now=now, warnings=warnings)
+    return apply_actions(evolve_dir, actions, dry_run=dry_run, now=now, warnings=warnings)
+
+
+def summary(report):
+    verb = "would flag/delete" if report["dry_run"] else "flagged/deleted"
+    return f"{verb}: {len(report['flagged'])} flagged, {len(report['deleted'])} deleted, {len(report['errors'])} errors"
+
+
+if __name__ == "__main__":
+    # Self-test (pure paths only; file behavior is covered by pytest).
+    assert load_rules({}) == []
+    assert load_rules({"retention": {"rules": []}}) == []
+
+    rules = validate_rules([{"name": "r", "max_age_days": 30}])
+    assert rules[0]["action"] == "flag"  # default
+    assert rules[0]["max_age_days"] == 30.0
+
+    for bad in (
+        [{"name": "r"}],  # no threshold
+        [{"name": "r", "max_age_days": 30, "action": "purge"}],  # bad action
+        [{"max_age_days": 30}],  # no name
+        [{"name": "r", "max_age_days": "soon"}],  # non-numeric
+    ):
+        try:
+            validate_rules(bad)
+        except ValueError:
+            pass
+        else:  # pragma: no cover
+            raise AssertionError(f"expected ValueError for {bad}")
+
+    assert _parse_iso("2026-06-29T00:00:00Z") is not None
+    assert _parse_iso("not-a-date") is None
+    assert _parse_iso(None) is None
+    print("retention.py ok")

--- a/platform-integrations/bob/evolve-lite/lib/evolve-lite/retention.py
+++ b/platform-integrations/bob/evolve-lite/lib/evolve-lite/retention.py
@@ -75,6 +75,13 @@ from pathlib import Path
 
 VALID_ACTIONS = ("flag", "delete")
 
+#: What a delete rule does when an "unused" match has no recorded recall (disuse
+#: fell back to file mtime). Mirrors the package's RetentionRule field of the
+#: same name. "skip" (default, fail-safe) spares the entity and reports it;
+#: "flag" downgrades the delete to a non-destructive flag; "delete" deletes on
+#: the mtime fallback (the original behaviour).
+VALID_MISSING_SIGNAL = ("skip", "flag", "delete")
+
 #: How the trajectory tree is typed in rules (matches the package's
 #: ``entity_type: trajectory`` convention).
 TRAJECTORY_TYPE = "trajectory"
@@ -109,6 +116,7 @@ def validate_rules(raw_rules):
             "max_age_days": _coerce_days(raw.get("max_age_days"), name, "max_age_days"),
             "max_unused_days": _coerce_days(raw.get("max_unused_days"), name, "max_unused_days"),
             "action": raw.get("action", "flag"),
+            "on_missing_access_signal": raw.get("on_missing_access_signal", "skip"),
             "cascade_derived": bool(raw.get("cascade_derived", False)),
         }
         entity_type = raw.get("entity_type")
@@ -120,6 +128,11 @@ def validate_rules(raw_rules):
             raise ValueError(f"retention rule {name!r} must set max_age_days and/or max_unused_days")
         if rule["action"] not in VALID_ACTIONS:
             raise ValueError(f"retention rule {name!r}: action must be one of {VALID_ACTIONS}, got {rule['action']!r}")
+        if rule["on_missing_access_signal"] not in VALID_MISSING_SIGNAL:
+            raise ValueError(
+                f"retention rule {name!r}: on_missing_access_signal must be one of {VALID_MISSING_SIGNAL}, "
+                f"got {rule['on_missing_access_signal']!r}"
+            )
         rules.append(rule)
     return rules
 
@@ -302,16 +315,19 @@ NO_RECALL_SIGNAL_HINT = (
 
 
 def _match(item, rule, now, last_access):
-    """Return ``(reason, detail)`` if *rule* matches *item*, else None.
+    """Return ``(reason, detail, degraded)`` if *rule* matches *item*, else None.
 
     ``reason`` is 'age' or 'unused'; ``detail`` is the human-readable why,
-    including which signal was used and whether it fell back.
+    including which signal was used and whether it fell back. ``degraded`` is
+    True only for an 'unused' match whose disuse was measured from file mtime
+    because no recall row existed — ``on_missing_access_signal`` governs whether
+    such a match may still delete.
     """
     if rule["entity_type"] is not None and item["type"] != rule["entity_type"]:
         return None
     age_days = (now - item["mtime"]).total_seconds() / 86400.0
     if rule["max_age_days"] is not None and age_days > rule["max_age_days"]:
-        return "age", "modified {:.1f}d ago > max_age_days={} (from file mtime)".format(age_days, rule["max_age_days"])
+        return "age", "modified {:.1f}d ago > max_age_days={} (from file mtime)".format(age_days, rule["max_age_days"]), False
     if rule["max_unused_days"] is not None:
         recorded = last_access.get(item["id"])
         last = recorded or item["mtime"]
@@ -319,11 +335,11 @@ def _match(item, rule, now, last_access):
         if unused_days > rule["max_unused_days"]:
             detail = "not recalled for {:.1f}d > max_unused_days={}".format(unused_days, rule["max_unused_days"])
             detail += " (from the recall audit log)" if recorded else " — " + NO_RECALL_SIGNAL_HINT
-            return "unused", detail
+            return "unused", detail, not recorded
     return None
 
 
-def evaluate(evolve_dir, rules, now=None, warnings=None):
+def evaluate(evolve_dir, rules, now=None, warnings=None, skipped=None):
     """Compute the actions the rules imply, without mutating anything.
 
     Returns a list of ``{id, type, action, reason, rule, detail, path}`` dicts.
@@ -332,7 +348,9 @@ def evaluate(evolve_dir, rules, now=None, warnings=None):
     ``trajectory:`` frontmatter links back to it.
 
     When *warnings* is a list, non-fatal caveats about the run (e.g. a degraded
-    "unused" signal) are appended to it.
+    "unused" signal) are appended to it. When *skipped* is a list, items a
+    delete rule matched on a degraded signal but was spared under
+    ``on_missing_access_signal: skip`` are appended to it.
     """
     now = _utc(now) if now else datetime.datetime.now(datetime.timezone.utc)
     items = scan_store(evolve_dir)
@@ -373,14 +391,40 @@ def evaluate(evolve_dir, rules, now=None, warnings=None):
         for rule in rules:
             hit = _match(item, rule, now, last_access)
             if hit is not None:
-                matched = (rule, hit[0], hit[1])
+                matched = (rule, hit[0], hit[1], hit[2])
                 break
         if matched is None:
             continue
-        rule, reason, detail = matched
-        record(item, rule["action"], reason, rule["name"], detail)
+        rule, reason, detail, degraded = matched
 
-        if rule["action"] == "delete" and rule["cascade_derived"] and item["type"] == TRAJECTORY_TYPE:
+        action = rule["action"]
+        # A degraded "unused" match (no recall row, disuse from file mtime) only
+        # reaches a destructive action when the rule opts in. Default "skip"
+        # spares it; "flag" downgrades the delete; "delete" keeps the old
+        # behaviour. Only bites deletes — a flag action is not data loss.
+        if degraded and rule["action"] == "delete":
+            choice = rule["on_missing_access_signal"]
+            if choice == "skip":
+                if skipped is not None:
+                    skipped.append(
+                        {
+                            "id": item["id"],
+                            "type": item["type"],
+                            "action": "skip",
+                            "reason": reason,
+                            "rule": rule["name"],
+                            "detail": "matched but not deleted: {}; on_missing_access_signal=skip".format(detail),
+                            "path": item["path"],
+                        }
+                    )
+                continue
+            if choice == "flag":
+                action = "flag"
+                detail += "; downgraded delete->flag (on_missing_access_signal=flag)"
+
+        record(item, action, reason, rule["name"], detail)
+
+        if action == "delete" and rule["cascade_derived"] and item["type"] == TRAJECTORY_TYPE:
             for derived in derived_by_name.get(item["path"].name, []):
                 if derived["id"] == item["id"]:
                     continue
@@ -439,17 +483,24 @@ def _flag_entity_file(path, flagged_at, reason, rule_name):
     os.utime(path, (st.st_atime, st.st_mtime))
 
 
-def apply_actions(evolve_dir, actions, dry_run=True, now=None, warnings=None):
+def apply_actions(evolve_dir, actions, dry_run=True, now=None, warnings=None, skipped=None):
     """Apply (or, on dry run, merely report) a list of evaluated actions.
 
-    Returns ``{dry_run, flagged, deleted, errors, warnings}`` where
-    flagged/deleted hold the action dicts and errors/warnings hold strings.
+    Returns ``{dry_run, flagged, deleted, skipped, errors, warnings}`` where
+    flagged/deleted/skipped hold action dicts and errors/warnings hold strings.
     Non-dry-run actions each append an ``event: "retention"`` row to the audit
     log.
     """
     now = _utc(now) if now else datetime.datetime.now(datetime.timezone.utc)
     flagged_at = now.isoformat()
-    report = {"dry_run": dry_run, "flagged": [], "deleted": [], "errors": [], "warnings": list(warnings or [])}
+    report = {
+        "dry_run": dry_run,
+        "flagged": [],
+        "deleted": [],
+        "skipped": list(skipped or []),
+        "errors": [],
+        "warnings": list(warnings or []),
+    }
 
     for action in actions:
         try:
@@ -488,13 +539,17 @@ def _audit(evolve_dir, action):
 def run(evolve_dir, rules, dry_run=True, now=None):
     """Evaluate the rules against the store and apply (or dry-run) the result."""
     warnings = []
-    actions = evaluate(evolve_dir, rules, now=now, warnings=warnings)
-    return apply_actions(evolve_dir, actions, dry_run=dry_run, now=now, warnings=warnings)
+    skipped = []
+    actions = evaluate(evolve_dir, rules, now=now, warnings=warnings, skipped=skipped)
+    return apply_actions(evolve_dir, actions, dry_run=dry_run, now=now, warnings=warnings, skipped=skipped)
 
 
 def summary(report):
     verb = "would flag/delete" if report["dry_run"] else "flagged/deleted"
-    return f"{verb}: {len(report['flagged'])} flagged, {len(report['deleted'])} deleted, {len(report['errors'])} errors"
+    out = f"{verb}: {len(report['flagged'])} flagged, {len(report['deleted'])} deleted, {len(report['errors'])} errors"
+    if report.get("skipped"):
+        out += f", {len(report['skipped'])} skipped (degraded signal)"
+    return out
 
 
 if __name__ == "__main__":
@@ -504,11 +559,13 @@ if __name__ == "__main__":
 
     rules = validate_rules([{"name": "r", "max_age_days": 30}])
     assert rules[0]["action"] == "flag"  # default
+    assert rules[0]["on_missing_access_signal"] == "skip"  # fail-safe default
     assert rules[0]["max_age_days"] == 30.0
 
     for bad in (
         [{"name": "r"}],  # no threshold
         [{"name": "r", "max_age_days": 30, "action": "purge"}],  # bad action
+        [{"name": "r", "max_age_days": 30, "on_missing_access_signal": "nuke"}],  # bad signal policy
         [{"max_age_days": 30}],  # no name
         [{"name": "r", "max_age_days": "soon"}],  # non-numeric
     ):

--- a/platform-integrations/bob/evolve-lite/skills/evolve-lite-retention/SKILL.md
+++ b/platform-integrations/bob/evolve-lite/skills/evolve-lite-retention/SKILL.md
@@ -42,7 +42,16 @@ retention:
 
 Each rule needs a `name` and at least one of `max_age_days` /
 `max_unused_days`; `action` is `flag` (default) or `delete`. Rules are checked
-top-to-bottom and the first match wins, so put narrow rules first.
+top-to-bottom and the first match wins, so put narrow rules first — and put a
+longer-threshold `delete` before a shorter-threshold `flag` on the same type,
+or the flag shadows the delete and it never fires.
+
+A `delete` rule may also set `on_missing_access_signal` to say what happens when
+an `unused` match has **no recorded recall** (disuse measured from file mtime):
+`skip` (default, fail-safe — spare it and report it as skipped), `flag`
+(downgrade the delete to a non-destructive flag), or `delete` (delete on the
+mtime fallback anyway). The safe default means an `unused` delete never destroys
+a memory the agent simply never recorded a recall for.
 
 ### Step 2: Dry run
 
@@ -52,11 +61,12 @@ From the project root:
 python3 .bob/skills/evolve-lite-retention/scripts/run_retention.py
 ```
 
-Show the user the full report — every entry says what *would* be flagged or
-deleted, why (`age`, `unused`, or `cascade:<session>`), by which rule, and on
-what evidence. Relay any `WARNING` lines too: they say when a signal was
-weaker than it looks (for example, disuse measured from file mtime because the
-entity has no recall row).
+Show the user the full report — every entry says what *would* be flagged,
+deleted, or skipped, why (`age`, `unused`, or `cascade:<session>`), by which
+rule, and on what evidence. `SKIP` lines are entities a `delete` rule matched on
+a degraded signal but spared under `on_missing_access_signal: skip`. Relay any
+`WARNING` lines too: they say when a signal was weaker than it looks (for
+example, disuse measured from file mtime because the entity has no recall row).
 
 ### Step 3: Apply — only on explicit user confirmation
 

--- a/platform-integrations/bob/evolve-lite/skills/evolve-lite-retention/SKILL.md
+++ b/platform-integrations/bob/evolve-lite/skills/evolve-lite-retention/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: evolve-lite:retention
+description: Apply data-retention rules to the local evolve store — flag or delete stale and unused memories and expired sessions (dry-run by default)
+---
+
+# Retention
+
+## Overview
+
+Runs the data-retention rules configured in `evolve.config.yaml` against the
+local `.evolve/` store: private entities under `.evolve/entities/` and session
+transcripts under `.evolve/trajectories/`. Rules match by entity type plus age
+(`max_age_days`, from file mtime) or disuse (`max_unused_days`, from `recall`
+rows in `.evolve/audit.log`), and either **flag** (a non-destructive frontmatter
+marker) or **delete**. A `delete` rule on trajectories with
+`cascade_derived: true` also deletes the entities derived from those sessions
+(linked by their `trajectory:` frontmatter).
+
+The script is **dry-run by default** — it never mutates anything unless
+`--apply` is passed.
+
+## Workflow
+
+### Step 1: Require rules
+
+Read `evolve.config.yaml`. If there is no `retention:` block with a `rules:`
+list, show the user this example and stop:
+
+```yaml
+retention:
+  rules:
+    - name: stale-guidelines
+      entity_type: guideline
+      max_age_days: 90
+      action: flag
+    - name: old-sessions
+      entity_type: trajectory
+      max_age_days: 365
+      action: delete
+      cascade_derived: true
+```
+
+Each rule needs a `name` and at least one of `max_age_days` /
+`max_unused_days`; `action` is `flag` (default) or `delete`. Rules are checked
+top-to-bottom and the first match wins, so put narrow rules first.
+
+### Step 2: Dry run
+
+From the project root:
+
+```bash
+python3 .bob/skills/evolve-lite-retention/scripts/run_retention.py
+```
+
+Show the user the full report — every entry says what *would* be flagged or
+deleted, why (`age`, `unused`, or `cascade:<session>`), by which rule, and on
+what evidence. Relay any `WARNING` lines too: they say when a signal was
+weaker than it looks (for example, disuse measured from file mtime because the
+entity has no recall row).
+
+### Step 3: Apply — only on explicit user confirmation
+
+Deleting is destructive and there is no undo. Ask the user to confirm the
+dry-run report first. Never pass `--apply` without an explicit go-ahead.
+
+```bash
+python3 .bob/skills/evolve-lite-retention/scripts/run_retention.py --apply
+```
+
+Relay the applied report back to the user.
+
+## Notes
+
+- **Flag** upserts `retention_flagged_at`, `retention_reason`, and
+  `retention_rule` into the entity's frontmatter; the file's mtime is
+  preserved so its age clock doesn't reset. Trajectory files are opaque JSON,
+  so their flag is recorded in `.evolve/audit.log` only.
+- Every applied action is logged to `.evolve/audit.log` as an
+  `event: "retention"` row.
+- Subscribed entities (`.evolve/entities/subscribed/`) are out of scope — they
+  are git clones owned by the sync skill and local deletes would be restored
+  on the next sync.
+- A standalone policy file can be passed with `--policy <file>` (a `rules:`
+  list in JSON or YAML), overriding the config block.
+- Signal caveats, worth stating when you relay a report: age is **file mtime**
+  (editing an entity resets its clock — there is no `created_at` in the
+  store), and the disuse signal only exists for entities the agent recorded
+  via the recall audit step. The `trajectory:` cascade link is supported but
+  nothing writes it automatically today, so `cascade_derived` only fires for
+  entities where that key was set by hand.

--- a/platform-integrations/bob/evolve-lite/skills/evolve-lite-retention/scripts/run_retention.py
+++ b/platform-integrations/bob/evolve-lite/skills/evolve-lite-retention/scripts/run_retention.py
@@ -76,6 +76,10 @@ def main():
     if not report["deleted"] and not report["flagged"]:
         print("  (no memories matched any rule)")
 
+    for action in report.get("skipped", []):
+        print(f"  SKIP   {action['id']}  reason={action['reason']}  rule={action['rule']}")
+        print(f"         why: {action['detail']}")
+
     for warning in report["warnings"]:
         print(f"  WARNING  {warning}")
     for err in report["errors"]:

--- a/platform-integrations/bob/evolve-lite/skills/evolve-lite-retention/scripts/run_retention.py
+++ b/platform-integrations/bob/evolve-lite/skills/evolve-lite-retention/scripts/run_retention.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""
+Retention Script
+Applies data-retention rules to the local .evolve store: flags or deletes
+stale / unused memories and expired sessions. Dry-run by default; nothing
+is mutated unless --apply is passed.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+# Walk up from the script location to find the installed plugin lib directory.
+# Every host installs the shared lib under lib/evolve-lite/ so multiple
+# plugins can coexist side by side (e.g. .bob/lib/evolve-lite/).
+_script = Path(__file__).resolve()
+_lib = None
+for _ancestor in _script.parents:
+    _candidate = _ancestor / "lib" / "evolve-lite"
+    if (_candidate / "entity_io.py").is_file():
+        _lib = _candidate
+        break
+if _lib is None:
+    raise ImportError(f"Cannot find plugin lib directory above {_script}")
+sys.path.insert(0, str(_lib))
+from entity_io import get_evolve_dir, log as _log  # noqa: E402
+from config import load_config  # noqa: E402
+import retention  # noqa: E402
+
+
+def log(message):
+    _log("retention", message)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Apply retention rules to the .evolve store (dry-run by default).")
+    parser.add_argument("--apply", action="store_true", help="Actually flag/delete. Without this flag, only report.")
+    parser.add_argument("--policy", default=None, help="Standalone policy file (JSON or YAML 'rules:' list) overriding evolve.config.yaml.")
+    args = parser.parse_args()
+
+    try:
+        if args.policy:
+            rules = retention.load_policy_file(args.policy)
+        else:
+            rules = retention.load_rules(load_config())
+    except (ValueError, OSError) as exc:
+        log(f"Invalid retention rules: {exc}")
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if not rules:
+        print(
+            "No retention rules configured. Add a `retention:` block with a `rules:` list to evolve.config.yaml (or pass --policy <file>)."
+        )
+        sys.exit(0)
+
+    evolve_dir = get_evolve_dir()
+    if not evolve_dir.is_dir():
+        print(f"No evolve store at {evolve_dir}; nothing to do.")
+        sys.exit(0)
+    evolve_dir = evolve_dir.resolve()
+
+    dry_run = not args.apply
+    report = retention.run(evolve_dir, rules, dry_run=dry_run)
+    log(f"{'DRY RUN' if dry_run else 'APPLY'}: {retention.summary(report)}")
+
+    if dry_run:
+        print("DRY RUN — nothing was changed. Re-run with --apply to enforce.")
+    else:
+        print("APPLIED:")
+
+    for action in [*report["deleted"], *report["flagged"]]:
+        verb = action["action"].upper()
+        print(f"  {verb:6} {action['id']}  reason={action['reason']}  rule={action['rule']}")
+        print(f"         why: {action['detail']}")
+    if not report["deleted"] and not report["flagged"]:
+        print("  (no memories matched any rule)")
+
+    for warning in report["warnings"]:
+        print(f"  WARNING  {warning}")
+    for err in report["errors"]:
+        print(f"  ERROR  {err}", file=sys.stderr)
+
+    print(retention.summary(report))
+    sys.exit(1 if report["errors"] else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/platform-integrations/claude/plugins/evolve-lite/lib/evolve-lite/retention.py
+++ b/platform-integrations/claude/plugins/evolve-lite/lib/evolve-lite/retention.py
@@ -1,0 +1,525 @@
+"""Data retention for the evolve-lite plugin store (issue #275).
+
+Mirrors the ``altk_evolve/retention/`` semantics against the plugin's
+``.evolve/`` file store: age-based and unused-based rules that **flag** or
+**delete**, dry-run by default, and the session -> derived cascade. Stdlib-only,
+because plugin scripts run in the host's Python where nothing beyond the
+standard library is guaranteed.
+
+The plugin store is markdown files, not a backend with per-entity metadata, so
+the package's signals map onto what the files actually carry. Each mapping is
+weaker than its package-side counterpart — the gaps are called out here and in
+``docs/guides/retention.md``:
+
+- **age** — file mtime. Plugin entities carry no ``created_at`` frontmatter, so
+  mtime is the only available clock. It is a *modification* time, not a birth
+  time: editing an entity resets its age. (Flagging deliberately restores the
+  mtime so the sweep itself never resets the clock — see below.)
+- **unused** — the latest ``recall`` row in ``.evolve/audit.log`` naming the
+  entity id (``<type>/<name>``, the id scheme ``audit_recall.py`` logs and
+  ``EVOLVE.md`` instructs the agent to pass), falling back to file mtime when
+  an entity was never recalled. This is the plugin's answer to the package's
+  ``metadata.last_accessed``, and it has the same failure mode: it only exists
+  if something records the recall. Package-side that is ``AccessStampPlugin``
+  (automatic); plugin-side it is a model-invoked ``audit_recall.py`` call — so
+  the signal is only as complete as the agent's compliance with EVOLVE.md.
+- **cascade** — the package links a derived memory to its session via
+  ``metadata.source_task_id == trace_id``. Plugin-side the equivalent link is a
+  ``trajectory:`` frontmatter key naming the session file under
+  ``.evolve/trajectories/``; a ``cascade_derived`` delete of a trajectory also
+  deletes entities whose link resolves to it (matched by filename — trajectory
+  filenames embed a timestamp + session id and are unique by construction).
+  **Known gap: nothing in the shipped plugin writes that key today.**
+  ``entity_io._FRONTMATTER_KEYS`` supports it and it is preserved on round-trip,
+  but neither the save flow nor ``adapt-memory`` populates it, so in practice
+  the plugin-side cascade only fires for entities whose ``trajectory:`` key was
+  written by hand or by a downstream tool. Deleting a session therefore does
+  *not* by itself clean up the memories derived from it the way the package
+  side does.
+
+Actions:
+
+- **flag** — upsert ``retention_flagged_at`` / ``retention_reason`` /
+  ``retention_rule`` into the entity's frontmatter (non-destructive; the file's
+  mtime is preserved so the age clock does not reset). Trajectory files are
+  opaque JSON with no frontmatter, so their flag lives in the audit log only.
+- **delete** — unlink the file.
+
+Every applied (non-dry-run) action also appends an ``event: "retention"`` row
+to ``.evolve/audit.log`` for auditability.
+
+Scope: private entities under ``.evolve/entities/`` — excluding
+``entities/subscribed/`` (git clones managed by the sync skill; local deletes
+there would be clobbered by the next sync) — plus session files under
+``.evolve/trajectories/``.
+
+Rules load from a ``retention:`` block in ``evolve.config.yaml``::
+
+    retention:
+      rules:
+        - name: stale-guidelines
+          entity_type: guideline
+          max_age_days: 90
+          action: flag
+        - name: old-sessions
+          entity_type: trajectory
+          max_age_days: 365
+          action: delete
+          cascade_derived: true
+"""
+
+import datetime
+import json
+import os
+from pathlib import Path
+
+VALID_ACTIONS = ("flag", "delete")
+
+#: How the trajectory tree is typed in rules (matches the package's
+#: ``entity_type: trajectory`` convention).
+TRAJECTORY_TYPE = "trajectory"
+
+
+# ---------------------------------------------------------------------------
+# Rules
+# ---------------------------------------------------------------------------
+
+
+def validate_rules(raw_rules):
+    """Validate a raw ``rules`` list into normalized rule dicts.
+
+    Mirrors the package's ``RetentionRule`` schema: every rule needs a ``name``
+    and at least one of ``max_age_days`` / ``max_unused_days``; ``action``
+    defaults to ``flag``. Raises ``ValueError`` on the first invalid rule.
+    """
+    if raw_rules is None:
+        return []
+    if not isinstance(raw_rules, list):
+        raise ValueError("retention rules must be a list")
+    rules = []
+    for raw in raw_rules:
+        if not isinstance(raw, dict):
+            raise ValueError(f"retention rule must be a mapping, got {type(raw).__name__}")
+        name = raw.get("name")
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError("retention rule must have a non-empty string 'name'")
+        rule = {
+            "name": name.strip(),
+            "entity_type": None,
+            "max_age_days": _coerce_days(raw.get("max_age_days"), name, "max_age_days"),
+            "max_unused_days": _coerce_days(raw.get("max_unused_days"), name, "max_unused_days"),
+            "action": raw.get("action", "flag"),
+            "cascade_derived": bool(raw.get("cascade_derived", False)),
+        }
+        entity_type = raw.get("entity_type")
+        if entity_type is not None:
+            if not isinstance(entity_type, str) or not entity_type.strip():
+                raise ValueError(f"retention rule {name!r}: entity_type must be a non-empty string")
+            rule["entity_type"] = entity_type.strip()
+        if rule["max_age_days"] is None and rule["max_unused_days"] is None:
+            raise ValueError(f"retention rule {name!r} must set max_age_days and/or max_unused_days")
+        if rule["action"] not in VALID_ACTIONS:
+            raise ValueError(f"retention rule {name!r}: action must be one of {VALID_ACTIONS}, got {rule['action']!r}")
+        rules.append(rule)
+    return rules
+
+
+def _coerce_days(value, rule_name, key):
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"retention rule {rule_name!r}: {key} must be a number, got {value!r}")
+    if value < 0:
+        raise ValueError(f"retention rule {rule_name!r}: {key} must be >= 0")
+    return float(value)
+
+
+def load_rules(config):
+    """Return validated rules from an evolve config dict's ``retention:`` block.
+
+    Returns ``[]`` when no block / no rules are configured.
+    """
+    retention_cfg = (config or {}).get("retention") or {}
+    if not isinstance(retention_cfg, dict):
+        raise ValueError("'retention' config block must be a mapping")
+    return validate_rules(retention_cfg.get("rules"))
+
+
+def load_policy_file(path):
+    """Load rules from a standalone policy file (JSON, or the same minimal
+    YAML subset ``evolve.config.yaml`` uses). The file holds a top-level
+    ``rules:`` list, like the package's ``retention.example.yaml``."""
+    text = Path(path).read_text(encoding="utf-8")
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        from config import _parse_yaml  # sibling lib module; resolved via sys.path
+
+        data = _parse_yaml(text)
+    if not isinstance(data, dict):
+        raise ValueError(f"policy file {path} must hold a mapping with a 'rules' list")
+    return validate_rules(data.get("rules"))
+
+
+# ---------------------------------------------------------------------------
+# Store scan
+# ---------------------------------------------------------------------------
+
+
+def _utc(dt):
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=datetime.timezone.utc)
+    return dt
+
+
+def _parse_iso(value):
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return _utc(datetime.datetime.fromisoformat(value.replace("Z", "+00:00")))
+    except ValueError:
+        return None
+
+
+def _mtime(path):
+    return datetime.datetime.fromtimestamp(path.stat().st_mtime, tz=datetime.timezone.utc)
+
+
+def _frontmatter(path):
+    """Parse simple ``key: value`` frontmatter lines from a markdown file."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return {}
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}
+    out = {}
+    for line in lines[1:]:
+        if line.strip() == "---":
+            return out
+        key, _, value = line.partition(":")
+        key, value = key.strip(), value.strip()
+        if key and value:
+            out[key] = value
+    return {}
+
+
+def scan_store(evolve_dir):
+    """Return one item dict per retention-eligible file in the store.
+
+    Items are shaped ``{id, type, path, mtime, trajectory_link}`` where
+    ``trajectory_link`` is the filename of the session the entity was derived
+    from (via its ``trajectory:`` frontmatter), or ``None``.
+    """
+    evolve_dir = Path(evolve_dir)
+    items = []
+
+    entities_root = evolve_dir / "entities"
+    if entities_root.is_dir():
+        for md in sorted(entities_root.glob("**/*.md")):
+            rel = md.relative_to(entities_root)
+            # subscribed/ trees are git clones owned by the sync skill; local
+            # deletes there would be silently restored by the next sync.
+            if rel.parts and rel.parts[0] == "subscribed":
+                continue
+            if md.is_symlink() or ".git" in rel.parts:
+                continue
+            meta = _frontmatter(md)
+            link = meta.get("trajectory")
+            items.append(
+                {
+                    "id": rel.with_suffix("").as_posix(),
+                    "type": meta.get("type") or (rel.parts[0] if len(rel.parts) > 1 else "guideline"),
+                    "path": md,
+                    "mtime": _mtime(md),
+                    "trajectory_link": Path(link).name if link else None,
+                }
+            )
+
+    traj_root = evolve_dir / "trajectories"
+    if traj_root.is_dir():
+        for traj in sorted(traj_root.iterdir()):
+            if not traj.is_file() or traj.is_symlink():
+                continue
+            items.append(
+                {
+                    "id": f"trajectories/{traj.name}",
+                    "type": TRAJECTORY_TYPE,
+                    "path": traj,
+                    "mtime": _mtime(traj),
+                    "trajectory_link": None,
+                }
+            )
+
+    return items
+
+
+def last_access_index(evolve_dir):
+    """Map entity id -> latest ``recall`` timestamp from ``.evolve/audit.log``.
+
+    This is the plugin's "unused" signal: ``audit_recall.py`` appends a recall
+    row (with ``entities: ["<type>/<name>", ...]``) when the agent records the
+    memories it consulted, mirroring what ``AccessStampPlugin`` /
+    ``EvolveClient.record_access`` stamp as ``metadata.last_accessed``
+    package-side. Unlike the package's hook, this one is model-invoked, so an
+    entity's absence from the index means "no recorded recall", not "not used".
+    """
+    audit_log = Path(evolve_dir) / "audit.log"
+    index = {}
+    if not audit_log.is_file():
+        return index
+    for line in audit_log.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(row, dict) or row.get("event") != "recall":
+            continue
+        ts = _parse_iso(row.get("ts"))
+        if ts is None:
+            continue
+        for eid in row.get("entities") or []:
+            if isinstance(eid, str) and eid:
+                prev = index.get(eid)
+                if prev is None or ts > prev:
+                    index[eid] = ts
+    return index
+
+
+# ---------------------------------------------------------------------------
+# Evaluation (mirrors altk_evolve.retention.engine.RetentionEngine.evaluate)
+# ---------------------------------------------------------------------------
+
+
+#: Appended to the "why" of an unused-rule match with no recorded recall.
+NO_RECALL_SIGNAL_HINT = (
+    "no recall row in .evolve/audit.log for this entity, so disuse was measured from file mtime; "
+    "the recall audit is model-invoked, so treat a never-recalled verdict as 'never recorded'"
+)
+
+
+def _match(item, rule, now, last_access):
+    """Return ``(reason, detail)`` if *rule* matches *item*, else None.
+
+    ``reason`` is 'age' or 'unused'; ``detail`` is the human-readable why,
+    including which signal was used and whether it fell back.
+    """
+    if rule["entity_type"] is not None and item["type"] != rule["entity_type"]:
+        return None
+    age_days = (now - item["mtime"]).total_seconds() / 86400.0
+    if rule["max_age_days"] is not None and age_days > rule["max_age_days"]:
+        return "age", "modified {:.1f}d ago > max_age_days={} (from file mtime)".format(age_days, rule["max_age_days"])
+    if rule["max_unused_days"] is not None:
+        recorded = last_access.get(item["id"])
+        last = recorded or item["mtime"]
+        unused_days = (now - last).total_seconds() / 86400.0
+        if unused_days > rule["max_unused_days"]:
+            detail = "not recalled for {:.1f}d > max_unused_days={}".format(unused_days, rule["max_unused_days"])
+            detail += " (from the recall audit log)" if recorded else " — " + NO_RECALL_SIGNAL_HINT
+            return "unused", detail
+    return None
+
+
+def evaluate(evolve_dir, rules, now=None, warnings=None):
+    """Compute the actions the rules imply, without mutating anything.
+
+    Returns a list of ``{id, type, action, reason, rule, detail, path}`` dicts.
+    First matching rule wins per item; delete supersedes flag; a delete rule
+    with ``cascade_derived`` on a trajectory also deletes the entities whose
+    ``trajectory:`` frontmatter links back to it.
+
+    When *warnings* is a list, non-fatal caveats about the run (e.g. a degraded
+    "unused" signal) are appended to it.
+    """
+    now = _utc(now) if now else datetime.datetime.now(datetime.timezone.utc)
+    items = scan_store(evolve_dir)
+    last_access = last_access_index(evolve_dir)
+
+    # Provenance index: trajectory filename -> [derived items]
+    derived_by_name = {}
+    for item in items:
+        link = item["trajectory_link"]
+        if link:
+            derived_by_name.setdefault(link, []).append(item)
+
+    # delete supersedes flag for the same item; first writer otherwise wins.
+    actions = {}
+
+    def record(item, action, reason, rule_name, detail):
+        existing = actions.get(item["id"])
+        if existing is not None and (existing["action"] == "delete" or action == "flag"):
+            return
+        actions[item["id"]] = {
+            "id": item["id"],
+            "type": item["type"],
+            "action": action,
+            "reason": reason,
+            "rule": rule_name,
+            "detail": detail,
+            "path": item["path"],
+        }
+
+    unrecalled = 0
+    uses_unused_rule = any(r["max_unused_days"] is not None for r in rules)
+
+    for item in items:
+        if uses_unused_rule and item["id"] not in last_access:
+            unrecalled += 1
+
+        matched = None
+        for rule in rules:
+            hit = _match(item, rule, now, last_access)
+            if hit is not None:
+                matched = (rule, hit[0], hit[1])
+                break
+        if matched is None:
+            continue
+        rule, reason, detail = matched
+        record(item, rule["action"], reason, rule["name"], detail)
+
+        if rule["action"] == "delete" and rule["cascade_derived"] and item["type"] == TRAJECTORY_TYPE:
+            for derived in derived_by_name.get(item["path"].name, []):
+                if derived["id"] == item["id"]:
+                    continue
+                record(
+                    derived,
+                    "delete",
+                    f"cascade:{item['path'].name}",
+                    rule["name"],
+                    f"trajectory: frontmatter links it to session {item['path'].name}, which this rule deletes",
+                )
+
+    if warnings is not None and unrecalled:
+        warnings.append(
+            f"{unrecalled} of {len(items)} store entries have no recall row in .evolve/audit.log, so their "
+            "disuse was measured from file mtime — for those, an unused rule behaves like an age rule."
+        )
+
+    return list(actions.values())
+
+
+# ---------------------------------------------------------------------------
+# Application
+# ---------------------------------------------------------------------------
+
+
+def _flag_entity_file(path, flagged_at, reason, rule_name):
+    """Upsert retention_* markers into an entity file's frontmatter.
+
+    Preserves the file's mtime so flagging does not reset the age clock.
+    """
+    path = Path(path)
+    st = path.stat()
+    text = path.read_text(encoding="utf-8")
+    marker = [
+        f"retention_flagged_at: {flagged_at}",
+        f"retention_reason: {reason}",
+        f"retention_rule: {rule_name}",
+    ]
+    lines = text.splitlines()
+    closing = None
+    if lines and lines[0].strip() == "---":
+        for i in range(1, len(lines)):
+            if lines[i].strip() == "---":
+                closing = i
+                break
+    if closing is not None:
+        head = [ln for ln in lines[1:closing] if not ln.strip().startswith("retention_")]
+        new_lines = [lines[0], *head, *marker, *lines[closing:]]
+    else:
+        # No frontmatter (shouldn't happen for entities we wrote) — prepend one.
+        new_lines = ["---", *marker, "---", "", *lines]
+    new_text = "\n".join(new_lines)
+    if text.endswith("\n"):
+        new_text += "\n"
+    path.write_text(new_text, encoding="utf-8")
+    os.utime(path, (st.st_atime, st.st_mtime))
+
+
+def apply_actions(evolve_dir, actions, dry_run=True, now=None, warnings=None):
+    """Apply (or, on dry run, merely report) a list of evaluated actions.
+
+    Returns ``{dry_run, flagged, deleted, errors, warnings}`` where
+    flagged/deleted hold the action dicts and errors/warnings hold strings.
+    Non-dry-run actions each append an ``event: "retention"`` row to the audit
+    log.
+    """
+    now = _utc(now) if now else datetime.datetime.now(datetime.timezone.utc)
+    flagged_at = now.isoformat()
+    report = {"dry_run": dry_run, "flagged": [], "deleted": [], "errors": [], "warnings": list(warnings or [])}
+
+    for action in actions:
+        try:
+            if action["action"] == "delete":
+                if not dry_run:
+                    Path(action["path"]).unlink(missing_ok=True)
+                    _audit(evolve_dir, action)
+                report["deleted"].append(action)
+            else:  # flag
+                if not dry_run:
+                    if action["type"] != TRAJECTORY_TYPE:
+                        _flag_entity_file(action["path"], flagged_at, action["reason"], action["rule"])
+                    # Trajectory files are opaque JSON — no frontmatter to mark;
+                    # the audit row below is their durable flag record.
+                    _audit(evolve_dir, action)
+                report["flagged"].append(action)
+        except OSError as exc:  # don't let one bad file abort the sweep
+            report["errors"].append(f"{action['action']} {action['id']}: {exc}")
+
+    return report
+
+
+def _audit(evolve_dir, action):
+    import audit  # sibling lib module; resolved via sys.path
+
+    audit.append(
+        evolve_dir=str(evolve_dir),
+        event="retention",
+        action=action["action"],
+        entity=action["id"],
+        reason=action["reason"],
+        rule=action["rule"],
+    )
+
+
+def run(evolve_dir, rules, dry_run=True, now=None):
+    """Evaluate the rules against the store and apply (or dry-run) the result."""
+    warnings = []
+    actions = evaluate(evolve_dir, rules, now=now, warnings=warnings)
+    return apply_actions(evolve_dir, actions, dry_run=dry_run, now=now, warnings=warnings)
+
+
+def summary(report):
+    verb = "would flag/delete" if report["dry_run"] else "flagged/deleted"
+    return f"{verb}: {len(report['flagged'])} flagged, {len(report['deleted'])} deleted, {len(report['errors'])} errors"
+
+
+if __name__ == "__main__":
+    # Self-test (pure paths only; file behavior is covered by pytest).
+    assert load_rules({}) == []
+    assert load_rules({"retention": {"rules": []}}) == []
+
+    rules = validate_rules([{"name": "r", "max_age_days": 30}])
+    assert rules[0]["action"] == "flag"  # default
+    assert rules[0]["max_age_days"] == 30.0
+
+    for bad in (
+        [{"name": "r"}],  # no threshold
+        [{"name": "r", "max_age_days": 30, "action": "purge"}],  # bad action
+        [{"max_age_days": 30}],  # no name
+        [{"name": "r", "max_age_days": "soon"}],  # non-numeric
+    ):
+        try:
+            validate_rules(bad)
+        except ValueError:
+            pass
+        else:  # pragma: no cover
+            raise AssertionError(f"expected ValueError for {bad}")
+
+    assert _parse_iso("2026-06-29T00:00:00Z") is not None
+    assert _parse_iso("not-a-date") is None
+    assert _parse_iso(None) is None
+    print("retention.py ok")

--- a/platform-integrations/claude/plugins/evolve-lite/lib/evolve-lite/retention.py
+++ b/platform-integrations/claude/plugins/evolve-lite/lib/evolve-lite/retention.py
@@ -75,6 +75,13 @@ from pathlib import Path
 
 VALID_ACTIONS = ("flag", "delete")
 
+#: What a delete rule does when an "unused" match has no recorded recall (disuse
+#: fell back to file mtime). Mirrors the package's RetentionRule field of the
+#: same name. "skip" (default, fail-safe) spares the entity and reports it;
+#: "flag" downgrades the delete to a non-destructive flag; "delete" deletes on
+#: the mtime fallback (the original behaviour).
+VALID_MISSING_SIGNAL = ("skip", "flag", "delete")
+
 #: How the trajectory tree is typed in rules (matches the package's
 #: ``entity_type: trajectory`` convention).
 TRAJECTORY_TYPE = "trajectory"
@@ -109,6 +116,7 @@ def validate_rules(raw_rules):
             "max_age_days": _coerce_days(raw.get("max_age_days"), name, "max_age_days"),
             "max_unused_days": _coerce_days(raw.get("max_unused_days"), name, "max_unused_days"),
             "action": raw.get("action", "flag"),
+            "on_missing_access_signal": raw.get("on_missing_access_signal", "skip"),
             "cascade_derived": bool(raw.get("cascade_derived", False)),
         }
         entity_type = raw.get("entity_type")
@@ -120,6 +128,11 @@ def validate_rules(raw_rules):
             raise ValueError(f"retention rule {name!r} must set max_age_days and/or max_unused_days")
         if rule["action"] not in VALID_ACTIONS:
             raise ValueError(f"retention rule {name!r}: action must be one of {VALID_ACTIONS}, got {rule['action']!r}")
+        if rule["on_missing_access_signal"] not in VALID_MISSING_SIGNAL:
+            raise ValueError(
+                f"retention rule {name!r}: on_missing_access_signal must be one of {VALID_MISSING_SIGNAL}, "
+                f"got {rule['on_missing_access_signal']!r}"
+            )
         rules.append(rule)
     return rules
 
@@ -302,16 +315,19 @@ NO_RECALL_SIGNAL_HINT = (
 
 
 def _match(item, rule, now, last_access):
-    """Return ``(reason, detail)`` if *rule* matches *item*, else None.
+    """Return ``(reason, detail, degraded)`` if *rule* matches *item*, else None.
 
     ``reason`` is 'age' or 'unused'; ``detail`` is the human-readable why,
-    including which signal was used and whether it fell back.
+    including which signal was used and whether it fell back. ``degraded`` is
+    True only for an 'unused' match whose disuse was measured from file mtime
+    because no recall row existed — ``on_missing_access_signal`` governs whether
+    such a match may still delete.
     """
     if rule["entity_type"] is not None and item["type"] != rule["entity_type"]:
         return None
     age_days = (now - item["mtime"]).total_seconds() / 86400.0
     if rule["max_age_days"] is not None and age_days > rule["max_age_days"]:
-        return "age", "modified {:.1f}d ago > max_age_days={} (from file mtime)".format(age_days, rule["max_age_days"])
+        return "age", "modified {:.1f}d ago > max_age_days={} (from file mtime)".format(age_days, rule["max_age_days"]), False
     if rule["max_unused_days"] is not None:
         recorded = last_access.get(item["id"])
         last = recorded or item["mtime"]
@@ -319,11 +335,11 @@ def _match(item, rule, now, last_access):
         if unused_days > rule["max_unused_days"]:
             detail = "not recalled for {:.1f}d > max_unused_days={}".format(unused_days, rule["max_unused_days"])
             detail += " (from the recall audit log)" if recorded else " — " + NO_RECALL_SIGNAL_HINT
-            return "unused", detail
+            return "unused", detail, not recorded
     return None
 
 
-def evaluate(evolve_dir, rules, now=None, warnings=None):
+def evaluate(evolve_dir, rules, now=None, warnings=None, skipped=None):
     """Compute the actions the rules imply, without mutating anything.
 
     Returns a list of ``{id, type, action, reason, rule, detail, path}`` dicts.
@@ -332,7 +348,9 @@ def evaluate(evolve_dir, rules, now=None, warnings=None):
     ``trajectory:`` frontmatter links back to it.
 
     When *warnings* is a list, non-fatal caveats about the run (e.g. a degraded
-    "unused" signal) are appended to it.
+    "unused" signal) are appended to it. When *skipped* is a list, items a
+    delete rule matched on a degraded signal but was spared under
+    ``on_missing_access_signal: skip`` are appended to it.
     """
     now = _utc(now) if now else datetime.datetime.now(datetime.timezone.utc)
     items = scan_store(evolve_dir)
@@ -373,14 +391,40 @@ def evaluate(evolve_dir, rules, now=None, warnings=None):
         for rule in rules:
             hit = _match(item, rule, now, last_access)
             if hit is not None:
-                matched = (rule, hit[0], hit[1])
+                matched = (rule, hit[0], hit[1], hit[2])
                 break
         if matched is None:
             continue
-        rule, reason, detail = matched
-        record(item, rule["action"], reason, rule["name"], detail)
+        rule, reason, detail, degraded = matched
 
-        if rule["action"] == "delete" and rule["cascade_derived"] and item["type"] == TRAJECTORY_TYPE:
+        action = rule["action"]
+        # A degraded "unused" match (no recall row, disuse from file mtime) only
+        # reaches a destructive action when the rule opts in. Default "skip"
+        # spares it; "flag" downgrades the delete; "delete" keeps the old
+        # behaviour. Only bites deletes — a flag action is not data loss.
+        if degraded and rule["action"] == "delete":
+            choice = rule["on_missing_access_signal"]
+            if choice == "skip":
+                if skipped is not None:
+                    skipped.append(
+                        {
+                            "id": item["id"],
+                            "type": item["type"],
+                            "action": "skip",
+                            "reason": reason,
+                            "rule": rule["name"],
+                            "detail": "matched but not deleted: {}; on_missing_access_signal=skip".format(detail),
+                            "path": item["path"],
+                        }
+                    )
+                continue
+            if choice == "flag":
+                action = "flag"
+                detail += "; downgraded delete->flag (on_missing_access_signal=flag)"
+
+        record(item, action, reason, rule["name"], detail)
+
+        if action == "delete" and rule["cascade_derived"] and item["type"] == TRAJECTORY_TYPE:
             for derived in derived_by_name.get(item["path"].name, []):
                 if derived["id"] == item["id"]:
                     continue
@@ -439,17 +483,24 @@ def _flag_entity_file(path, flagged_at, reason, rule_name):
     os.utime(path, (st.st_atime, st.st_mtime))
 
 
-def apply_actions(evolve_dir, actions, dry_run=True, now=None, warnings=None):
+def apply_actions(evolve_dir, actions, dry_run=True, now=None, warnings=None, skipped=None):
     """Apply (or, on dry run, merely report) a list of evaluated actions.
 
-    Returns ``{dry_run, flagged, deleted, errors, warnings}`` where
-    flagged/deleted hold the action dicts and errors/warnings hold strings.
+    Returns ``{dry_run, flagged, deleted, skipped, errors, warnings}`` where
+    flagged/deleted/skipped hold action dicts and errors/warnings hold strings.
     Non-dry-run actions each append an ``event: "retention"`` row to the audit
     log.
     """
     now = _utc(now) if now else datetime.datetime.now(datetime.timezone.utc)
     flagged_at = now.isoformat()
-    report = {"dry_run": dry_run, "flagged": [], "deleted": [], "errors": [], "warnings": list(warnings or [])}
+    report = {
+        "dry_run": dry_run,
+        "flagged": [],
+        "deleted": [],
+        "skipped": list(skipped or []),
+        "errors": [],
+        "warnings": list(warnings or []),
+    }
 
     for action in actions:
         try:
@@ -488,13 +539,17 @@ def _audit(evolve_dir, action):
 def run(evolve_dir, rules, dry_run=True, now=None):
     """Evaluate the rules against the store and apply (or dry-run) the result."""
     warnings = []
-    actions = evaluate(evolve_dir, rules, now=now, warnings=warnings)
-    return apply_actions(evolve_dir, actions, dry_run=dry_run, now=now, warnings=warnings)
+    skipped = []
+    actions = evaluate(evolve_dir, rules, now=now, warnings=warnings, skipped=skipped)
+    return apply_actions(evolve_dir, actions, dry_run=dry_run, now=now, warnings=warnings, skipped=skipped)
 
 
 def summary(report):
     verb = "would flag/delete" if report["dry_run"] else "flagged/deleted"
-    return f"{verb}: {len(report['flagged'])} flagged, {len(report['deleted'])} deleted, {len(report['errors'])} errors"
+    out = f"{verb}: {len(report['flagged'])} flagged, {len(report['deleted'])} deleted, {len(report['errors'])} errors"
+    if report.get("skipped"):
+        out += f", {len(report['skipped'])} skipped (degraded signal)"
+    return out
 
 
 if __name__ == "__main__":
@@ -504,11 +559,13 @@ if __name__ == "__main__":
 
     rules = validate_rules([{"name": "r", "max_age_days": 30}])
     assert rules[0]["action"] == "flag"  # default
+    assert rules[0]["on_missing_access_signal"] == "skip"  # fail-safe default
     assert rules[0]["max_age_days"] == 30.0
 
     for bad in (
         [{"name": "r"}],  # no threshold
         [{"name": "r", "max_age_days": 30, "action": "purge"}],  # bad action
+        [{"name": "r", "max_age_days": 30, "on_missing_access_signal": "nuke"}],  # bad signal policy
         [{"max_age_days": 30}],  # no name
         [{"name": "r", "max_age_days": "soon"}],  # non-numeric
     ):

--- a/platform-integrations/claude/plugins/evolve-lite/skills/evolve-lite/retention/SKILL.md
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/evolve-lite/retention/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: retention
+description: Apply data-retention rules to the local evolve store — flag or delete stale and unused memories and expired sessions (dry-run by default)
+---
+
+# Retention
+
+## Overview
+
+Runs the data-retention rules configured in `evolve.config.yaml` against the
+local `.evolve/` store: private entities under `.evolve/entities/` and session
+transcripts under `.evolve/trajectories/`. Rules match by entity type plus age
+(`max_age_days`, from file mtime) or disuse (`max_unused_days`, from `recall`
+rows in `.evolve/audit.log`), and either **flag** (a non-destructive frontmatter
+marker) or **delete**. A `delete` rule on trajectories with
+`cascade_derived: true` also deletes the entities derived from those sessions
+(linked by their `trajectory:` frontmatter).
+
+The script is **dry-run by default** — it never mutates anything unless
+`--apply` is passed.
+
+## Workflow
+
+### Step 1: Require rules
+
+Read `evolve.config.yaml`. If there is no `retention:` block with a `rules:`
+list, show the user this example and stop:
+
+```yaml
+retention:
+  rules:
+    - name: stale-guidelines
+      entity_type: guideline
+      max_age_days: 90
+      action: flag
+    - name: old-sessions
+      entity_type: trajectory
+      max_age_days: 365
+      action: delete
+      cascade_derived: true
+```
+
+Each rule needs a `name` and at least one of `max_age_days` /
+`max_unused_days`; `action` is `flag` (default) or `delete`. Rules are checked
+top-to-bottom and the first match wins, so put narrow rules first.
+
+### Step 2: Dry run
+
+From the project root:
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/evolve-lite/retention/scripts/run_retention.py
+```
+
+Show the user the full report — every entry says what *would* be flagged or
+deleted, why (`age`, `unused`, or `cascade:<session>`), by which rule, and on
+what evidence. Relay any `WARNING` lines too: they say when a signal was
+weaker than it looks (for example, disuse measured from file mtime because the
+entity has no recall row).
+
+### Step 3: Apply — only on explicit user confirmation
+
+Deleting is destructive and there is no undo. Ask the user to confirm the
+dry-run report first. Never pass `--apply` without an explicit go-ahead.
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/evolve-lite/retention/scripts/run_retention.py --apply
+```
+
+Relay the applied report back to the user.
+
+## Notes
+
+- **Flag** upserts `retention_flagged_at`, `retention_reason`, and
+  `retention_rule` into the entity's frontmatter; the file's mtime is
+  preserved so its age clock doesn't reset. Trajectory files are opaque JSON,
+  so their flag is recorded in `.evolve/audit.log` only.
+- Every applied action is logged to `.evolve/audit.log` as an
+  `event: "retention"` row.
+- Subscribed entities (`.evolve/entities/subscribed/`) are out of scope — they
+  are git clones owned by the sync skill and local deletes would be restored
+  on the next sync.
+- A standalone policy file can be passed with `--policy <file>` (a `rules:`
+  list in JSON or YAML), overriding the config block.
+- Signal caveats, worth stating when you relay a report: age is **file mtime**
+  (editing an entity resets its clock — there is no `created_at` in the
+  store), and the disuse signal only exists for entities the agent recorded
+  via the recall audit step. The `trajectory:` cascade link is supported but
+  nothing writes it automatically today, so `cascade_derived` only fires for
+  entities where that key was set by hand.

--- a/platform-integrations/claude/plugins/evolve-lite/skills/evolve-lite/retention/SKILL.md
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/evolve-lite/retention/SKILL.md
@@ -42,7 +42,16 @@ retention:
 
 Each rule needs a `name` and at least one of `max_age_days` /
 `max_unused_days`; `action` is `flag` (default) or `delete`. Rules are checked
-top-to-bottom and the first match wins, so put narrow rules first.
+top-to-bottom and the first match wins, so put narrow rules first — and put a
+longer-threshold `delete` before a shorter-threshold `flag` on the same type,
+or the flag shadows the delete and it never fires.
+
+A `delete` rule may also set `on_missing_access_signal` to say what happens when
+an `unused` match has **no recorded recall** (disuse measured from file mtime):
+`skip` (default, fail-safe — spare it and report it as skipped), `flag`
+(downgrade the delete to a non-destructive flag), or `delete` (delete on the
+mtime fallback anyway). The safe default means an `unused` delete never destroys
+a memory the agent simply never recorded a recall for.
 
 ### Step 2: Dry run
 
@@ -52,11 +61,12 @@ From the project root:
 python3 ${CLAUDE_PLUGIN_ROOT}/skills/evolve-lite/retention/scripts/run_retention.py
 ```
 
-Show the user the full report — every entry says what *would* be flagged or
-deleted, why (`age`, `unused`, or `cascade:<session>`), by which rule, and on
-what evidence. Relay any `WARNING` lines too: they say when a signal was
-weaker than it looks (for example, disuse measured from file mtime because the
-entity has no recall row).
+Show the user the full report — every entry says what *would* be flagged,
+deleted, or skipped, why (`age`, `unused`, or `cascade:<session>`), by which
+rule, and on what evidence. `SKIP` lines are entities a `delete` rule matched on
+a degraded signal but spared under `on_missing_access_signal: skip`. Relay any
+`WARNING` lines too: they say when a signal was weaker than it looks (for
+example, disuse measured from file mtime because the entity has no recall row).
 
 ### Step 3: Apply — only on explicit user confirmation
 

--- a/platform-integrations/claude/plugins/evolve-lite/skills/evolve-lite/retention/scripts/run_retention.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/evolve-lite/retention/scripts/run_retention.py
@@ -76,6 +76,10 @@ def main():
     if not report["deleted"] and not report["flagged"]:
         print("  (no memories matched any rule)")
 
+    for action in report.get("skipped", []):
+        print(f"  SKIP   {action['id']}  reason={action['reason']}  rule={action['rule']}")
+        print(f"         why: {action['detail']}")
+
     for warning in report["warnings"]:
         print(f"  WARNING  {warning}")
     for err in report["errors"]:

--- a/platform-integrations/claude/plugins/evolve-lite/skills/evolve-lite/retention/scripts/run_retention.py
+++ b/platform-integrations/claude/plugins/evolve-lite/skills/evolve-lite/retention/scripts/run_retention.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""
+Retention Script
+Applies data-retention rules to the local .evolve store: flags or deletes
+stale / unused memories and expired sessions. Dry-run by default; nothing
+is mutated unless --apply is passed.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+# Walk up from the script location to find the installed plugin lib directory.
+# Every host installs the shared lib under lib/evolve-lite/ so multiple
+# plugins can coexist side by side (e.g. .bob/lib/evolve-lite/).
+_script = Path(__file__).resolve()
+_lib = None
+for _ancestor in _script.parents:
+    _candidate = _ancestor / "lib" / "evolve-lite"
+    if (_candidate / "entity_io.py").is_file():
+        _lib = _candidate
+        break
+if _lib is None:
+    raise ImportError(f"Cannot find plugin lib directory above {_script}")
+sys.path.insert(0, str(_lib))
+from entity_io import get_evolve_dir, log as _log  # noqa: E402
+from config import load_config  # noqa: E402
+import retention  # noqa: E402
+
+
+def log(message):
+    _log("retention", message)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Apply retention rules to the .evolve store (dry-run by default).")
+    parser.add_argument("--apply", action="store_true", help="Actually flag/delete. Without this flag, only report.")
+    parser.add_argument("--policy", default=None, help="Standalone policy file (JSON or YAML 'rules:' list) overriding evolve.config.yaml.")
+    args = parser.parse_args()
+
+    try:
+        if args.policy:
+            rules = retention.load_policy_file(args.policy)
+        else:
+            rules = retention.load_rules(load_config())
+    except (ValueError, OSError) as exc:
+        log(f"Invalid retention rules: {exc}")
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if not rules:
+        print(
+            "No retention rules configured. Add a `retention:` block with a `rules:` list to evolve.config.yaml (or pass --policy <file>)."
+        )
+        sys.exit(0)
+
+    evolve_dir = get_evolve_dir()
+    if not evolve_dir.is_dir():
+        print(f"No evolve store at {evolve_dir}; nothing to do.")
+        sys.exit(0)
+    evolve_dir = evolve_dir.resolve()
+
+    dry_run = not args.apply
+    report = retention.run(evolve_dir, rules, dry_run=dry_run)
+    log(f"{'DRY RUN' if dry_run else 'APPLY'}: {retention.summary(report)}")
+
+    if dry_run:
+        print("DRY RUN — nothing was changed. Re-run with --apply to enforce.")
+    else:
+        print("APPLIED:")
+
+    for action in [*report["deleted"], *report["flagged"]]:
+        verb = action["action"].upper()
+        print(f"  {verb:6} {action['id']}  reason={action['reason']}  rule={action['rule']}")
+        print(f"         why: {action['detail']}")
+    if not report["deleted"] and not report["flagged"]:
+        print("  (no memories matched any rule)")
+
+    for warning in report["warnings"]:
+        print(f"  WARNING  {warning}")
+    for err in report["errors"]:
+        print(f"  ERROR  {err}", file=sys.stderr)
+
+    print(retention.summary(report))
+    sys.exit(1 if report["errors"] else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/platform-integrations/claw-code/plugins/evolve-lite/lib/evolve-lite/retention.py
+++ b/platform-integrations/claw-code/plugins/evolve-lite/lib/evolve-lite/retention.py
@@ -1,0 +1,525 @@
+"""Data retention for the evolve-lite plugin store (issue #275).
+
+Mirrors the ``altk_evolve/retention/`` semantics against the plugin's
+``.evolve/`` file store: age-based and unused-based rules that **flag** or
+**delete**, dry-run by default, and the session -> derived cascade. Stdlib-only,
+because plugin scripts run in the host's Python where nothing beyond the
+standard library is guaranteed.
+
+The plugin store is markdown files, not a backend with per-entity metadata, so
+the package's signals map onto what the files actually carry. Each mapping is
+weaker than its package-side counterpart — the gaps are called out here and in
+``docs/guides/retention.md``:
+
+- **age** — file mtime. Plugin entities carry no ``created_at`` frontmatter, so
+  mtime is the only available clock. It is a *modification* time, not a birth
+  time: editing an entity resets its age. (Flagging deliberately restores the
+  mtime so the sweep itself never resets the clock — see below.)
+- **unused** — the latest ``recall`` row in ``.evolve/audit.log`` naming the
+  entity id (``<type>/<name>``, the id scheme ``audit_recall.py`` logs and
+  ``EVOLVE.md`` instructs the agent to pass), falling back to file mtime when
+  an entity was never recalled. This is the plugin's answer to the package's
+  ``metadata.last_accessed``, and it has the same failure mode: it only exists
+  if something records the recall. Package-side that is ``AccessStampPlugin``
+  (automatic); plugin-side it is a model-invoked ``audit_recall.py`` call — so
+  the signal is only as complete as the agent's compliance with EVOLVE.md.
+- **cascade** — the package links a derived memory to its session via
+  ``metadata.source_task_id == trace_id``. Plugin-side the equivalent link is a
+  ``trajectory:`` frontmatter key naming the session file under
+  ``.evolve/trajectories/``; a ``cascade_derived`` delete of a trajectory also
+  deletes entities whose link resolves to it (matched by filename — trajectory
+  filenames embed a timestamp + session id and are unique by construction).
+  **Known gap: nothing in the shipped plugin writes that key today.**
+  ``entity_io._FRONTMATTER_KEYS`` supports it and it is preserved on round-trip,
+  but neither the save flow nor ``adapt-memory`` populates it, so in practice
+  the plugin-side cascade only fires for entities whose ``trajectory:`` key was
+  written by hand or by a downstream tool. Deleting a session therefore does
+  *not* by itself clean up the memories derived from it the way the package
+  side does.
+
+Actions:
+
+- **flag** — upsert ``retention_flagged_at`` / ``retention_reason`` /
+  ``retention_rule`` into the entity's frontmatter (non-destructive; the file's
+  mtime is preserved so the age clock does not reset). Trajectory files are
+  opaque JSON with no frontmatter, so their flag lives in the audit log only.
+- **delete** — unlink the file.
+
+Every applied (non-dry-run) action also appends an ``event: "retention"`` row
+to ``.evolve/audit.log`` for auditability.
+
+Scope: private entities under ``.evolve/entities/`` — excluding
+``entities/subscribed/`` (git clones managed by the sync skill; local deletes
+there would be clobbered by the next sync) — plus session files under
+``.evolve/trajectories/``.
+
+Rules load from a ``retention:`` block in ``evolve.config.yaml``::
+
+    retention:
+      rules:
+        - name: stale-guidelines
+          entity_type: guideline
+          max_age_days: 90
+          action: flag
+        - name: old-sessions
+          entity_type: trajectory
+          max_age_days: 365
+          action: delete
+          cascade_derived: true
+"""
+
+import datetime
+import json
+import os
+from pathlib import Path
+
+VALID_ACTIONS = ("flag", "delete")
+
+#: How the trajectory tree is typed in rules (matches the package's
+#: ``entity_type: trajectory`` convention).
+TRAJECTORY_TYPE = "trajectory"
+
+
+# ---------------------------------------------------------------------------
+# Rules
+# ---------------------------------------------------------------------------
+
+
+def validate_rules(raw_rules):
+    """Validate a raw ``rules`` list into normalized rule dicts.
+
+    Mirrors the package's ``RetentionRule`` schema: every rule needs a ``name``
+    and at least one of ``max_age_days`` / ``max_unused_days``; ``action``
+    defaults to ``flag``. Raises ``ValueError`` on the first invalid rule.
+    """
+    if raw_rules is None:
+        return []
+    if not isinstance(raw_rules, list):
+        raise ValueError("retention rules must be a list")
+    rules = []
+    for raw in raw_rules:
+        if not isinstance(raw, dict):
+            raise ValueError(f"retention rule must be a mapping, got {type(raw).__name__}")
+        name = raw.get("name")
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError("retention rule must have a non-empty string 'name'")
+        rule = {
+            "name": name.strip(),
+            "entity_type": None,
+            "max_age_days": _coerce_days(raw.get("max_age_days"), name, "max_age_days"),
+            "max_unused_days": _coerce_days(raw.get("max_unused_days"), name, "max_unused_days"),
+            "action": raw.get("action", "flag"),
+            "cascade_derived": bool(raw.get("cascade_derived", False)),
+        }
+        entity_type = raw.get("entity_type")
+        if entity_type is not None:
+            if not isinstance(entity_type, str) or not entity_type.strip():
+                raise ValueError(f"retention rule {name!r}: entity_type must be a non-empty string")
+            rule["entity_type"] = entity_type.strip()
+        if rule["max_age_days"] is None and rule["max_unused_days"] is None:
+            raise ValueError(f"retention rule {name!r} must set max_age_days and/or max_unused_days")
+        if rule["action"] not in VALID_ACTIONS:
+            raise ValueError(f"retention rule {name!r}: action must be one of {VALID_ACTIONS}, got {rule['action']!r}")
+        rules.append(rule)
+    return rules
+
+
+def _coerce_days(value, rule_name, key):
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"retention rule {rule_name!r}: {key} must be a number, got {value!r}")
+    if value < 0:
+        raise ValueError(f"retention rule {rule_name!r}: {key} must be >= 0")
+    return float(value)
+
+
+def load_rules(config):
+    """Return validated rules from an evolve config dict's ``retention:`` block.
+
+    Returns ``[]`` when no block / no rules are configured.
+    """
+    retention_cfg = (config or {}).get("retention") or {}
+    if not isinstance(retention_cfg, dict):
+        raise ValueError("'retention' config block must be a mapping")
+    return validate_rules(retention_cfg.get("rules"))
+
+
+def load_policy_file(path):
+    """Load rules from a standalone policy file (JSON, or the same minimal
+    YAML subset ``evolve.config.yaml`` uses). The file holds a top-level
+    ``rules:`` list, like the package's ``retention.example.yaml``."""
+    text = Path(path).read_text(encoding="utf-8")
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        from config import _parse_yaml  # sibling lib module; resolved via sys.path
+
+        data = _parse_yaml(text)
+    if not isinstance(data, dict):
+        raise ValueError(f"policy file {path} must hold a mapping with a 'rules' list")
+    return validate_rules(data.get("rules"))
+
+
+# ---------------------------------------------------------------------------
+# Store scan
+# ---------------------------------------------------------------------------
+
+
+def _utc(dt):
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=datetime.timezone.utc)
+    return dt
+
+
+def _parse_iso(value):
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return _utc(datetime.datetime.fromisoformat(value.replace("Z", "+00:00")))
+    except ValueError:
+        return None
+
+
+def _mtime(path):
+    return datetime.datetime.fromtimestamp(path.stat().st_mtime, tz=datetime.timezone.utc)
+
+
+def _frontmatter(path):
+    """Parse simple ``key: value`` frontmatter lines from a markdown file."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return {}
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}
+    out = {}
+    for line in lines[1:]:
+        if line.strip() == "---":
+            return out
+        key, _, value = line.partition(":")
+        key, value = key.strip(), value.strip()
+        if key and value:
+            out[key] = value
+    return {}
+
+
+def scan_store(evolve_dir):
+    """Return one item dict per retention-eligible file in the store.
+
+    Items are shaped ``{id, type, path, mtime, trajectory_link}`` where
+    ``trajectory_link`` is the filename of the session the entity was derived
+    from (via its ``trajectory:`` frontmatter), or ``None``.
+    """
+    evolve_dir = Path(evolve_dir)
+    items = []
+
+    entities_root = evolve_dir / "entities"
+    if entities_root.is_dir():
+        for md in sorted(entities_root.glob("**/*.md")):
+            rel = md.relative_to(entities_root)
+            # subscribed/ trees are git clones owned by the sync skill; local
+            # deletes there would be silently restored by the next sync.
+            if rel.parts and rel.parts[0] == "subscribed":
+                continue
+            if md.is_symlink() or ".git" in rel.parts:
+                continue
+            meta = _frontmatter(md)
+            link = meta.get("trajectory")
+            items.append(
+                {
+                    "id": rel.with_suffix("").as_posix(),
+                    "type": meta.get("type") or (rel.parts[0] if len(rel.parts) > 1 else "guideline"),
+                    "path": md,
+                    "mtime": _mtime(md),
+                    "trajectory_link": Path(link).name if link else None,
+                }
+            )
+
+    traj_root = evolve_dir / "trajectories"
+    if traj_root.is_dir():
+        for traj in sorted(traj_root.iterdir()):
+            if not traj.is_file() or traj.is_symlink():
+                continue
+            items.append(
+                {
+                    "id": f"trajectories/{traj.name}",
+                    "type": TRAJECTORY_TYPE,
+                    "path": traj,
+                    "mtime": _mtime(traj),
+                    "trajectory_link": None,
+                }
+            )
+
+    return items
+
+
+def last_access_index(evolve_dir):
+    """Map entity id -> latest ``recall`` timestamp from ``.evolve/audit.log``.
+
+    This is the plugin's "unused" signal: ``audit_recall.py`` appends a recall
+    row (with ``entities: ["<type>/<name>", ...]``) when the agent records the
+    memories it consulted, mirroring what ``AccessStampPlugin`` /
+    ``EvolveClient.record_access`` stamp as ``metadata.last_accessed``
+    package-side. Unlike the package's hook, this one is model-invoked, so an
+    entity's absence from the index means "no recorded recall", not "not used".
+    """
+    audit_log = Path(evolve_dir) / "audit.log"
+    index = {}
+    if not audit_log.is_file():
+        return index
+    for line in audit_log.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(row, dict) or row.get("event") != "recall":
+            continue
+        ts = _parse_iso(row.get("ts"))
+        if ts is None:
+            continue
+        for eid in row.get("entities") or []:
+            if isinstance(eid, str) and eid:
+                prev = index.get(eid)
+                if prev is None or ts > prev:
+                    index[eid] = ts
+    return index
+
+
+# ---------------------------------------------------------------------------
+# Evaluation (mirrors altk_evolve.retention.engine.RetentionEngine.evaluate)
+# ---------------------------------------------------------------------------
+
+
+#: Appended to the "why" of an unused-rule match with no recorded recall.
+NO_RECALL_SIGNAL_HINT = (
+    "no recall row in .evolve/audit.log for this entity, so disuse was measured from file mtime; "
+    "the recall audit is model-invoked, so treat a never-recalled verdict as 'never recorded'"
+)
+
+
+def _match(item, rule, now, last_access):
+    """Return ``(reason, detail)`` if *rule* matches *item*, else None.
+
+    ``reason`` is 'age' or 'unused'; ``detail`` is the human-readable why,
+    including which signal was used and whether it fell back.
+    """
+    if rule["entity_type"] is not None and item["type"] != rule["entity_type"]:
+        return None
+    age_days = (now - item["mtime"]).total_seconds() / 86400.0
+    if rule["max_age_days"] is not None and age_days > rule["max_age_days"]:
+        return "age", "modified {:.1f}d ago > max_age_days={} (from file mtime)".format(age_days, rule["max_age_days"])
+    if rule["max_unused_days"] is not None:
+        recorded = last_access.get(item["id"])
+        last = recorded or item["mtime"]
+        unused_days = (now - last).total_seconds() / 86400.0
+        if unused_days > rule["max_unused_days"]:
+            detail = "not recalled for {:.1f}d > max_unused_days={}".format(unused_days, rule["max_unused_days"])
+            detail += " (from the recall audit log)" if recorded else " — " + NO_RECALL_SIGNAL_HINT
+            return "unused", detail
+    return None
+
+
+def evaluate(evolve_dir, rules, now=None, warnings=None):
+    """Compute the actions the rules imply, without mutating anything.
+
+    Returns a list of ``{id, type, action, reason, rule, detail, path}`` dicts.
+    First matching rule wins per item; delete supersedes flag; a delete rule
+    with ``cascade_derived`` on a trajectory also deletes the entities whose
+    ``trajectory:`` frontmatter links back to it.
+
+    When *warnings* is a list, non-fatal caveats about the run (e.g. a degraded
+    "unused" signal) are appended to it.
+    """
+    now = _utc(now) if now else datetime.datetime.now(datetime.timezone.utc)
+    items = scan_store(evolve_dir)
+    last_access = last_access_index(evolve_dir)
+
+    # Provenance index: trajectory filename -> [derived items]
+    derived_by_name = {}
+    for item in items:
+        link = item["trajectory_link"]
+        if link:
+            derived_by_name.setdefault(link, []).append(item)
+
+    # delete supersedes flag for the same item; first writer otherwise wins.
+    actions = {}
+
+    def record(item, action, reason, rule_name, detail):
+        existing = actions.get(item["id"])
+        if existing is not None and (existing["action"] == "delete" or action == "flag"):
+            return
+        actions[item["id"]] = {
+            "id": item["id"],
+            "type": item["type"],
+            "action": action,
+            "reason": reason,
+            "rule": rule_name,
+            "detail": detail,
+            "path": item["path"],
+        }
+
+    unrecalled = 0
+    uses_unused_rule = any(r["max_unused_days"] is not None for r in rules)
+
+    for item in items:
+        if uses_unused_rule and item["id"] not in last_access:
+            unrecalled += 1
+
+        matched = None
+        for rule in rules:
+            hit = _match(item, rule, now, last_access)
+            if hit is not None:
+                matched = (rule, hit[0], hit[1])
+                break
+        if matched is None:
+            continue
+        rule, reason, detail = matched
+        record(item, rule["action"], reason, rule["name"], detail)
+
+        if rule["action"] == "delete" and rule["cascade_derived"] and item["type"] == TRAJECTORY_TYPE:
+            for derived in derived_by_name.get(item["path"].name, []):
+                if derived["id"] == item["id"]:
+                    continue
+                record(
+                    derived,
+                    "delete",
+                    f"cascade:{item['path'].name}",
+                    rule["name"],
+                    f"trajectory: frontmatter links it to session {item['path'].name}, which this rule deletes",
+                )
+
+    if warnings is not None and unrecalled:
+        warnings.append(
+            f"{unrecalled} of {len(items)} store entries have no recall row in .evolve/audit.log, so their "
+            "disuse was measured from file mtime — for those, an unused rule behaves like an age rule."
+        )
+
+    return list(actions.values())
+
+
+# ---------------------------------------------------------------------------
+# Application
+# ---------------------------------------------------------------------------
+
+
+def _flag_entity_file(path, flagged_at, reason, rule_name):
+    """Upsert retention_* markers into an entity file's frontmatter.
+
+    Preserves the file's mtime so flagging does not reset the age clock.
+    """
+    path = Path(path)
+    st = path.stat()
+    text = path.read_text(encoding="utf-8")
+    marker = [
+        f"retention_flagged_at: {flagged_at}",
+        f"retention_reason: {reason}",
+        f"retention_rule: {rule_name}",
+    ]
+    lines = text.splitlines()
+    closing = None
+    if lines and lines[0].strip() == "---":
+        for i in range(1, len(lines)):
+            if lines[i].strip() == "---":
+                closing = i
+                break
+    if closing is not None:
+        head = [ln for ln in lines[1:closing] if not ln.strip().startswith("retention_")]
+        new_lines = [lines[0], *head, *marker, *lines[closing:]]
+    else:
+        # No frontmatter (shouldn't happen for entities we wrote) — prepend one.
+        new_lines = ["---", *marker, "---", "", *lines]
+    new_text = "\n".join(new_lines)
+    if text.endswith("\n"):
+        new_text += "\n"
+    path.write_text(new_text, encoding="utf-8")
+    os.utime(path, (st.st_atime, st.st_mtime))
+
+
+def apply_actions(evolve_dir, actions, dry_run=True, now=None, warnings=None):
+    """Apply (or, on dry run, merely report) a list of evaluated actions.
+
+    Returns ``{dry_run, flagged, deleted, errors, warnings}`` where
+    flagged/deleted hold the action dicts and errors/warnings hold strings.
+    Non-dry-run actions each append an ``event: "retention"`` row to the audit
+    log.
+    """
+    now = _utc(now) if now else datetime.datetime.now(datetime.timezone.utc)
+    flagged_at = now.isoformat()
+    report = {"dry_run": dry_run, "flagged": [], "deleted": [], "errors": [], "warnings": list(warnings or [])}
+
+    for action in actions:
+        try:
+            if action["action"] == "delete":
+                if not dry_run:
+                    Path(action["path"]).unlink(missing_ok=True)
+                    _audit(evolve_dir, action)
+                report["deleted"].append(action)
+            else:  # flag
+                if not dry_run:
+                    if action["type"] != TRAJECTORY_TYPE:
+                        _flag_entity_file(action["path"], flagged_at, action["reason"], action["rule"])
+                    # Trajectory files are opaque JSON — no frontmatter to mark;
+                    # the audit row below is their durable flag record.
+                    _audit(evolve_dir, action)
+                report["flagged"].append(action)
+        except OSError as exc:  # don't let one bad file abort the sweep
+            report["errors"].append(f"{action['action']} {action['id']}: {exc}")
+
+    return report
+
+
+def _audit(evolve_dir, action):
+    import audit  # sibling lib module; resolved via sys.path
+
+    audit.append(
+        evolve_dir=str(evolve_dir),
+        event="retention",
+        action=action["action"],
+        entity=action["id"],
+        reason=action["reason"],
+        rule=action["rule"],
+    )
+
+
+def run(evolve_dir, rules, dry_run=True, now=None):
+    """Evaluate the rules against the store and apply (or dry-run) the result."""
+    warnings = []
+    actions = evaluate(evolve_dir, rules, now=now, warnings=warnings)
+    return apply_actions(evolve_dir, actions, dry_run=dry_run, now=now, warnings=warnings)
+
+
+def summary(report):
+    verb = "would flag/delete" if report["dry_run"] else "flagged/deleted"
+    return f"{verb}: {len(report['flagged'])} flagged, {len(report['deleted'])} deleted, {len(report['errors'])} errors"
+
+
+if __name__ == "__main__":
+    # Self-test (pure paths only; file behavior is covered by pytest).
+    assert load_rules({}) == []
+    assert load_rules({"retention": {"rules": []}}) == []
+
+    rules = validate_rules([{"name": "r", "max_age_days": 30}])
+    assert rules[0]["action"] == "flag"  # default
+    assert rules[0]["max_age_days"] == 30.0
+
+    for bad in (
+        [{"name": "r"}],  # no threshold
+        [{"name": "r", "max_age_days": 30, "action": "purge"}],  # bad action
+        [{"max_age_days": 30}],  # no name
+        [{"name": "r", "max_age_days": "soon"}],  # non-numeric
+    ):
+        try:
+            validate_rules(bad)
+        except ValueError:
+            pass
+        else:  # pragma: no cover
+            raise AssertionError(f"expected ValueError for {bad}")
+
+    assert _parse_iso("2026-06-29T00:00:00Z") is not None
+    assert _parse_iso("not-a-date") is None
+    assert _parse_iso(None) is None
+    print("retention.py ok")

--- a/platform-integrations/claw-code/plugins/evolve-lite/lib/evolve-lite/retention.py
+++ b/platform-integrations/claw-code/plugins/evolve-lite/lib/evolve-lite/retention.py
@@ -75,6 +75,13 @@ from pathlib import Path
 
 VALID_ACTIONS = ("flag", "delete")
 
+#: What a delete rule does when an "unused" match has no recorded recall (disuse
+#: fell back to file mtime). Mirrors the package's RetentionRule field of the
+#: same name. "skip" (default, fail-safe) spares the entity and reports it;
+#: "flag" downgrades the delete to a non-destructive flag; "delete" deletes on
+#: the mtime fallback (the original behaviour).
+VALID_MISSING_SIGNAL = ("skip", "flag", "delete")
+
 #: How the trajectory tree is typed in rules (matches the package's
 #: ``entity_type: trajectory`` convention).
 TRAJECTORY_TYPE = "trajectory"
@@ -109,6 +116,7 @@ def validate_rules(raw_rules):
             "max_age_days": _coerce_days(raw.get("max_age_days"), name, "max_age_days"),
             "max_unused_days": _coerce_days(raw.get("max_unused_days"), name, "max_unused_days"),
             "action": raw.get("action", "flag"),
+            "on_missing_access_signal": raw.get("on_missing_access_signal", "skip"),
             "cascade_derived": bool(raw.get("cascade_derived", False)),
         }
         entity_type = raw.get("entity_type")
@@ -120,6 +128,11 @@ def validate_rules(raw_rules):
             raise ValueError(f"retention rule {name!r} must set max_age_days and/or max_unused_days")
         if rule["action"] not in VALID_ACTIONS:
             raise ValueError(f"retention rule {name!r}: action must be one of {VALID_ACTIONS}, got {rule['action']!r}")
+        if rule["on_missing_access_signal"] not in VALID_MISSING_SIGNAL:
+            raise ValueError(
+                f"retention rule {name!r}: on_missing_access_signal must be one of {VALID_MISSING_SIGNAL}, "
+                f"got {rule['on_missing_access_signal']!r}"
+            )
         rules.append(rule)
     return rules
 
@@ -302,16 +315,19 @@ NO_RECALL_SIGNAL_HINT = (
 
 
 def _match(item, rule, now, last_access):
-    """Return ``(reason, detail)`` if *rule* matches *item*, else None.
+    """Return ``(reason, detail, degraded)`` if *rule* matches *item*, else None.
 
     ``reason`` is 'age' or 'unused'; ``detail`` is the human-readable why,
-    including which signal was used and whether it fell back.
+    including which signal was used and whether it fell back. ``degraded`` is
+    True only for an 'unused' match whose disuse was measured from file mtime
+    because no recall row existed — ``on_missing_access_signal`` governs whether
+    such a match may still delete.
     """
     if rule["entity_type"] is not None and item["type"] != rule["entity_type"]:
         return None
     age_days = (now - item["mtime"]).total_seconds() / 86400.0
     if rule["max_age_days"] is not None and age_days > rule["max_age_days"]:
-        return "age", "modified {:.1f}d ago > max_age_days={} (from file mtime)".format(age_days, rule["max_age_days"])
+        return "age", "modified {:.1f}d ago > max_age_days={} (from file mtime)".format(age_days, rule["max_age_days"]), False
     if rule["max_unused_days"] is not None:
         recorded = last_access.get(item["id"])
         last = recorded or item["mtime"]
@@ -319,11 +335,11 @@ def _match(item, rule, now, last_access):
         if unused_days > rule["max_unused_days"]:
             detail = "not recalled for {:.1f}d > max_unused_days={}".format(unused_days, rule["max_unused_days"])
             detail += " (from the recall audit log)" if recorded else " — " + NO_RECALL_SIGNAL_HINT
-            return "unused", detail
+            return "unused", detail, not recorded
     return None
 
 
-def evaluate(evolve_dir, rules, now=None, warnings=None):
+def evaluate(evolve_dir, rules, now=None, warnings=None, skipped=None):
     """Compute the actions the rules imply, without mutating anything.
 
     Returns a list of ``{id, type, action, reason, rule, detail, path}`` dicts.
@@ -332,7 +348,9 @@ def evaluate(evolve_dir, rules, now=None, warnings=None):
     ``trajectory:`` frontmatter links back to it.
 
     When *warnings* is a list, non-fatal caveats about the run (e.g. a degraded
-    "unused" signal) are appended to it.
+    "unused" signal) are appended to it. When *skipped* is a list, items a
+    delete rule matched on a degraded signal but was spared under
+    ``on_missing_access_signal: skip`` are appended to it.
     """
     now = _utc(now) if now else datetime.datetime.now(datetime.timezone.utc)
     items = scan_store(evolve_dir)
@@ -373,14 +391,40 @@ def evaluate(evolve_dir, rules, now=None, warnings=None):
         for rule in rules:
             hit = _match(item, rule, now, last_access)
             if hit is not None:
-                matched = (rule, hit[0], hit[1])
+                matched = (rule, hit[0], hit[1], hit[2])
                 break
         if matched is None:
             continue
-        rule, reason, detail = matched
-        record(item, rule["action"], reason, rule["name"], detail)
+        rule, reason, detail, degraded = matched
 
-        if rule["action"] == "delete" and rule["cascade_derived"] and item["type"] == TRAJECTORY_TYPE:
+        action = rule["action"]
+        # A degraded "unused" match (no recall row, disuse from file mtime) only
+        # reaches a destructive action when the rule opts in. Default "skip"
+        # spares it; "flag" downgrades the delete; "delete" keeps the old
+        # behaviour. Only bites deletes — a flag action is not data loss.
+        if degraded and rule["action"] == "delete":
+            choice = rule["on_missing_access_signal"]
+            if choice == "skip":
+                if skipped is not None:
+                    skipped.append(
+                        {
+                            "id": item["id"],
+                            "type": item["type"],
+                            "action": "skip",
+                            "reason": reason,
+                            "rule": rule["name"],
+                            "detail": "matched but not deleted: {}; on_missing_access_signal=skip".format(detail),
+                            "path": item["path"],
+                        }
+                    )
+                continue
+            if choice == "flag":
+                action = "flag"
+                detail += "; downgraded delete->flag (on_missing_access_signal=flag)"
+
+        record(item, action, reason, rule["name"], detail)
+
+        if action == "delete" and rule["cascade_derived"] and item["type"] == TRAJECTORY_TYPE:
             for derived in derived_by_name.get(item["path"].name, []):
                 if derived["id"] == item["id"]:
                     continue
@@ -439,17 +483,24 @@ def _flag_entity_file(path, flagged_at, reason, rule_name):
     os.utime(path, (st.st_atime, st.st_mtime))
 
 
-def apply_actions(evolve_dir, actions, dry_run=True, now=None, warnings=None):
+def apply_actions(evolve_dir, actions, dry_run=True, now=None, warnings=None, skipped=None):
     """Apply (or, on dry run, merely report) a list of evaluated actions.
 
-    Returns ``{dry_run, flagged, deleted, errors, warnings}`` where
-    flagged/deleted hold the action dicts and errors/warnings hold strings.
+    Returns ``{dry_run, flagged, deleted, skipped, errors, warnings}`` where
+    flagged/deleted/skipped hold action dicts and errors/warnings hold strings.
     Non-dry-run actions each append an ``event: "retention"`` row to the audit
     log.
     """
     now = _utc(now) if now else datetime.datetime.now(datetime.timezone.utc)
     flagged_at = now.isoformat()
-    report = {"dry_run": dry_run, "flagged": [], "deleted": [], "errors": [], "warnings": list(warnings or [])}
+    report = {
+        "dry_run": dry_run,
+        "flagged": [],
+        "deleted": [],
+        "skipped": list(skipped or []),
+        "errors": [],
+        "warnings": list(warnings or []),
+    }
 
     for action in actions:
         try:
@@ -488,13 +539,17 @@ def _audit(evolve_dir, action):
 def run(evolve_dir, rules, dry_run=True, now=None):
     """Evaluate the rules against the store and apply (or dry-run) the result."""
     warnings = []
-    actions = evaluate(evolve_dir, rules, now=now, warnings=warnings)
-    return apply_actions(evolve_dir, actions, dry_run=dry_run, now=now, warnings=warnings)
+    skipped = []
+    actions = evaluate(evolve_dir, rules, now=now, warnings=warnings, skipped=skipped)
+    return apply_actions(evolve_dir, actions, dry_run=dry_run, now=now, warnings=warnings, skipped=skipped)
 
 
 def summary(report):
     verb = "would flag/delete" if report["dry_run"] else "flagged/deleted"
-    return f"{verb}: {len(report['flagged'])} flagged, {len(report['deleted'])} deleted, {len(report['errors'])} errors"
+    out = f"{verb}: {len(report['flagged'])} flagged, {len(report['deleted'])} deleted, {len(report['errors'])} errors"
+    if report.get("skipped"):
+        out += f", {len(report['skipped'])} skipped (degraded signal)"
+    return out
 
 
 if __name__ == "__main__":
@@ -504,11 +559,13 @@ if __name__ == "__main__":
 
     rules = validate_rules([{"name": "r", "max_age_days": 30}])
     assert rules[0]["action"] == "flag"  # default
+    assert rules[0]["on_missing_access_signal"] == "skip"  # fail-safe default
     assert rules[0]["max_age_days"] == 30.0
 
     for bad in (
         [{"name": "r"}],  # no threshold
         [{"name": "r", "max_age_days": 30, "action": "purge"}],  # bad action
+        [{"name": "r", "max_age_days": 30, "on_missing_access_signal": "nuke"}],  # bad signal policy
         [{"max_age_days": 30}],  # no name
         [{"name": "r", "max_age_days": "soon"}],  # non-numeric
     ):

--- a/platform-integrations/claw-code/plugins/evolve-lite/skills/evolve-lite/retention/SKILL.md
+++ b/platform-integrations/claw-code/plugins/evolve-lite/skills/evolve-lite/retention/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: retention
+description: Apply data-retention rules to the local evolve store — flag or delete stale and unused memories and expired sessions (dry-run by default)
+---
+
+# Retention
+
+## Overview
+
+Runs the data-retention rules configured in `evolve.config.yaml` against the
+local `.evolve/` store: private entities under `.evolve/entities/` and session
+transcripts under `.evolve/trajectories/`. Rules match by entity type plus age
+(`max_age_days`, from file mtime) or disuse (`max_unused_days`, from `recall`
+rows in `.evolve/audit.log`), and either **flag** (a non-destructive frontmatter
+marker) or **delete**. A `delete` rule on trajectories with
+`cascade_derived: true` also deletes the entities derived from those sessions
+(linked by their `trajectory:` frontmatter).
+
+The script is **dry-run by default** — it never mutates anything unless
+`--apply` is passed.
+
+## Workflow
+
+### Step 1: Require rules
+
+Read `evolve.config.yaml`. If there is no `retention:` block with a `rules:`
+list, show the user this example and stop:
+
+```yaml
+retention:
+  rules:
+    - name: stale-guidelines
+      entity_type: guideline
+      max_age_days: 90
+      action: flag
+    - name: old-sessions
+      entity_type: trajectory
+      max_age_days: 365
+      action: delete
+      cascade_derived: true
+```
+
+Each rule needs a `name` and at least one of `max_age_days` /
+`max_unused_days`; `action` is `flag` (default) or `delete`. Rules are checked
+top-to-bottom and the first match wins, so put narrow rules first.
+
+### Step 2: Dry run
+
+From the project root:
+
+```bash
+sh -lc 'real_home="$(python3 -c "import os,pwd; print(pwd.getpwuid(os.getuid()).pw_dir)")"; config_home="${CLAW_CONFIG_HOME:-$real_home/.claw}"; script=".claw/skills/evolve-lite:retention/scripts/run_retention.py"; [ -f "$script" ] || script="$config_home/skills/evolve-lite:retention/scripts/run_retention.py"; python3 "$script"'
+```
+
+Show the user the full report — every entry says what *would* be flagged or
+deleted, why (`age`, `unused`, or `cascade:<session>`), by which rule, and on
+what evidence. Relay any `WARNING` lines too: they say when a signal was
+weaker than it looks (for example, disuse measured from file mtime because the
+entity has no recall row).
+
+### Step 3: Apply — only on explicit user confirmation
+
+Deleting is destructive and there is no undo. Ask the user to confirm the
+dry-run report first. Never pass `--apply` without an explicit go-ahead.
+
+```bash
+sh -lc 'real_home="$(python3 -c "import os,pwd; print(pwd.getpwuid(os.getuid()).pw_dir)")"; config_home="${CLAW_CONFIG_HOME:-$real_home/.claw}"; script=".claw/skills/evolve-lite:retention/scripts/run_retention.py"; [ -f "$script" ] || script="$config_home/skills/evolve-lite:retention/scripts/run_retention.py"; python3 "$script" --apply'
+```
+
+Relay the applied report back to the user.
+
+## Notes
+
+- **Flag** upserts `retention_flagged_at`, `retention_reason`, and
+  `retention_rule` into the entity's frontmatter; the file's mtime is
+  preserved so its age clock doesn't reset. Trajectory files are opaque JSON,
+  so their flag is recorded in `.evolve/audit.log` only.
+- Every applied action is logged to `.evolve/audit.log` as an
+  `event: "retention"` row.
+- Subscribed entities (`.evolve/entities/subscribed/`) are out of scope — they
+  are git clones owned by the sync skill and local deletes would be restored
+  on the next sync.
+- A standalone policy file can be passed with `--policy <file>` (a `rules:`
+  list in JSON or YAML), overriding the config block.
+- Signal caveats, worth stating when you relay a report: age is **file mtime**
+  (editing an entity resets its clock — there is no `created_at` in the
+  store), and the disuse signal only exists for entities the agent recorded
+  via the recall audit step. The `trajectory:` cascade link is supported but
+  nothing writes it automatically today, so `cascade_derived` only fires for
+  entities where that key was set by hand.

--- a/platform-integrations/claw-code/plugins/evolve-lite/skills/evolve-lite/retention/SKILL.md
+++ b/platform-integrations/claw-code/plugins/evolve-lite/skills/evolve-lite/retention/SKILL.md
@@ -42,7 +42,16 @@ retention:
 
 Each rule needs a `name` and at least one of `max_age_days` /
 `max_unused_days`; `action` is `flag` (default) or `delete`. Rules are checked
-top-to-bottom and the first match wins, so put narrow rules first.
+top-to-bottom and the first match wins, so put narrow rules first — and put a
+longer-threshold `delete` before a shorter-threshold `flag` on the same type,
+or the flag shadows the delete and it never fires.
+
+A `delete` rule may also set `on_missing_access_signal` to say what happens when
+an `unused` match has **no recorded recall** (disuse measured from file mtime):
+`skip` (default, fail-safe — spare it and report it as skipped), `flag`
+(downgrade the delete to a non-destructive flag), or `delete` (delete on the
+mtime fallback anyway). The safe default means an `unused` delete never destroys
+a memory the agent simply never recorded a recall for.
 
 ### Step 2: Dry run
 
@@ -52,11 +61,12 @@ From the project root:
 sh -lc 'real_home="$(python3 -c "import os,pwd; print(pwd.getpwuid(os.getuid()).pw_dir)")"; config_home="${CLAW_CONFIG_HOME:-$real_home/.claw}"; script=".claw/skills/evolve-lite:retention/scripts/run_retention.py"; [ -f "$script" ] || script="$config_home/skills/evolve-lite:retention/scripts/run_retention.py"; python3 "$script"'
 ```
 
-Show the user the full report — every entry says what *would* be flagged or
-deleted, why (`age`, `unused`, or `cascade:<session>`), by which rule, and on
-what evidence. Relay any `WARNING` lines too: they say when a signal was
-weaker than it looks (for example, disuse measured from file mtime because the
-entity has no recall row).
+Show the user the full report — every entry says what *would* be flagged,
+deleted, or skipped, why (`age`, `unused`, or `cascade:<session>`), by which
+rule, and on what evidence. `SKIP` lines are entities a `delete` rule matched on
+a degraded signal but spared under `on_missing_access_signal: skip`. Relay any
+`WARNING` lines too: they say when a signal was weaker than it looks (for
+example, disuse measured from file mtime because the entity has no recall row).
 
 ### Step 3: Apply — only on explicit user confirmation
 

--- a/platform-integrations/claw-code/plugins/evolve-lite/skills/evolve-lite/retention/scripts/run_retention.py
+++ b/platform-integrations/claw-code/plugins/evolve-lite/skills/evolve-lite/retention/scripts/run_retention.py
@@ -76,6 +76,10 @@ def main():
     if not report["deleted"] and not report["flagged"]:
         print("  (no memories matched any rule)")
 
+    for action in report.get("skipped", []):
+        print(f"  SKIP   {action['id']}  reason={action['reason']}  rule={action['rule']}")
+        print(f"         why: {action['detail']}")
+
     for warning in report["warnings"]:
         print(f"  WARNING  {warning}")
     for err in report["errors"]:

--- a/platform-integrations/claw-code/plugins/evolve-lite/skills/evolve-lite/retention/scripts/run_retention.py
+++ b/platform-integrations/claw-code/plugins/evolve-lite/skills/evolve-lite/retention/scripts/run_retention.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""
+Retention Script
+Applies data-retention rules to the local .evolve store: flags or deletes
+stale / unused memories and expired sessions. Dry-run by default; nothing
+is mutated unless --apply is passed.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+# Walk up from the script location to find the installed plugin lib directory.
+# Every host installs the shared lib under lib/evolve-lite/ so multiple
+# plugins can coexist side by side (e.g. .bob/lib/evolve-lite/).
+_script = Path(__file__).resolve()
+_lib = None
+for _ancestor in _script.parents:
+    _candidate = _ancestor / "lib" / "evolve-lite"
+    if (_candidate / "entity_io.py").is_file():
+        _lib = _candidate
+        break
+if _lib is None:
+    raise ImportError(f"Cannot find plugin lib directory above {_script}")
+sys.path.insert(0, str(_lib))
+from entity_io import get_evolve_dir, log as _log  # noqa: E402
+from config import load_config  # noqa: E402
+import retention  # noqa: E402
+
+
+def log(message):
+    _log("retention", message)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Apply retention rules to the .evolve store (dry-run by default).")
+    parser.add_argument("--apply", action="store_true", help="Actually flag/delete. Without this flag, only report.")
+    parser.add_argument("--policy", default=None, help="Standalone policy file (JSON or YAML 'rules:' list) overriding evolve.config.yaml.")
+    args = parser.parse_args()
+
+    try:
+        if args.policy:
+            rules = retention.load_policy_file(args.policy)
+        else:
+            rules = retention.load_rules(load_config())
+    except (ValueError, OSError) as exc:
+        log(f"Invalid retention rules: {exc}")
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if not rules:
+        print(
+            "No retention rules configured. Add a `retention:` block with a `rules:` list to evolve.config.yaml (or pass --policy <file>)."
+        )
+        sys.exit(0)
+
+    evolve_dir = get_evolve_dir()
+    if not evolve_dir.is_dir():
+        print(f"No evolve store at {evolve_dir}; nothing to do.")
+        sys.exit(0)
+    evolve_dir = evolve_dir.resolve()
+
+    dry_run = not args.apply
+    report = retention.run(evolve_dir, rules, dry_run=dry_run)
+    log(f"{'DRY RUN' if dry_run else 'APPLY'}: {retention.summary(report)}")
+
+    if dry_run:
+        print("DRY RUN — nothing was changed. Re-run with --apply to enforce.")
+    else:
+        print("APPLIED:")
+
+    for action in [*report["deleted"], *report["flagged"]]:
+        verb = action["action"].upper()
+        print(f"  {verb:6} {action['id']}  reason={action['reason']}  rule={action['rule']}")
+        print(f"         why: {action['detail']}")
+    if not report["deleted"] and not report["flagged"]:
+        print("  (no memories matched any rule)")
+
+    for warning in report["warnings"]:
+        print(f"  WARNING  {warning}")
+    for err in report["errors"]:
+        print(f"  ERROR  {err}", file=sys.stderr)
+
+    print(retention.summary(report))
+    sys.exit(1 if report["errors"] else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/platform-integrations/codex/plugins/evolve-lite/lib/evolve-lite/retention.py
+++ b/platform-integrations/codex/plugins/evolve-lite/lib/evolve-lite/retention.py
@@ -1,0 +1,525 @@
+"""Data retention for the evolve-lite plugin store (issue #275).
+
+Mirrors the ``altk_evolve/retention/`` semantics against the plugin's
+``.evolve/`` file store: age-based and unused-based rules that **flag** or
+**delete**, dry-run by default, and the session -> derived cascade. Stdlib-only,
+because plugin scripts run in the host's Python where nothing beyond the
+standard library is guaranteed.
+
+The plugin store is markdown files, not a backend with per-entity metadata, so
+the package's signals map onto what the files actually carry. Each mapping is
+weaker than its package-side counterpart — the gaps are called out here and in
+``docs/guides/retention.md``:
+
+- **age** — file mtime. Plugin entities carry no ``created_at`` frontmatter, so
+  mtime is the only available clock. It is a *modification* time, not a birth
+  time: editing an entity resets its age. (Flagging deliberately restores the
+  mtime so the sweep itself never resets the clock — see below.)
+- **unused** — the latest ``recall`` row in ``.evolve/audit.log`` naming the
+  entity id (``<type>/<name>``, the id scheme ``audit_recall.py`` logs and
+  ``EVOLVE.md`` instructs the agent to pass), falling back to file mtime when
+  an entity was never recalled. This is the plugin's answer to the package's
+  ``metadata.last_accessed``, and it has the same failure mode: it only exists
+  if something records the recall. Package-side that is ``AccessStampPlugin``
+  (automatic); plugin-side it is a model-invoked ``audit_recall.py`` call — so
+  the signal is only as complete as the agent's compliance with EVOLVE.md.
+- **cascade** — the package links a derived memory to its session via
+  ``metadata.source_task_id == trace_id``. Plugin-side the equivalent link is a
+  ``trajectory:`` frontmatter key naming the session file under
+  ``.evolve/trajectories/``; a ``cascade_derived`` delete of a trajectory also
+  deletes entities whose link resolves to it (matched by filename — trajectory
+  filenames embed a timestamp + session id and are unique by construction).
+  **Known gap: nothing in the shipped plugin writes that key today.**
+  ``entity_io._FRONTMATTER_KEYS`` supports it and it is preserved on round-trip,
+  but neither the save flow nor ``adapt-memory`` populates it, so in practice
+  the plugin-side cascade only fires for entities whose ``trajectory:`` key was
+  written by hand or by a downstream tool. Deleting a session therefore does
+  *not* by itself clean up the memories derived from it the way the package
+  side does.
+
+Actions:
+
+- **flag** — upsert ``retention_flagged_at`` / ``retention_reason`` /
+  ``retention_rule`` into the entity's frontmatter (non-destructive; the file's
+  mtime is preserved so the age clock does not reset). Trajectory files are
+  opaque JSON with no frontmatter, so their flag lives in the audit log only.
+- **delete** — unlink the file.
+
+Every applied (non-dry-run) action also appends an ``event: "retention"`` row
+to ``.evolve/audit.log`` for auditability.
+
+Scope: private entities under ``.evolve/entities/`` — excluding
+``entities/subscribed/`` (git clones managed by the sync skill; local deletes
+there would be clobbered by the next sync) — plus session files under
+``.evolve/trajectories/``.
+
+Rules load from a ``retention:`` block in ``evolve.config.yaml``::
+
+    retention:
+      rules:
+        - name: stale-guidelines
+          entity_type: guideline
+          max_age_days: 90
+          action: flag
+        - name: old-sessions
+          entity_type: trajectory
+          max_age_days: 365
+          action: delete
+          cascade_derived: true
+"""
+
+import datetime
+import json
+import os
+from pathlib import Path
+
+VALID_ACTIONS = ("flag", "delete")
+
+#: How the trajectory tree is typed in rules (matches the package's
+#: ``entity_type: trajectory`` convention).
+TRAJECTORY_TYPE = "trajectory"
+
+
+# ---------------------------------------------------------------------------
+# Rules
+# ---------------------------------------------------------------------------
+
+
+def validate_rules(raw_rules):
+    """Validate a raw ``rules`` list into normalized rule dicts.
+
+    Mirrors the package's ``RetentionRule`` schema: every rule needs a ``name``
+    and at least one of ``max_age_days`` / ``max_unused_days``; ``action``
+    defaults to ``flag``. Raises ``ValueError`` on the first invalid rule.
+    """
+    if raw_rules is None:
+        return []
+    if not isinstance(raw_rules, list):
+        raise ValueError("retention rules must be a list")
+    rules = []
+    for raw in raw_rules:
+        if not isinstance(raw, dict):
+            raise ValueError(f"retention rule must be a mapping, got {type(raw).__name__}")
+        name = raw.get("name")
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError("retention rule must have a non-empty string 'name'")
+        rule = {
+            "name": name.strip(),
+            "entity_type": None,
+            "max_age_days": _coerce_days(raw.get("max_age_days"), name, "max_age_days"),
+            "max_unused_days": _coerce_days(raw.get("max_unused_days"), name, "max_unused_days"),
+            "action": raw.get("action", "flag"),
+            "cascade_derived": bool(raw.get("cascade_derived", False)),
+        }
+        entity_type = raw.get("entity_type")
+        if entity_type is not None:
+            if not isinstance(entity_type, str) or not entity_type.strip():
+                raise ValueError(f"retention rule {name!r}: entity_type must be a non-empty string")
+            rule["entity_type"] = entity_type.strip()
+        if rule["max_age_days"] is None and rule["max_unused_days"] is None:
+            raise ValueError(f"retention rule {name!r} must set max_age_days and/or max_unused_days")
+        if rule["action"] not in VALID_ACTIONS:
+            raise ValueError(f"retention rule {name!r}: action must be one of {VALID_ACTIONS}, got {rule['action']!r}")
+        rules.append(rule)
+    return rules
+
+
+def _coerce_days(value, rule_name, key):
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"retention rule {rule_name!r}: {key} must be a number, got {value!r}")
+    if value < 0:
+        raise ValueError(f"retention rule {rule_name!r}: {key} must be >= 0")
+    return float(value)
+
+
+def load_rules(config):
+    """Return validated rules from an evolve config dict's ``retention:`` block.
+
+    Returns ``[]`` when no block / no rules are configured.
+    """
+    retention_cfg = (config or {}).get("retention") or {}
+    if not isinstance(retention_cfg, dict):
+        raise ValueError("'retention' config block must be a mapping")
+    return validate_rules(retention_cfg.get("rules"))
+
+
+def load_policy_file(path):
+    """Load rules from a standalone policy file (JSON, or the same minimal
+    YAML subset ``evolve.config.yaml`` uses). The file holds a top-level
+    ``rules:`` list, like the package's ``retention.example.yaml``."""
+    text = Path(path).read_text(encoding="utf-8")
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        from config import _parse_yaml  # sibling lib module; resolved via sys.path
+
+        data = _parse_yaml(text)
+    if not isinstance(data, dict):
+        raise ValueError(f"policy file {path} must hold a mapping with a 'rules' list")
+    return validate_rules(data.get("rules"))
+
+
+# ---------------------------------------------------------------------------
+# Store scan
+# ---------------------------------------------------------------------------
+
+
+def _utc(dt):
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=datetime.timezone.utc)
+    return dt
+
+
+def _parse_iso(value):
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return _utc(datetime.datetime.fromisoformat(value.replace("Z", "+00:00")))
+    except ValueError:
+        return None
+
+
+def _mtime(path):
+    return datetime.datetime.fromtimestamp(path.stat().st_mtime, tz=datetime.timezone.utc)
+
+
+def _frontmatter(path):
+    """Parse simple ``key: value`` frontmatter lines from a markdown file."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return {}
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}
+    out = {}
+    for line in lines[1:]:
+        if line.strip() == "---":
+            return out
+        key, _, value = line.partition(":")
+        key, value = key.strip(), value.strip()
+        if key and value:
+            out[key] = value
+    return {}
+
+
+def scan_store(evolve_dir):
+    """Return one item dict per retention-eligible file in the store.
+
+    Items are shaped ``{id, type, path, mtime, trajectory_link}`` where
+    ``trajectory_link`` is the filename of the session the entity was derived
+    from (via its ``trajectory:`` frontmatter), or ``None``.
+    """
+    evolve_dir = Path(evolve_dir)
+    items = []
+
+    entities_root = evolve_dir / "entities"
+    if entities_root.is_dir():
+        for md in sorted(entities_root.glob("**/*.md")):
+            rel = md.relative_to(entities_root)
+            # subscribed/ trees are git clones owned by the sync skill; local
+            # deletes there would be silently restored by the next sync.
+            if rel.parts and rel.parts[0] == "subscribed":
+                continue
+            if md.is_symlink() or ".git" in rel.parts:
+                continue
+            meta = _frontmatter(md)
+            link = meta.get("trajectory")
+            items.append(
+                {
+                    "id": rel.with_suffix("").as_posix(),
+                    "type": meta.get("type") or (rel.parts[0] if len(rel.parts) > 1 else "guideline"),
+                    "path": md,
+                    "mtime": _mtime(md),
+                    "trajectory_link": Path(link).name if link else None,
+                }
+            )
+
+    traj_root = evolve_dir / "trajectories"
+    if traj_root.is_dir():
+        for traj in sorted(traj_root.iterdir()):
+            if not traj.is_file() or traj.is_symlink():
+                continue
+            items.append(
+                {
+                    "id": f"trajectories/{traj.name}",
+                    "type": TRAJECTORY_TYPE,
+                    "path": traj,
+                    "mtime": _mtime(traj),
+                    "trajectory_link": None,
+                }
+            )
+
+    return items
+
+
+def last_access_index(evolve_dir):
+    """Map entity id -> latest ``recall`` timestamp from ``.evolve/audit.log``.
+
+    This is the plugin's "unused" signal: ``audit_recall.py`` appends a recall
+    row (with ``entities: ["<type>/<name>", ...]``) when the agent records the
+    memories it consulted, mirroring what ``AccessStampPlugin`` /
+    ``EvolveClient.record_access`` stamp as ``metadata.last_accessed``
+    package-side. Unlike the package's hook, this one is model-invoked, so an
+    entity's absence from the index means "no recorded recall", not "not used".
+    """
+    audit_log = Path(evolve_dir) / "audit.log"
+    index = {}
+    if not audit_log.is_file():
+        return index
+    for line in audit_log.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(row, dict) or row.get("event") != "recall":
+            continue
+        ts = _parse_iso(row.get("ts"))
+        if ts is None:
+            continue
+        for eid in row.get("entities") or []:
+            if isinstance(eid, str) and eid:
+                prev = index.get(eid)
+                if prev is None or ts > prev:
+                    index[eid] = ts
+    return index
+
+
+# ---------------------------------------------------------------------------
+# Evaluation (mirrors altk_evolve.retention.engine.RetentionEngine.evaluate)
+# ---------------------------------------------------------------------------
+
+
+#: Appended to the "why" of an unused-rule match with no recorded recall.
+NO_RECALL_SIGNAL_HINT = (
+    "no recall row in .evolve/audit.log for this entity, so disuse was measured from file mtime; "
+    "the recall audit is model-invoked, so treat a never-recalled verdict as 'never recorded'"
+)
+
+
+def _match(item, rule, now, last_access):
+    """Return ``(reason, detail)`` if *rule* matches *item*, else None.
+
+    ``reason`` is 'age' or 'unused'; ``detail`` is the human-readable why,
+    including which signal was used and whether it fell back.
+    """
+    if rule["entity_type"] is not None and item["type"] != rule["entity_type"]:
+        return None
+    age_days = (now - item["mtime"]).total_seconds() / 86400.0
+    if rule["max_age_days"] is not None and age_days > rule["max_age_days"]:
+        return "age", "modified {:.1f}d ago > max_age_days={} (from file mtime)".format(age_days, rule["max_age_days"])
+    if rule["max_unused_days"] is not None:
+        recorded = last_access.get(item["id"])
+        last = recorded or item["mtime"]
+        unused_days = (now - last).total_seconds() / 86400.0
+        if unused_days > rule["max_unused_days"]:
+            detail = "not recalled for {:.1f}d > max_unused_days={}".format(unused_days, rule["max_unused_days"])
+            detail += " (from the recall audit log)" if recorded else " — " + NO_RECALL_SIGNAL_HINT
+            return "unused", detail
+    return None
+
+
+def evaluate(evolve_dir, rules, now=None, warnings=None):
+    """Compute the actions the rules imply, without mutating anything.
+
+    Returns a list of ``{id, type, action, reason, rule, detail, path}`` dicts.
+    First matching rule wins per item; delete supersedes flag; a delete rule
+    with ``cascade_derived`` on a trajectory also deletes the entities whose
+    ``trajectory:`` frontmatter links back to it.
+
+    When *warnings* is a list, non-fatal caveats about the run (e.g. a degraded
+    "unused" signal) are appended to it.
+    """
+    now = _utc(now) if now else datetime.datetime.now(datetime.timezone.utc)
+    items = scan_store(evolve_dir)
+    last_access = last_access_index(evolve_dir)
+
+    # Provenance index: trajectory filename -> [derived items]
+    derived_by_name = {}
+    for item in items:
+        link = item["trajectory_link"]
+        if link:
+            derived_by_name.setdefault(link, []).append(item)
+
+    # delete supersedes flag for the same item; first writer otherwise wins.
+    actions = {}
+
+    def record(item, action, reason, rule_name, detail):
+        existing = actions.get(item["id"])
+        if existing is not None and (existing["action"] == "delete" or action == "flag"):
+            return
+        actions[item["id"]] = {
+            "id": item["id"],
+            "type": item["type"],
+            "action": action,
+            "reason": reason,
+            "rule": rule_name,
+            "detail": detail,
+            "path": item["path"],
+        }
+
+    unrecalled = 0
+    uses_unused_rule = any(r["max_unused_days"] is not None for r in rules)
+
+    for item in items:
+        if uses_unused_rule and item["id"] not in last_access:
+            unrecalled += 1
+
+        matched = None
+        for rule in rules:
+            hit = _match(item, rule, now, last_access)
+            if hit is not None:
+                matched = (rule, hit[0], hit[1])
+                break
+        if matched is None:
+            continue
+        rule, reason, detail = matched
+        record(item, rule["action"], reason, rule["name"], detail)
+
+        if rule["action"] == "delete" and rule["cascade_derived"] and item["type"] == TRAJECTORY_TYPE:
+            for derived in derived_by_name.get(item["path"].name, []):
+                if derived["id"] == item["id"]:
+                    continue
+                record(
+                    derived,
+                    "delete",
+                    f"cascade:{item['path'].name}",
+                    rule["name"],
+                    f"trajectory: frontmatter links it to session {item['path'].name}, which this rule deletes",
+                )
+
+    if warnings is not None and unrecalled:
+        warnings.append(
+            f"{unrecalled} of {len(items)} store entries have no recall row in .evolve/audit.log, so their "
+            "disuse was measured from file mtime — for those, an unused rule behaves like an age rule."
+        )
+
+    return list(actions.values())
+
+
+# ---------------------------------------------------------------------------
+# Application
+# ---------------------------------------------------------------------------
+
+
+def _flag_entity_file(path, flagged_at, reason, rule_name):
+    """Upsert retention_* markers into an entity file's frontmatter.
+
+    Preserves the file's mtime so flagging does not reset the age clock.
+    """
+    path = Path(path)
+    st = path.stat()
+    text = path.read_text(encoding="utf-8")
+    marker = [
+        f"retention_flagged_at: {flagged_at}",
+        f"retention_reason: {reason}",
+        f"retention_rule: {rule_name}",
+    ]
+    lines = text.splitlines()
+    closing = None
+    if lines and lines[0].strip() == "---":
+        for i in range(1, len(lines)):
+            if lines[i].strip() == "---":
+                closing = i
+                break
+    if closing is not None:
+        head = [ln for ln in lines[1:closing] if not ln.strip().startswith("retention_")]
+        new_lines = [lines[0], *head, *marker, *lines[closing:]]
+    else:
+        # No frontmatter (shouldn't happen for entities we wrote) — prepend one.
+        new_lines = ["---", *marker, "---", "", *lines]
+    new_text = "\n".join(new_lines)
+    if text.endswith("\n"):
+        new_text += "\n"
+    path.write_text(new_text, encoding="utf-8")
+    os.utime(path, (st.st_atime, st.st_mtime))
+
+
+def apply_actions(evolve_dir, actions, dry_run=True, now=None, warnings=None):
+    """Apply (or, on dry run, merely report) a list of evaluated actions.
+
+    Returns ``{dry_run, flagged, deleted, errors, warnings}`` where
+    flagged/deleted hold the action dicts and errors/warnings hold strings.
+    Non-dry-run actions each append an ``event: "retention"`` row to the audit
+    log.
+    """
+    now = _utc(now) if now else datetime.datetime.now(datetime.timezone.utc)
+    flagged_at = now.isoformat()
+    report = {"dry_run": dry_run, "flagged": [], "deleted": [], "errors": [], "warnings": list(warnings or [])}
+
+    for action in actions:
+        try:
+            if action["action"] == "delete":
+                if not dry_run:
+                    Path(action["path"]).unlink(missing_ok=True)
+                    _audit(evolve_dir, action)
+                report["deleted"].append(action)
+            else:  # flag
+                if not dry_run:
+                    if action["type"] != TRAJECTORY_TYPE:
+                        _flag_entity_file(action["path"], flagged_at, action["reason"], action["rule"])
+                    # Trajectory files are opaque JSON — no frontmatter to mark;
+                    # the audit row below is their durable flag record.
+                    _audit(evolve_dir, action)
+                report["flagged"].append(action)
+        except OSError as exc:  # don't let one bad file abort the sweep
+            report["errors"].append(f"{action['action']} {action['id']}: {exc}")
+
+    return report
+
+
+def _audit(evolve_dir, action):
+    import audit  # sibling lib module; resolved via sys.path
+
+    audit.append(
+        evolve_dir=str(evolve_dir),
+        event="retention",
+        action=action["action"],
+        entity=action["id"],
+        reason=action["reason"],
+        rule=action["rule"],
+    )
+
+
+def run(evolve_dir, rules, dry_run=True, now=None):
+    """Evaluate the rules against the store and apply (or dry-run) the result."""
+    warnings = []
+    actions = evaluate(evolve_dir, rules, now=now, warnings=warnings)
+    return apply_actions(evolve_dir, actions, dry_run=dry_run, now=now, warnings=warnings)
+
+
+def summary(report):
+    verb = "would flag/delete" if report["dry_run"] else "flagged/deleted"
+    return f"{verb}: {len(report['flagged'])} flagged, {len(report['deleted'])} deleted, {len(report['errors'])} errors"
+
+
+if __name__ == "__main__":
+    # Self-test (pure paths only; file behavior is covered by pytest).
+    assert load_rules({}) == []
+    assert load_rules({"retention": {"rules": []}}) == []
+
+    rules = validate_rules([{"name": "r", "max_age_days": 30}])
+    assert rules[0]["action"] == "flag"  # default
+    assert rules[0]["max_age_days"] == 30.0
+
+    for bad in (
+        [{"name": "r"}],  # no threshold
+        [{"name": "r", "max_age_days": 30, "action": "purge"}],  # bad action
+        [{"max_age_days": 30}],  # no name
+        [{"name": "r", "max_age_days": "soon"}],  # non-numeric
+    ):
+        try:
+            validate_rules(bad)
+        except ValueError:
+            pass
+        else:  # pragma: no cover
+            raise AssertionError(f"expected ValueError for {bad}")
+
+    assert _parse_iso("2026-06-29T00:00:00Z") is not None
+    assert _parse_iso("not-a-date") is None
+    assert _parse_iso(None) is None
+    print("retention.py ok")

--- a/platform-integrations/codex/plugins/evolve-lite/lib/evolve-lite/retention.py
+++ b/platform-integrations/codex/plugins/evolve-lite/lib/evolve-lite/retention.py
@@ -75,6 +75,13 @@ from pathlib import Path
 
 VALID_ACTIONS = ("flag", "delete")
 
+#: What a delete rule does when an "unused" match has no recorded recall (disuse
+#: fell back to file mtime). Mirrors the package's RetentionRule field of the
+#: same name. "skip" (default, fail-safe) spares the entity and reports it;
+#: "flag" downgrades the delete to a non-destructive flag; "delete" deletes on
+#: the mtime fallback (the original behaviour).
+VALID_MISSING_SIGNAL = ("skip", "flag", "delete")
+
 #: How the trajectory tree is typed in rules (matches the package's
 #: ``entity_type: trajectory`` convention).
 TRAJECTORY_TYPE = "trajectory"
@@ -109,6 +116,7 @@ def validate_rules(raw_rules):
             "max_age_days": _coerce_days(raw.get("max_age_days"), name, "max_age_days"),
             "max_unused_days": _coerce_days(raw.get("max_unused_days"), name, "max_unused_days"),
             "action": raw.get("action", "flag"),
+            "on_missing_access_signal": raw.get("on_missing_access_signal", "skip"),
             "cascade_derived": bool(raw.get("cascade_derived", False)),
         }
         entity_type = raw.get("entity_type")
@@ -120,6 +128,11 @@ def validate_rules(raw_rules):
             raise ValueError(f"retention rule {name!r} must set max_age_days and/or max_unused_days")
         if rule["action"] not in VALID_ACTIONS:
             raise ValueError(f"retention rule {name!r}: action must be one of {VALID_ACTIONS}, got {rule['action']!r}")
+        if rule["on_missing_access_signal"] not in VALID_MISSING_SIGNAL:
+            raise ValueError(
+                f"retention rule {name!r}: on_missing_access_signal must be one of {VALID_MISSING_SIGNAL}, "
+                f"got {rule['on_missing_access_signal']!r}"
+            )
         rules.append(rule)
     return rules
 
@@ -302,16 +315,19 @@ NO_RECALL_SIGNAL_HINT = (
 
 
 def _match(item, rule, now, last_access):
-    """Return ``(reason, detail)`` if *rule* matches *item*, else None.
+    """Return ``(reason, detail, degraded)`` if *rule* matches *item*, else None.
 
     ``reason`` is 'age' or 'unused'; ``detail`` is the human-readable why,
-    including which signal was used and whether it fell back.
+    including which signal was used and whether it fell back. ``degraded`` is
+    True only for an 'unused' match whose disuse was measured from file mtime
+    because no recall row existed — ``on_missing_access_signal`` governs whether
+    such a match may still delete.
     """
     if rule["entity_type"] is not None and item["type"] != rule["entity_type"]:
         return None
     age_days = (now - item["mtime"]).total_seconds() / 86400.0
     if rule["max_age_days"] is not None and age_days > rule["max_age_days"]:
-        return "age", "modified {:.1f}d ago > max_age_days={} (from file mtime)".format(age_days, rule["max_age_days"])
+        return "age", "modified {:.1f}d ago > max_age_days={} (from file mtime)".format(age_days, rule["max_age_days"]), False
     if rule["max_unused_days"] is not None:
         recorded = last_access.get(item["id"])
         last = recorded or item["mtime"]
@@ -319,11 +335,11 @@ def _match(item, rule, now, last_access):
         if unused_days > rule["max_unused_days"]:
             detail = "not recalled for {:.1f}d > max_unused_days={}".format(unused_days, rule["max_unused_days"])
             detail += " (from the recall audit log)" if recorded else " — " + NO_RECALL_SIGNAL_HINT
-            return "unused", detail
+            return "unused", detail, not recorded
     return None
 
 
-def evaluate(evolve_dir, rules, now=None, warnings=None):
+def evaluate(evolve_dir, rules, now=None, warnings=None, skipped=None):
     """Compute the actions the rules imply, without mutating anything.
 
     Returns a list of ``{id, type, action, reason, rule, detail, path}`` dicts.
@@ -332,7 +348,9 @@ def evaluate(evolve_dir, rules, now=None, warnings=None):
     ``trajectory:`` frontmatter links back to it.
 
     When *warnings* is a list, non-fatal caveats about the run (e.g. a degraded
-    "unused" signal) are appended to it.
+    "unused" signal) are appended to it. When *skipped* is a list, items a
+    delete rule matched on a degraded signal but was spared under
+    ``on_missing_access_signal: skip`` are appended to it.
     """
     now = _utc(now) if now else datetime.datetime.now(datetime.timezone.utc)
     items = scan_store(evolve_dir)
@@ -373,14 +391,40 @@ def evaluate(evolve_dir, rules, now=None, warnings=None):
         for rule in rules:
             hit = _match(item, rule, now, last_access)
             if hit is not None:
-                matched = (rule, hit[0], hit[1])
+                matched = (rule, hit[0], hit[1], hit[2])
                 break
         if matched is None:
             continue
-        rule, reason, detail = matched
-        record(item, rule["action"], reason, rule["name"], detail)
+        rule, reason, detail, degraded = matched
 
-        if rule["action"] == "delete" and rule["cascade_derived"] and item["type"] == TRAJECTORY_TYPE:
+        action = rule["action"]
+        # A degraded "unused" match (no recall row, disuse from file mtime) only
+        # reaches a destructive action when the rule opts in. Default "skip"
+        # spares it; "flag" downgrades the delete; "delete" keeps the old
+        # behaviour. Only bites deletes — a flag action is not data loss.
+        if degraded and rule["action"] == "delete":
+            choice = rule["on_missing_access_signal"]
+            if choice == "skip":
+                if skipped is not None:
+                    skipped.append(
+                        {
+                            "id": item["id"],
+                            "type": item["type"],
+                            "action": "skip",
+                            "reason": reason,
+                            "rule": rule["name"],
+                            "detail": "matched but not deleted: {}; on_missing_access_signal=skip".format(detail),
+                            "path": item["path"],
+                        }
+                    )
+                continue
+            if choice == "flag":
+                action = "flag"
+                detail += "; downgraded delete->flag (on_missing_access_signal=flag)"
+
+        record(item, action, reason, rule["name"], detail)
+
+        if action == "delete" and rule["cascade_derived"] and item["type"] == TRAJECTORY_TYPE:
             for derived in derived_by_name.get(item["path"].name, []):
                 if derived["id"] == item["id"]:
                     continue
@@ -439,17 +483,24 @@ def _flag_entity_file(path, flagged_at, reason, rule_name):
     os.utime(path, (st.st_atime, st.st_mtime))
 
 
-def apply_actions(evolve_dir, actions, dry_run=True, now=None, warnings=None):
+def apply_actions(evolve_dir, actions, dry_run=True, now=None, warnings=None, skipped=None):
     """Apply (or, on dry run, merely report) a list of evaluated actions.
 
-    Returns ``{dry_run, flagged, deleted, errors, warnings}`` where
-    flagged/deleted hold the action dicts and errors/warnings hold strings.
+    Returns ``{dry_run, flagged, deleted, skipped, errors, warnings}`` where
+    flagged/deleted/skipped hold action dicts and errors/warnings hold strings.
     Non-dry-run actions each append an ``event: "retention"`` row to the audit
     log.
     """
     now = _utc(now) if now else datetime.datetime.now(datetime.timezone.utc)
     flagged_at = now.isoformat()
-    report = {"dry_run": dry_run, "flagged": [], "deleted": [], "errors": [], "warnings": list(warnings or [])}
+    report = {
+        "dry_run": dry_run,
+        "flagged": [],
+        "deleted": [],
+        "skipped": list(skipped or []),
+        "errors": [],
+        "warnings": list(warnings or []),
+    }
 
     for action in actions:
         try:
@@ -488,13 +539,17 @@ def _audit(evolve_dir, action):
 def run(evolve_dir, rules, dry_run=True, now=None):
     """Evaluate the rules against the store and apply (or dry-run) the result."""
     warnings = []
-    actions = evaluate(evolve_dir, rules, now=now, warnings=warnings)
-    return apply_actions(evolve_dir, actions, dry_run=dry_run, now=now, warnings=warnings)
+    skipped = []
+    actions = evaluate(evolve_dir, rules, now=now, warnings=warnings, skipped=skipped)
+    return apply_actions(evolve_dir, actions, dry_run=dry_run, now=now, warnings=warnings, skipped=skipped)
 
 
 def summary(report):
     verb = "would flag/delete" if report["dry_run"] else "flagged/deleted"
-    return f"{verb}: {len(report['flagged'])} flagged, {len(report['deleted'])} deleted, {len(report['errors'])} errors"
+    out = f"{verb}: {len(report['flagged'])} flagged, {len(report['deleted'])} deleted, {len(report['errors'])} errors"
+    if report.get("skipped"):
+        out += f", {len(report['skipped'])} skipped (degraded signal)"
+    return out
 
 
 if __name__ == "__main__":
@@ -504,11 +559,13 @@ if __name__ == "__main__":
 
     rules = validate_rules([{"name": "r", "max_age_days": 30}])
     assert rules[0]["action"] == "flag"  # default
+    assert rules[0]["on_missing_access_signal"] == "skip"  # fail-safe default
     assert rules[0]["max_age_days"] == 30.0
 
     for bad in (
         [{"name": "r"}],  # no threshold
         [{"name": "r", "max_age_days": 30, "action": "purge"}],  # bad action
+        [{"name": "r", "max_age_days": 30, "on_missing_access_signal": "nuke"}],  # bad signal policy
         [{"max_age_days": 30}],  # no name
         [{"name": "r", "max_age_days": "soon"}],  # non-numeric
     ):

--- a/platform-integrations/codex/plugins/evolve-lite/skills/evolve-lite/retention/SKILL.md
+++ b/platform-integrations/codex/plugins/evolve-lite/skills/evolve-lite/retention/SKILL.md
@@ -42,7 +42,16 @@ retention:
 
 Each rule needs a `name` and at least one of `max_age_days` /
 `max_unused_days`; `action` is `flag` (default) or `delete`. Rules are checked
-top-to-bottom and the first match wins, so put narrow rules first.
+top-to-bottom and the first match wins, so put narrow rules first — and put a
+longer-threshold `delete` before a shorter-threshold `flag` on the same type,
+or the flag shadows the delete and it never fires.
+
+A `delete` rule may also set `on_missing_access_signal` to say what happens when
+an `unused` match has **no recorded recall** (disuse measured from file mtime):
+`skip` (default, fail-safe — spare it and report it as skipped), `flag`
+(downgrade the delete to a non-destructive flag), or `delete` (delete on the
+mtime fallback anyway). The safe default means an `unused` delete never destroys
+a memory the agent simply never recorded a recall for.
 
 ### Step 2: Dry run
 
@@ -52,11 +61,12 @@ From the project root:
 python3 "$(git rev-parse --show-toplevel 2>/dev/null || pwd)/plugins/evolve-lite/skills/evolve-lite/retention/scripts/run_retention.py"
 ```
 
-Show the user the full report — every entry says what *would* be flagged or
-deleted, why (`age`, `unused`, or `cascade:<session>`), by which rule, and on
-what evidence. Relay any `WARNING` lines too: they say when a signal was
-weaker than it looks (for example, disuse measured from file mtime because the
-entity has no recall row).
+Show the user the full report — every entry says what *would* be flagged,
+deleted, or skipped, why (`age`, `unused`, or `cascade:<session>`), by which
+rule, and on what evidence. `SKIP` lines are entities a `delete` rule matched on
+a degraded signal but spared under `on_missing_access_signal: skip`. Relay any
+`WARNING` lines too: they say when a signal was weaker than it looks (for
+example, disuse measured from file mtime because the entity has no recall row).
 
 ### Step 3: Apply — only on explicit user confirmation
 

--- a/platform-integrations/codex/plugins/evolve-lite/skills/evolve-lite/retention/SKILL.md
+++ b/platform-integrations/codex/plugins/evolve-lite/skills/evolve-lite/retention/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: retention
+description: Apply data-retention rules to the local evolve store — flag or delete stale and unused memories and expired sessions (dry-run by default)
+---
+
+# Retention
+
+## Overview
+
+Runs the data-retention rules configured in `evolve.config.yaml` against the
+local `.evolve/` store: private entities under `.evolve/entities/` and session
+transcripts under `.evolve/trajectories/`. Rules match by entity type plus age
+(`max_age_days`, from file mtime) or disuse (`max_unused_days`, from `recall`
+rows in `.evolve/audit.log`), and either **flag** (a non-destructive frontmatter
+marker) or **delete**. A `delete` rule on trajectories with
+`cascade_derived: true` also deletes the entities derived from those sessions
+(linked by their `trajectory:` frontmatter).
+
+The script is **dry-run by default** — it never mutates anything unless
+`--apply` is passed.
+
+## Workflow
+
+### Step 1: Require rules
+
+Read `evolve.config.yaml`. If there is no `retention:` block with a `rules:`
+list, show the user this example and stop:
+
+```yaml
+retention:
+  rules:
+    - name: stale-guidelines
+      entity_type: guideline
+      max_age_days: 90
+      action: flag
+    - name: old-sessions
+      entity_type: trajectory
+      max_age_days: 365
+      action: delete
+      cascade_derived: true
+```
+
+Each rule needs a `name` and at least one of `max_age_days` /
+`max_unused_days`; `action` is `flag` (default) or `delete`. Rules are checked
+top-to-bottom and the first match wins, so put narrow rules first.
+
+### Step 2: Dry run
+
+From the project root:
+
+```bash
+python3 "$(git rev-parse --show-toplevel 2>/dev/null || pwd)/plugins/evolve-lite/skills/evolve-lite/retention/scripts/run_retention.py"
+```
+
+Show the user the full report — every entry says what *would* be flagged or
+deleted, why (`age`, `unused`, or `cascade:<session>`), by which rule, and on
+what evidence. Relay any `WARNING` lines too: they say when a signal was
+weaker than it looks (for example, disuse measured from file mtime because the
+entity has no recall row).
+
+### Step 3: Apply — only on explicit user confirmation
+
+Deleting is destructive and there is no undo. Ask the user to confirm the
+dry-run report first. Never pass `--apply` without an explicit go-ahead.
+
+```bash
+python3 "$(git rev-parse --show-toplevel 2>/dev/null || pwd)/plugins/evolve-lite/skills/evolve-lite/retention/scripts/run_retention.py" --apply
+```
+
+Relay the applied report back to the user.
+
+## Notes
+
+- **Flag** upserts `retention_flagged_at`, `retention_reason`, and
+  `retention_rule` into the entity's frontmatter; the file's mtime is
+  preserved so its age clock doesn't reset. Trajectory files are opaque JSON,
+  so their flag is recorded in `.evolve/audit.log` only.
+- Every applied action is logged to `.evolve/audit.log` as an
+  `event: "retention"` row.
+- Subscribed entities (`.evolve/entities/subscribed/`) are out of scope — they
+  are git clones owned by the sync skill and local deletes would be restored
+  on the next sync.
+- A standalone policy file can be passed with `--policy <file>` (a `rules:`
+  list in JSON or YAML), overriding the config block.
+- Signal caveats, worth stating when you relay a report: age is **file mtime**
+  (editing an entity resets its clock — there is no `created_at` in the
+  store), and the disuse signal only exists for entities the agent recorded
+  via the recall audit step. The `trajectory:` cascade link is supported but
+  nothing writes it automatically today, so `cascade_derived` only fires for
+  entities where that key was set by hand.

--- a/platform-integrations/codex/plugins/evolve-lite/skills/evolve-lite/retention/scripts/run_retention.py
+++ b/platform-integrations/codex/plugins/evolve-lite/skills/evolve-lite/retention/scripts/run_retention.py
@@ -76,6 +76,10 @@ def main():
     if not report["deleted"] and not report["flagged"]:
         print("  (no memories matched any rule)")
 
+    for action in report.get("skipped", []):
+        print(f"  SKIP   {action['id']}  reason={action['reason']}  rule={action['rule']}")
+        print(f"         why: {action['detail']}")
+
     for warning in report["warnings"]:
         print(f"  WARNING  {warning}")
     for err in report["errors"]:

--- a/platform-integrations/codex/plugins/evolve-lite/skills/evolve-lite/retention/scripts/run_retention.py
+++ b/platform-integrations/codex/plugins/evolve-lite/skills/evolve-lite/retention/scripts/run_retention.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""
+Retention Script
+Applies data-retention rules to the local .evolve store: flags or deletes
+stale / unused memories and expired sessions. Dry-run by default; nothing
+is mutated unless --apply is passed.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+# Walk up from the script location to find the installed plugin lib directory.
+# Every host installs the shared lib under lib/evolve-lite/ so multiple
+# plugins can coexist side by side (e.g. .bob/lib/evolve-lite/).
+_script = Path(__file__).resolve()
+_lib = None
+for _ancestor in _script.parents:
+    _candidate = _ancestor / "lib" / "evolve-lite"
+    if (_candidate / "entity_io.py").is_file():
+        _lib = _candidate
+        break
+if _lib is None:
+    raise ImportError(f"Cannot find plugin lib directory above {_script}")
+sys.path.insert(0, str(_lib))
+from entity_io import get_evolve_dir, log as _log  # noqa: E402
+from config import load_config  # noqa: E402
+import retention  # noqa: E402
+
+
+def log(message):
+    _log("retention", message)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Apply retention rules to the .evolve store (dry-run by default).")
+    parser.add_argument("--apply", action="store_true", help="Actually flag/delete. Without this flag, only report.")
+    parser.add_argument("--policy", default=None, help="Standalone policy file (JSON or YAML 'rules:' list) overriding evolve.config.yaml.")
+    args = parser.parse_args()
+
+    try:
+        if args.policy:
+            rules = retention.load_policy_file(args.policy)
+        else:
+            rules = retention.load_rules(load_config())
+    except (ValueError, OSError) as exc:
+        log(f"Invalid retention rules: {exc}")
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if not rules:
+        print(
+            "No retention rules configured. Add a `retention:` block with a `rules:` list to evolve.config.yaml (or pass --policy <file>)."
+        )
+        sys.exit(0)
+
+    evolve_dir = get_evolve_dir()
+    if not evolve_dir.is_dir():
+        print(f"No evolve store at {evolve_dir}; nothing to do.")
+        sys.exit(0)
+    evolve_dir = evolve_dir.resolve()
+
+    dry_run = not args.apply
+    report = retention.run(evolve_dir, rules, dry_run=dry_run)
+    log(f"{'DRY RUN' if dry_run else 'APPLY'}: {retention.summary(report)}")
+
+    if dry_run:
+        print("DRY RUN — nothing was changed. Re-run with --apply to enforce.")
+    else:
+        print("APPLIED:")
+
+    for action in [*report["deleted"], *report["flagged"]]:
+        verb = action["action"].upper()
+        print(f"  {verb:6} {action['id']}  reason={action['reason']}  rule={action['rule']}")
+        print(f"         why: {action['detail']}")
+    if not report["deleted"] and not report["flagged"]:
+        print("  (no memories matched any rule)")
+
+    for warning in report["warnings"]:
+        print(f"  WARNING  {warning}")
+    for err in report["errors"]:
+        print(f"  ERROR  {err}", file=sys.stderr)
+
+    print(retention.summary(report))
+    sys.exit(1 if report["errors"] else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugin-source/lib/retention.py
+++ b/plugin-source/lib/retention.py
@@ -1,0 +1,525 @@
+"""Data retention for the evolve-lite plugin store (issue #275).
+
+Mirrors the ``altk_evolve/retention/`` semantics against the plugin's
+``.evolve/`` file store: age-based and unused-based rules that **flag** or
+**delete**, dry-run by default, and the session -> derived cascade. Stdlib-only,
+because plugin scripts run in the host's Python where nothing beyond the
+standard library is guaranteed.
+
+The plugin store is markdown files, not a backend with per-entity metadata, so
+the package's signals map onto what the files actually carry. Each mapping is
+weaker than its package-side counterpart — the gaps are called out here and in
+``docs/guides/retention.md``:
+
+- **age** — file mtime. Plugin entities carry no ``created_at`` frontmatter, so
+  mtime is the only available clock. It is a *modification* time, not a birth
+  time: editing an entity resets its age. (Flagging deliberately restores the
+  mtime so the sweep itself never resets the clock — see below.)
+- **unused** — the latest ``recall`` row in ``.evolve/audit.log`` naming the
+  entity id (``<type>/<name>``, the id scheme ``audit_recall.py`` logs and
+  ``EVOLVE.md`` instructs the agent to pass), falling back to file mtime when
+  an entity was never recalled. This is the plugin's answer to the package's
+  ``metadata.last_accessed``, and it has the same failure mode: it only exists
+  if something records the recall. Package-side that is ``AccessStampPlugin``
+  (automatic); plugin-side it is a model-invoked ``audit_recall.py`` call — so
+  the signal is only as complete as the agent's compliance with EVOLVE.md.
+- **cascade** — the package links a derived memory to its session via
+  ``metadata.source_task_id == trace_id``. Plugin-side the equivalent link is a
+  ``trajectory:`` frontmatter key naming the session file under
+  ``.evolve/trajectories/``; a ``cascade_derived`` delete of a trajectory also
+  deletes entities whose link resolves to it (matched by filename — trajectory
+  filenames embed a timestamp + session id and are unique by construction).
+  **Known gap: nothing in the shipped plugin writes that key today.**
+  ``entity_io._FRONTMATTER_KEYS`` supports it and it is preserved on round-trip,
+  but neither the save flow nor ``adapt-memory`` populates it, so in practice
+  the plugin-side cascade only fires for entities whose ``trajectory:`` key was
+  written by hand or by a downstream tool. Deleting a session therefore does
+  *not* by itself clean up the memories derived from it the way the package
+  side does.
+
+Actions:
+
+- **flag** — upsert ``retention_flagged_at`` / ``retention_reason`` /
+  ``retention_rule`` into the entity's frontmatter (non-destructive; the file's
+  mtime is preserved so the age clock does not reset). Trajectory files are
+  opaque JSON with no frontmatter, so their flag lives in the audit log only.
+- **delete** — unlink the file.
+
+Every applied (non-dry-run) action also appends an ``event: "retention"`` row
+to ``.evolve/audit.log`` for auditability.
+
+Scope: private entities under ``.evolve/entities/`` — excluding
+``entities/subscribed/`` (git clones managed by the sync skill; local deletes
+there would be clobbered by the next sync) — plus session files under
+``.evolve/trajectories/``.
+
+Rules load from a ``retention:`` block in ``evolve.config.yaml``::
+
+    retention:
+      rules:
+        - name: stale-guidelines
+          entity_type: guideline
+          max_age_days: 90
+          action: flag
+        - name: old-sessions
+          entity_type: trajectory
+          max_age_days: 365
+          action: delete
+          cascade_derived: true
+"""
+
+import datetime
+import json
+import os
+from pathlib import Path
+
+VALID_ACTIONS = ("flag", "delete")
+
+#: How the trajectory tree is typed in rules (matches the package's
+#: ``entity_type: trajectory`` convention).
+TRAJECTORY_TYPE = "trajectory"
+
+
+# ---------------------------------------------------------------------------
+# Rules
+# ---------------------------------------------------------------------------
+
+
+def validate_rules(raw_rules):
+    """Validate a raw ``rules`` list into normalized rule dicts.
+
+    Mirrors the package's ``RetentionRule`` schema: every rule needs a ``name``
+    and at least one of ``max_age_days`` / ``max_unused_days``; ``action``
+    defaults to ``flag``. Raises ``ValueError`` on the first invalid rule.
+    """
+    if raw_rules is None:
+        return []
+    if not isinstance(raw_rules, list):
+        raise ValueError("retention rules must be a list")
+    rules = []
+    for raw in raw_rules:
+        if not isinstance(raw, dict):
+            raise ValueError(f"retention rule must be a mapping, got {type(raw).__name__}")
+        name = raw.get("name")
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError("retention rule must have a non-empty string 'name'")
+        rule = {
+            "name": name.strip(),
+            "entity_type": None,
+            "max_age_days": _coerce_days(raw.get("max_age_days"), name, "max_age_days"),
+            "max_unused_days": _coerce_days(raw.get("max_unused_days"), name, "max_unused_days"),
+            "action": raw.get("action", "flag"),
+            "cascade_derived": bool(raw.get("cascade_derived", False)),
+        }
+        entity_type = raw.get("entity_type")
+        if entity_type is not None:
+            if not isinstance(entity_type, str) or not entity_type.strip():
+                raise ValueError(f"retention rule {name!r}: entity_type must be a non-empty string")
+            rule["entity_type"] = entity_type.strip()
+        if rule["max_age_days"] is None and rule["max_unused_days"] is None:
+            raise ValueError(f"retention rule {name!r} must set max_age_days and/or max_unused_days")
+        if rule["action"] not in VALID_ACTIONS:
+            raise ValueError(f"retention rule {name!r}: action must be one of {VALID_ACTIONS}, got {rule['action']!r}")
+        rules.append(rule)
+    return rules
+
+
+def _coerce_days(value, rule_name, key):
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"retention rule {rule_name!r}: {key} must be a number, got {value!r}")
+    if value < 0:
+        raise ValueError(f"retention rule {rule_name!r}: {key} must be >= 0")
+    return float(value)
+
+
+def load_rules(config):
+    """Return validated rules from an evolve config dict's ``retention:`` block.
+
+    Returns ``[]`` when no block / no rules are configured.
+    """
+    retention_cfg = (config or {}).get("retention") or {}
+    if not isinstance(retention_cfg, dict):
+        raise ValueError("'retention' config block must be a mapping")
+    return validate_rules(retention_cfg.get("rules"))
+
+
+def load_policy_file(path):
+    """Load rules from a standalone policy file (JSON, or the same minimal
+    YAML subset ``evolve.config.yaml`` uses). The file holds a top-level
+    ``rules:`` list, like the package's ``retention.example.yaml``."""
+    text = Path(path).read_text(encoding="utf-8")
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        from config import _parse_yaml  # sibling lib module; resolved via sys.path
+
+        data = _parse_yaml(text)
+    if not isinstance(data, dict):
+        raise ValueError(f"policy file {path} must hold a mapping with a 'rules' list")
+    return validate_rules(data.get("rules"))
+
+
+# ---------------------------------------------------------------------------
+# Store scan
+# ---------------------------------------------------------------------------
+
+
+def _utc(dt):
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=datetime.timezone.utc)
+    return dt
+
+
+def _parse_iso(value):
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return _utc(datetime.datetime.fromisoformat(value.replace("Z", "+00:00")))
+    except ValueError:
+        return None
+
+
+def _mtime(path):
+    return datetime.datetime.fromtimestamp(path.stat().st_mtime, tz=datetime.timezone.utc)
+
+
+def _frontmatter(path):
+    """Parse simple ``key: value`` frontmatter lines from a markdown file."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return {}
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}
+    out = {}
+    for line in lines[1:]:
+        if line.strip() == "---":
+            return out
+        key, _, value = line.partition(":")
+        key, value = key.strip(), value.strip()
+        if key and value:
+            out[key] = value
+    return {}
+
+
+def scan_store(evolve_dir):
+    """Return one item dict per retention-eligible file in the store.
+
+    Items are shaped ``{id, type, path, mtime, trajectory_link}`` where
+    ``trajectory_link`` is the filename of the session the entity was derived
+    from (via its ``trajectory:`` frontmatter), or ``None``.
+    """
+    evolve_dir = Path(evolve_dir)
+    items = []
+
+    entities_root = evolve_dir / "entities"
+    if entities_root.is_dir():
+        for md in sorted(entities_root.glob("**/*.md")):
+            rel = md.relative_to(entities_root)
+            # subscribed/ trees are git clones owned by the sync skill; local
+            # deletes there would be silently restored by the next sync.
+            if rel.parts and rel.parts[0] == "subscribed":
+                continue
+            if md.is_symlink() or ".git" in rel.parts:
+                continue
+            meta = _frontmatter(md)
+            link = meta.get("trajectory")
+            items.append(
+                {
+                    "id": rel.with_suffix("").as_posix(),
+                    "type": meta.get("type") or (rel.parts[0] if len(rel.parts) > 1 else "guideline"),
+                    "path": md,
+                    "mtime": _mtime(md),
+                    "trajectory_link": Path(link).name if link else None,
+                }
+            )
+
+    traj_root = evolve_dir / "trajectories"
+    if traj_root.is_dir():
+        for traj in sorted(traj_root.iterdir()):
+            if not traj.is_file() or traj.is_symlink():
+                continue
+            items.append(
+                {
+                    "id": f"trajectories/{traj.name}",
+                    "type": TRAJECTORY_TYPE,
+                    "path": traj,
+                    "mtime": _mtime(traj),
+                    "trajectory_link": None,
+                }
+            )
+
+    return items
+
+
+def last_access_index(evolve_dir):
+    """Map entity id -> latest ``recall`` timestamp from ``.evolve/audit.log``.
+
+    This is the plugin's "unused" signal: ``audit_recall.py`` appends a recall
+    row (with ``entities: ["<type>/<name>", ...]``) when the agent records the
+    memories it consulted, mirroring what ``AccessStampPlugin`` /
+    ``EvolveClient.record_access`` stamp as ``metadata.last_accessed``
+    package-side. Unlike the package's hook, this one is model-invoked, so an
+    entity's absence from the index means "no recorded recall", not "not used".
+    """
+    audit_log = Path(evolve_dir) / "audit.log"
+    index = {}
+    if not audit_log.is_file():
+        return index
+    for line in audit_log.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(row, dict) or row.get("event") != "recall":
+            continue
+        ts = _parse_iso(row.get("ts"))
+        if ts is None:
+            continue
+        for eid in row.get("entities") or []:
+            if isinstance(eid, str) and eid:
+                prev = index.get(eid)
+                if prev is None or ts > prev:
+                    index[eid] = ts
+    return index
+
+
+# ---------------------------------------------------------------------------
+# Evaluation (mirrors altk_evolve.retention.engine.RetentionEngine.evaluate)
+# ---------------------------------------------------------------------------
+
+
+#: Appended to the "why" of an unused-rule match with no recorded recall.
+NO_RECALL_SIGNAL_HINT = (
+    "no recall row in .evolve/audit.log for this entity, so disuse was measured from file mtime; "
+    "the recall audit is model-invoked, so treat a never-recalled verdict as 'never recorded'"
+)
+
+
+def _match(item, rule, now, last_access):
+    """Return ``(reason, detail)`` if *rule* matches *item*, else None.
+
+    ``reason`` is 'age' or 'unused'; ``detail`` is the human-readable why,
+    including which signal was used and whether it fell back.
+    """
+    if rule["entity_type"] is not None and item["type"] != rule["entity_type"]:
+        return None
+    age_days = (now - item["mtime"]).total_seconds() / 86400.0
+    if rule["max_age_days"] is not None and age_days > rule["max_age_days"]:
+        return "age", "modified {:.1f}d ago > max_age_days={} (from file mtime)".format(age_days, rule["max_age_days"])
+    if rule["max_unused_days"] is not None:
+        recorded = last_access.get(item["id"])
+        last = recorded or item["mtime"]
+        unused_days = (now - last).total_seconds() / 86400.0
+        if unused_days > rule["max_unused_days"]:
+            detail = "not recalled for {:.1f}d > max_unused_days={}".format(unused_days, rule["max_unused_days"])
+            detail += " (from the recall audit log)" if recorded else " — " + NO_RECALL_SIGNAL_HINT
+            return "unused", detail
+    return None
+
+
+def evaluate(evolve_dir, rules, now=None, warnings=None):
+    """Compute the actions the rules imply, without mutating anything.
+
+    Returns a list of ``{id, type, action, reason, rule, detail, path}`` dicts.
+    First matching rule wins per item; delete supersedes flag; a delete rule
+    with ``cascade_derived`` on a trajectory also deletes the entities whose
+    ``trajectory:`` frontmatter links back to it.
+
+    When *warnings* is a list, non-fatal caveats about the run (e.g. a degraded
+    "unused" signal) are appended to it.
+    """
+    now = _utc(now) if now else datetime.datetime.now(datetime.timezone.utc)
+    items = scan_store(evolve_dir)
+    last_access = last_access_index(evolve_dir)
+
+    # Provenance index: trajectory filename -> [derived items]
+    derived_by_name = {}
+    for item in items:
+        link = item["trajectory_link"]
+        if link:
+            derived_by_name.setdefault(link, []).append(item)
+
+    # delete supersedes flag for the same item; first writer otherwise wins.
+    actions = {}
+
+    def record(item, action, reason, rule_name, detail):
+        existing = actions.get(item["id"])
+        if existing is not None and (existing["action"] == "delete" or action == "flag"):
+            return
+        actions[item["id"]] = {
+            "id": item["id"],
+            "type": item["type"],
+            "action": action,
+            "reason": reason,
+            "rule": rule_name,
+            "detail": detail,
+            "path": item["path"],
+        }
+
+    unrecalled = 0
+    uses_unused_rule = any(r["max_unused_days"] is not None for r in rules)
+
+    for item in items:
+        if uses_unused_rule and item["id"] not in last_access:
+            unrecalled += 1
+
+        matched = None
+        for rule in rules:
+            hit = _match(item, rule, now, last_access)
+            if hit is not None:
+                matched = (rule, hit[0], hit[1])
+                break
+        if matched is None:
+            continue
+        rule, reason, detail = matched
+        record(item, rule["action"], reason, rule["name"], detail)
+
+        if rule["action"] == "delete" and rule["cascade_derived"] and item["type"] == TRAJECTORY_TYPE:
+            for derived in derived_by_name.get(item["path"].name, []):
+                if derived["id"] == item["id"]:
+                    continue
+                record(
+                    derived,
+                    "delete",
+                    f"cascade:{item['path'].name}",
+                    rule["name"],
+                    f"trajectory: frontmatter links it to session {item['path'].name}, which this rule deletes",
+                )
+
+    if warnings is not None and unrecalled:
+        warnings.append(
+            f"{unrecalled} of {len(items)} store entries have no recall row in .evolve/audit.log, so their "
+            "disuse was measured from file mtime — for those, an unused rule behaves like an age rule."
+        )
+
+    return list(actions.values())
+
+
+# ---------------------------------------------------------------------------
+# Application
+# ---------------------------------------------------------------------------
+
+
+def _flag_entity_file(path, flagged_at, reason, rule_name):
+    """Upsert retention_* markers into an entity file's frontmatter.
+
+    Preserves the file's mtime so flagging does not reset the age clock.
+    """
+    path = Path(path)
+    st = path.stat()
+    text = path.read_text(encoding="utf-8")
+    marker = [
+        f"retention_flagged_at: {flagged_at}",
+        f"retention_reason: {reason}",
+        f"retention_rule: {rule_name}",
+    ]
+    lines = text.splitlines()
+    closing = None
+    if lines and lines[0].strip() == "---":
+        for i in range(1, len(lines)):
+            if lines[i].strip() == "---":
+                closing = i
+                break
+    if closing is not None:
+        head = [ln for ln in lines[1:closing] if not ln.strip().startswith("retention_")]
+        new_lines = [lines[0], *head, *marker, *lines[closing:]]
+    else:
+        # No frontmatter (shouldn't happen for entities we wrote) — prepend one.
+        new_lines = ["---", *marker, "---", "", *lines]
+    new_text = "\n".join(new_lines)
+    if text.endswith("\n"):
+        new_text += "\n"
+    path.write_text(new_text, encoding="utf-8")
+    os.utime(path, (st.st_atime, st.st_mtime))
+
+
+def apply_actions(evolve_dir, actions, dry_run=True, now=None, warnings=None):
+    """Apply (or, on dry run, merely report) a list of evaluated actions.
+
+    Returns ``{dry_run, flagged, deleted, errors, warnings}`` where
+    flagged/deleted hold the action dicts and errors/warnings hold strings.
+    Non-dry-run actions each append an ``event: "retention"`` row to the audit
+    log.
+    """
+    now = _utc(now) if now else datetime.datetime.now(datetime.timezone.utc)
+    flagged_at = now.isoformat()
+    report = {"dry_run": dry_run, "flagged": [], "deleted": [], "errors": [], "warnings": list(warnings or [])}
+
+    for action in actions:
+        try:
+            if action["action"] == "delete":
+                if not dry_run:
+                    Path(action["path"]).unlink(missing_ok=True)
+                    _audit(evolve_dir, action)
+                report["deleted"].append(action)
+            else:  # flag
+                if not dry_run:
+                    if action["type"] != TRAJECTORY_TYPE:
+                        _flag_entity_file(action["path"], flagged_at, action["reason"], action["rule"])
+                    # Trajectory files are opaque JSON — no frontmatter to mark;
+                    # the audit row below is their durable flag record.
+                    _audit(evolve_dir, action)
+                report["flagged"].append(action)
+        except OSError as exc:  # don't let one bad file abort the sweep
+            report["errors"].append(f"{action['action']} {action['id']}: {exc}")
+
+    return report
+
+
+def _audit(evolve_dir, action):
+    import audit  # sibling lib module; resolved via sys.path
+
+    audit.append(
+        evolve_dir=str(evolve_dir),
+        event="retention",
+        action=action["action"],
+        entity=action["id"],
+        reason=action["reason"],
+        rule=action["rule"],
+    )
+
+
+def run(evolve_dir, rules, dry_run=True, now=None):
+    """Evaluate the rules against the store and apply (or dry-run) the result."""
+    warnings = []
+    actions = evaluate(evolve_dir, rules, now=now, warnings=warnings)
+    return apply_actions(evolve_dir, actions, dry_run=dry_run, now=now, warnings=warnings)
+
+
+def summary(report):
+    verb = "would flag/delete" if report["dry_run"] else "flagged/deleted"
+    return f"{verb}: {len(report['flagged'])} flagged, {len(report['deleted'])} deleted, {len(report['errors'])} errors"
+
+
+if __name__ == "__main__":
+    # Self-test (pure paths only; file behavior is covered by pytest).
+    assert load_rules({}) == []
+    assert load_rules({"retention": {"rules": []}}) == []
+
+    rules = validate_rules([{"name": "r", "max_age_days": 30}])
+    assert rules[0]["action"] == "flag"  # default
+    assert rules[0]["max_age_days"] == 30.0
+
+    for bad in (
+        [{"name": "r"}],  # no threshold
+        [{"name": "r", "max_age_days": 30, "action": "purge"}],  # bad action
+        [{"max_age_days": 30}],  # no name
+        [{"name": "r", "max_age_days": "soon"}],  # non-numeric
+    ):
+        try:
+            validate_rules(bad)
+        except ValueError:
+            pass
+        else:  # pragma: no cover
+            raise AssertionError(f"expected ValueError for {bad}")
+
+    assert _parse_iso("2026-06-29T00:00:00Z") is not None
+    assert _parse_iso("not-a-date") is None
+    assert _parse_iso(None) is None
+    print("retention.py ok")

--- a/plugin-source/lib/retention.py
+++ b/plugin-source/lib/retention.py
@@ -75,6 +75,13 @@ from pathlib import Path
 
 VALID_ACTIONS = ("flag", "delete")
 
+#: What a delete rule does when an "unused" match has no recorded recall (disuse
+#: fell back to file mtime). Mirrors the package's RetentionRule field of the
+#: same name. "skip" (default, fail-safe) spares the entity and reports it;
+#: "flag" downgrades the delete to a non-destructive flag; "delete" deletes on
+#: the mtime fallback (the original behaviour).
+VALID_MISSING_SIGNAL = ("skip", "flag", "delete")
+
 #: How the trajectory tree is typed in rules (matches the package's
 #: ``entity_type: trajectory`` convention).
 TRAJECTORY_TYPE = "trajectory"
@@ -109,6 +116,7 @@ def validate_rules(raw_rules):
             "max_age_days": _coerce_days(raw.get("max_age_days"), name, "max_age_days"),
             "max_unused_days": _coerce_days(raw.get("max_unused_days"), name, "max_unused_days"),
             "action": raw.get("action", "flag"),
+            "on_missing_access_signal": raw.get("on_missing_access_signal", "skip"),
             "cascade_derived": bool(raw.get("cascade_derived", False)),
         }
         entity_type = raw.get("entity_type")
@@ -120,6 +128,11 @@ def validate_rules(raw_rules):
             raise ValueError(f"retention rule {name!r} must set max_age_days and/or max_unused_days")
         if rule["action"] not in VALID_ACTIONS:
             raise ValueError(f"retention rule {name!r}: action must be one of {VALID_ACTIONS}, got {rule['action']!r}")
+        if rule["on_missing_access_signal"] not in VALID_MISSING_SIGNAL:
+            raise ValueError(
+                f"retention rule {name!r}: on_missing_access_signal must be one of {VALID_MISSING_SIGNAL}, "
+                f"got {rule['on_missing_access_signal']!r}"
+            )
         rules.append(rule)
     return rules
 
@@ -302,16 +315,19 @@ NO_RECALL_SIGNAL_HINT = (
 
 
 def _match(item, rule, now, last_access):
-    """Return ``(reason, detail)`` if *rule* matches *item*, else None.
+    """Return ``(reason, detail, degraded)`` if *rule* matches *item*, else None.
 
     ``reason`` is 'age' or 'unused'; ``detail`` is the human-readable why,
-    including which signal was used and whether it fell back.
+    including which signal was used and whether it fell back. ``degraded`` is
+    True only for an 'unused' match whose disuse was measured from file mtime
+    because no recall row existed — ``on_missing_access_signal`` governs whether
+    such a match may still delete.
     """
     if rule["entity_type"] is not None and item["type"] != rule["entity_type"]:
         return None
     age_days = (now - item["mtime"]).total_seconds() / 86400.0
     if rule["max_age_days"] is not None and age_days > rule["max_age_days"]:
-        return "age", "modified {:.1f}d ago > max_age_days={} (from file mtime)".format(age_days, rule["max_age_days"])
+        return "age", "modified {:.1f}d ago > max_age_days={} (from file mtime)".format(age_days, rule["max_age_days"]), False
     if rule["max_unused_days"] is not None:
         recorded = last_access.get(item["id"])
         last = recorded or item["mtime"]
@@ -319,11 +335,11 @@ def _match(item, rule, now, last_access):
         if unused_days > rule["max_unused_days"]:
             detail = "not recalled for {:.1f}d > max_unused_days={}".format(unused_days, rule["max_unused_days"])
             detail += " (from the recall audit log)" if recorded else " — " + NO_RECALL_SIGNAL_HINT
-            return "unused", detail
+            return "unused", detail, not recorded
     return None
 
 
-def evaluate(evolve_dir, rules, now=None, warnings=None):
+def evaluate(evolve_dir, rules, now=None, warnings=None, skipped=None):
     """Compute the actions the rules imply, without mutating anything.
 
     Returns a list of ``{id, type, action, reason, rule, detail, path}`` dicts.
@@ -332,7 +348,9 @@ def evaluate(evolve_dir, rules, now=None, warnings=None):
     ``trajectory:`` frontmatter links back to it.
 
     When *warnings* is a list, non-fatal caveats about the run (e.g. a degraded
-    "unused" signal) are appended to it.
+    "unused" signal) are appended to it. When *skipped* is a list, items a
+    delete rule matched on a degraded signal but was spared under
+    ``on_missing_access_signal: skip`` are appended to it.
     """
     now = _utc(now) if now else datetime.datetime.now(datetime.timezone.utc)
     items = scan_store(evolve_dir)
@@ -373,14 +391,40 @@ def evaluate(evolve_dir, rules, now=None, warnings=None):
         for rule in rules:
             hit = _match(item, rule, now, last_access)
             if hit is not None:
-                matched = (rule, hit[0], hit[1])
+                matched = (rule, hit[0], hit[1], hit[2])
                 break
         if matched is None:
             continue
-        rule, reason, detail = matched
-        record(item, rule["action"], reason, rule["name"], detail)
+        rule, reason, detail, degraded = matched
 
-        if rule["action"] == "delete" and rule["cascade_derived"] and item["type"] == TRAJECTORY_TYPE:
+        action = rule["action"]
+        # A degraded "unused" match (no recall row, disuse from file mtime) only
+        # reaches a destructive action when the rule opts in. Default "skip"
+        # spares it; "flag" downgrades the delete; "delete" keeps the old
+        # behaviour. Only bites deletes — a flag action is not data loss.
+        if degraded and rule["action"] == "delete":
+            choice = rule["on_missing_access_signal"]
+            if choice == "skip":
+                if skipped is not None:
+                    skipped.append(
+                        {
+                            "id": item["id"],
+                            "type": item["type"],
+                            "action": "skip",
+                            "reason": reason,
+                            "rule": rule["name"],
+                            "detail": "matched but not deleted: {}; on_missing_access_signal=skip".format(detail),
+                            "path": item["path"],
+                        }
+                    )
+                continue
+            if choice == "flag":
+                action = "flag"
+                detail += "; downgraded delete->flag (on_missing_access_signal=flag)"
+
+        record(item, action, reason, rule["name"], detail)
+
+        if action == "delete" and rule["cascade_derived"] and item["type"] == TRAJECTORY_TYPE:
             for derived in derived_by_name.get(item["path"].name, []):
                 if derived["id"] == item["id"]:
                     continue
@@ -439,17 +483,24 @@ def _flag_entity_file(path, flagged_at, reason, rule_name):
     os.utime(path, (st.st_atime, st.st_mtime))
 
 
-def apply_actions(evolve_dir, actions, dry_run=True, now=None, warnings=None):
+def apply_actions(evolve_dir, actions, dry_run=True, now=None, warnings=None, skipped=None):
     """Apply (or, on dry run, merely report) a list of evaluated actions.
 
-    Returns ``{dry_run, flagged, deleted, errors, warnings}`` where
-    flagged/deleted hold the action dicts and errors/warnings hold strings.
+    Returns ``{dry_run, flagged, deleted, skipped, errors, warnings}`` where
+    flagged/deleted/skipped hold action dicts and errors/warnings hold strings.
     Non-dry-run actions each append an ``event: "retention"`` row to the audit
     log.
     """
     now = _utc(now) if now else datetime.datetime.now(datetime.timezone.utc)
     flagged_at = now.isoformat()
-    report = {"dry_run": dry_run, "flagged": [], "deleted": [], "errors": [], "warnings": list(warnings or [])}
+    report = {
+        "dry_run": dry_run,
+        "flagged": [],
+        "deleted": [],
+        "skipped": list(skipped or []),
+        "errors": [],
+        "warnings": list(warnings or []),
+    }
 
     for action in actions:
         try:
@@ -488,13 +539,17 @@ def _audit(evolve_dir, action):
 def run(evolve_dir, rules, dry_run=True, now=None):
     """Evaluate the rules against the store and apply (or dry-run) the result."""
     warnings = []
-    actions = evaluate(evolve_dir, rules, now=now, warnings=warnings)
-    return apply_actions(evolve_dir, actions, dry_run=dry_run, now=now, warnings=warnings)
+    skipped = []
+    actions = evaluate(evolve_dir, rules, now=now, warnings=warnings, skipped=skipped)
+    return apply_actions(evolve_dir, actions, dry_run=dry_run, now=now, warnings=warnings, skipped=skipped)
 
 
 def summary(report):
     verb = "would flag/delete" if report["dry_run"] else "flagged/deleted"
-    return f"{verb}: {len(report['flagged'])} flagged, {len(report['deleted'])} deleted, {len(report['errors'])} errors"
+    out = f"{verb}: {len(report['flagged'])} flagged, {len(report['deleted'])} deleted, {len(report['errors'])} errors"
+    if report.get("skipped"):
+        out += f", {len(report['skipped'])} skipped (degraded signal)"
+    return out
 
 
 if __name__ == "__main__":
@@ -504,11 +559,13 @@ if __name__ == "__main__":
 
     rules = validate_rules([{"name": "r", "max_age_days": 30}])
     assert rules[0]["action"] == "flag"  # default
+    assert rules[0]["on_missing_access_signal"] == "skip"  # fail-safe default
     assert rules[0]["max_age_days"] == 30.0
 
     for bad in (
         [{"name": "r"}],  # no threshold
         [{"name": "r", "max_age_days": 30, "action": "purge"}],  # bad action
+        [{"name": "r", "max_age_days": 30, "on_missing_access_signal": "nuke"}],  # bad signal policy
         [{"max_age_days": 30}],  # no name
         [{"name": "r", "max_age_days": "soon"}],  # non-numeric
     ):

--- a/plugin-source/skills/evolve-lite/retention/SKILL.md.j2
+++ b/plugin-source/skills/evolve-lite/retention/SKILL.md.j2
@@ -1,0 +1,91 @@
+{%- from "_macros.j2" import invoke with context -%}
+---
+name: {% if platform == "bob" %}evolve-lite:{% endif %}retention
+description: Apply data-retention rules to the local evolve store — flag or delete stale and unused memories and expired sessions (dry-run by default)
+---
+
+# Retention
+
+## Overview
+
+Runs the data-retention rules configured in `evolve.config.yaml` against the
+local `.evolve/` store: private entities under `.evolve/entities/` and session
+transcripts under `.evolve/trajectories/`. Rules match by entity type plus age
+(`max_age_days`, from file mtime) or disuse (`max_unused_days`, from `recall`
+rows in `.evolve/audit.log`), and either **flag** (a non-destructive frontmatter
+marker) or **delete**. A `delete` rule on trajectories with
+`cascade_derived: true` also deletes the entities derived from those sessions
+(linked by their `trajectory:` frontmatter).
+
+The script is **dry-run by default** — it never mutates anything unless
+`--apply` is passed.
+
+## Workflow
+
+### Step 1: Require rules
+
+Read `evolve.config.yaml`. If there is no `retention:` block with a `rules:`
+list, show the user this example and stop:
+
+```yaml
+retention:
+  rules:
+    - name: stale-guidelines
+      entity_type: guideline
+      max_age_days: 90
+      action: flag
+    - name: old-sessions
+      entity_type: trajectory
+      max_age_days: 365
+      action: delete
+      cascade_derived: true
+```
+
+Each rule needs a `name` and at least one of `max_age_days` /
+`max_unused_days`; `action` is `flag` (default) or `delete`. Rules are checked
+top-to-bottom and the first match wins, so put narrow rules first.
+
+### Step 2: Dry run
+
+From the project root:
+
+```bash
+{{ invoke("retention", "run_retention.py") }}
+```
+
+Show the user the full report — every entry says what *would* be flagged or
+deleted, why (`age`, `unused`, or `cascade:<session>`), by which rule, and on
+what evidence. Relay any `WARNING` lines too: they say when a signal was
+weaker than it looks (for example, disuse measured from file mtime because the
+entity has no recall row).
+
+### Step 3: Apply — only on explicit user confirmation
+
+Deleting is destructive and there is no undo. Ask the user to confirm the
+dry-run report first. Never pass `--apply` without an explicit go-ahead.
+
+```bash
+{{ invoke("retention", "run_retention.py", "--apply") }}
+```
+
+Relay the applied report back to the user.
+
+## Notes
+
+- **Flag** upserts `retention_flagged_at`, `retention_reason`, and
+  `retention_rule` into the entity's frontmatter; the file's mtime is
+  preserved so its age clock doesn't reset. Trajectory files are opaque JSON,
+  so their flag is recorded in `.evolve/audit.log` only.
+- Every applied action is logged to `.evolve/audit.log` as an
+  `event: "retention"` row.
+- Subscribed entities (`.evolve/entities/subscribed/`) are out of scope — they
+  are git clones owned by the sync skill and local deletes would be restored
+  on the next sync.
+- A standalone policy file can be passed with `--policy <file>` (a `rules:`
+  list in JSON or YAML), overriding the config block.
+- Signal caveats, worth stating when you relay a report: age is **file mtime**
+  (editing an entity resets its clock — there is no `created_at` in the
+  store), and the disuse signal only exists for entities the agent recorded
+  via the recall audit step. The `trajectory:` cascade link is supported but
+  nothing writes it automatically today, so `cascade_derived` only fires for
+  entities where that key was set by hand.

--- a/plugin-source/skills/evolve-lite/retention/SKILL.md.j2
+++ b/plugin-source/skills/evolve-lite/retention/SKILL.md.j2
@@ -43,7 +43,16 @@ retention:
 
 Each rule needs a `name` and at least one of `max_age_days` /
 `max_unused_days`; `action` is `flag` (default) or `delete`. Rules are checked
-top-to-bottom and the first match wins, so put narrow rules first.
+top-to-bottom and the first match wins, so put narrow rules first — and put a
+longer-threshold `delete` before a shorter-threshold `flag` on the same type,
+or the flag shadows the delete and it never fires.
+
+A `delete` rule may also set `on_missing_access_signal` to say what happens when
+an `unused` match has **no recorded recall** (disuse measured from file mtime):
+`skip` (default, fail-safe — spare it and report it as skipped), `flag`
+(downgrade the delete to a non-destructive flag), or `delete` (delete on the
+mtime fallback anyway). The safe default means an `unused` delete never destroys
+a memory the agent simply never recorded a recall for.
 
 ### Step 2: Dry run
 
@@ -53,11 +62,12 @@ From the project root:
 {{ invoke("retention", "run_retention.py") }}
 ```
 
-Show the user the full report — every entry says what *would* be flagged or
-deleted, why (`age`, `unused`, or `cascade:<session>`), by which rule, and on
-what evidence. Relay any `WARNING` lines too: they say when a signal was
-weaker than it looks (for example, disuse measured from file mtime because the
-entity has no recall row).
+Show the user the full report — every entry says what *would* be flagged,
+deleted, or skipped, why (`age`, `unused`, or `cascade:<session>`), by which
+rule, and on what evidence. `SKIP` lines are entities a `delete` rule matched on
+a degraded signal but spared under `on_missing_access_signal: skip`. Relay any
+`WARNING` lines too: they say when a signal was weaker than it looks (for
+example, disuse measured from file mtime because the entity has no recall row).
 
 ### Step 3: Apply — only on explicit user confirmation
 

--- a/plugin-source/skills/evolve-lite/retention/scripts/run_retention.py
+++ b/plugin-source/skills/evolve-lite/retention/scripts/run_retention.py
@@ -76,6 +76,10 @@ def main():
     if not report["deleted"] and not report["flagged"]:
         print("  (no memories matched any rule)")
 
+    for action in report.get("skipped", []):
+        print(f"  SKIP   {action['id']}  reason={action['reason']}  rule={action['rule']}")
+        print(f"         why: {action['detail']}")
+
     for warning in report["warnings"]:
         print(f"  WARNING  {warning}")
     for err in report["errors"]:

--- a/plugin-source/skills/evolve-lite/retention/scripts/run_retention.py
+++ b/plugin-source/skills/evolve-lite/retention/scripts/run_retention.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""
+Retention Script
+Applies data-retention rules to the local .evolve store: flags or deletes
+stale / unused memories and expired sessions. Dry-run by default; nothing
+is mutated unless --apply is passed.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+# Walk up from the script location to find the installed plugin lib directory.
+# Every host installs the shared lib under lib/evolve-lite/ so multiple
+# plugins can coexist side by side (e.g. .bob/lib/evolve-lite/).
+_script = Path(__file__).resolve()
+_lib = None
+for _ancestor in _script.parents:
+    _candidate = _ancestor / "lib" / "evolve-lite"
+    if (_candidate / "entity_io.py").is_file():
+        _lib = _candidate
+        break
+if _lib is None:
+    raise ImportError(f"Cannot find plugin lib directory above {_script}")
+sys.path.insert(0, str(_lib))
+from entity_io import get_evolve_dir, log as _log  # noqa: E402
+from config import load_config  # noqa: E402
+import retention  # noqa: E402
+
+
+def log(message):
+    _log("retention", message)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Apply retention rules to the .evolve store (dry-run by default).")
+    parser.add_argument("--apply", action="store_true", help="Actually flag/delete. Without this flag, only report.")
+    parser.add_argument("--policy", default=None, help="Standalone policy file (JSON or YAML 'rules:' list) overriding evolve.config.yaml.")
+    args = parser.parse_args()
+
+    try:
+        if args.policy:
+            rules = retention.load_policy_file(args.policy)
+        else:
+            rules = retention.load_rules(load_config())
+    except (ValueError, OSError) as exc:
+        log(f"Invalid retention rules: {exc}")
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if not rules:
+        print(
+            "No retention rules configured. Add a `retention:` block with a `rules:` list to evolve.config.yaml (or pass --policy <file>)."
+        )
+        sys.exit(0)
+
+    evolve_dir = get_evolve_dir()
+    if not evolve_dir.is_dir():
+        print(f"No evolve store at {evolve_dir}; nothing to do.")
+        sys.exit(0)
+    evolve_dir = evolve_dir.resolve()
+
+    dry_run = not args.apply
+    report = retention.run(evolve_dir, rules, dry_run=dry_run)
+    log(f"{'DRY RUN' if dry_run else 'APPLY'}: {retention.summary(report)}")
+
+    if dry_run:
+        print("DRY RUN — nothing was changed. Re-run with --apply to enforce.")
+    else:
+        print("APPLIED:")
+
+    for action in [*report["deleted"], *report["flagged"]]:
+        verb = action["action"].upper()
+        print(f"  {verb:6} {action['id']}  reason={action['reason']}  rule={action['rule']}")
+        print(f"         why: {action['detail']}")
+    if not report["deleted"] and not report["flagged"]:
+        print("  (no memories matched any rule)")
+
+    for warning in report["warnings"]:
+        print(f"  WARNING  {warning}")
+    for err in report["errors"]:
+        print(f"  ERROR  {err}", file=sys.stderr)
+
+    print(retention.summary(report))
+    sys.exit(1 if report["errors"] else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,6 +221,7 @@ module = [
     "local_mcp_server",
     "config",
     "audit",
+    "retention",
     "yaml",
 ]
 ignore_missing_imports = true

--- a/tests/platform_integrations/test_retention_plugin.py
+++ b/tests/platform_integrations/test_retention_plugin.py
@@ -116,18 +116,73 @@ def test_unused_uses_recall_audit_when_present(evolve_dir):
     assert report["flagged"][0]["reason"] == "unused"
 
 
-def test_unused_falls_back_to_mtime_when_never_recalled_and_says_so(evolve_dir):
+def test_unused_delete_without_recall_skips_by_default_and_reports_it(evolve_dir):
+    """FIX 2: an unused DELETE on a never-recalled entity must not silently
+    unlink it. The fail-safe default spares it, reports it as skipped, and still
+    emits the degraded-signal warning."""
     never_recalled = _write_entity(evolve_dir, "forgotten", days_old=60)
     rules = _rules({"name": "idle", "max_unused_days": 30, "action": "delete"})
 
     report = retention.run(evolve_dir, rules, dry_run=False, now=NOW)
 
-    assert [a["id"] for a in report["deleted"]] == ["guideline/forgotten"]
-    assert not never_recalled.exists()
-    # the degraded signal is reported, not silently substituted
-    assert "file mtime" in report["deleted"][0]["detail"]
+    assert report["deleted"] == []
+    assert never_recalled.exists()  # spared
+    assert [a["id"] for a in report["skipped"]] == ["guideline/forgotten"]
+    assert "on_missing_access_signal=skip" in report["skipped"][0]["detail"]
     assert len(report["warnings"]) == 1
     assert "no recall row" in report["warnings"][0]
+
+
+def test_unused_delete_without_recall_deletes_when_opted_in(evolve_dir):
+    """on_missing_access_signal='delete' restores the mtime-fallback delete."""
+    never_recalled = _write_entity(evolve_dir, "forgotten", days_old=60)
+    rules = _rules({"name": "idle", "max_unused_days": 30, "action": "delete", "on_missing_access_signal": "delete"})
+
+    report = retention.run(evolve_dir, rules, dry_run=False, now=NOW)
+
+    assert [a["id"] for a in report["deleted"]] == ["guideline/forgotten"]
+    assert not never_recalled.exists()
+    assert "file mtime" in report["deleted"][0]["detail"]
+    assert report["skipped"] == []
+
+
+def test_unused_delete_without_recall_downgrades_to_flag_when_configured(evolve_dir):
+    """on_missing_access_signal='flag' turns the delete into a flag."""
+    entity = _write_entity(evolve_dir, "forgotten", days_old=60)
+    rules = _rules({"name": "idle", "max_unused_days": 30, "action": "delete", "on_missing_access_signal": "flag"})
+
+    report = retention.run(evolve_dir, rules, dry_run=False, now=NOW)
+
+    assert report["deleted"] == []
+    assert [a["id"] for a in report["flagged"]] == ["guideline/forgotten"]
+    assert "downgraded delete->flag" in report["flagged"][0]["detail"]
+    assert "retention_reason: unused" in entity.read_text(encoding="utf-8")
+
+
+def test_unused_delete_with_recall_deletes_normally_under_default_skip(evolve_dir):
+    """A recorded recall (idle past the threshold) is a real signal — the
+    default skip does not spare it."""
+    entity = _write_entity(evolve_dir, "idle", days_old=300)
+    _recall(evolve_dir, "guideline/idle", days_ago=60)
+    rules = _rules({"name": "idle", "max_unused_days": 30, "action": "delete"})  # skip default
+
+    report = retention.run(evolve_dir, rules, dry_run=False, now=NOW)
+
+    assert [a["id"] for a in report["deleted"]] == ["guideline/idle"]
+    assert not entity.exists()
+    assert report["skipped"] == []
+
+
+def test_flag_rule_flags_never_recalled_entity_under_default_skip(evolve_dir):
+    """skip only bites deletes — a flag rule flags a never-recalled entity."""
+    entity = _write_entity(evolve_dir, "forgotten", days_old=60)
+    rules = _rules({"name": "idle", "max_unused_days": 30, "action": "flag"})
+
+    report = retention.run(evolve_dir, rules, dry_run=False, now=NOW)
+
+    assert [a["id"] for a in report["flagged"]] == ["guideline/forgotten"]
+    assert report["skipped"] == []
+    assert "retention_flagged_at" in entity.read_text(encoding="utf-8")
 
 
 def test_no_degraded_signal_warning_without_an_unused_rule(evolve_dir):
@@ -200,6 +255,24 @@ def test_cascade_is_inert_without_a_trajectory_frontmatter_link(evolve_dir):
     assert unlinked.exists()
 
 
+def test_empty_trajectory_link_does_not_cascade(evolve_dir):
+    """FIX 1 (plugin): an empty ``trajectory:`` frontmatter value is not a real
+    provenance link and must never join a cascade bucket."""
+    session = _write_trajectory(evolve_dir, "trajectory_2025-05-01T00-00-00_T1.json", days_old=400)
+    # frontmatter carries a literal `trajectory:` line with an empty value
+    type_dir = evolve_dir / "entities" / "guideline"
+    type_dir.mkdir(parents=True, exist_ok=True)
+    empty_link = type_dir / "empty-link.md"
+    empty_link.write_text("---\ntype: guideline\ntrajectory: \n---\n\ncontent\n", encoding="utf-8")
+    _set_age(empty_link, 1)
+    rules = _rules({"name": "old-sessions", "entity_type": "trajectory", "max_age_days": 365, "action": "delete", "cascade_derived": True})
+
+    report = retention.run(evolve_dir, rules, dry_run=False, now=NOW)
+
+    assert {a["id"] for a in report["deleted"]} == {f"trajectories/{session.name}"}
+    assert empty_link.exists()
+
+
 def test_cascade_off_leaves_derived_memories(evolve_dir):
     session = _write_trajectory(evolve_dir, "trajectory_2025-05-01T00-00-00_T1.json", days_old=400)
     derived = _write_entity(evolve_dir, "derived", days_old=1, trajectory=f".evolve/trajectories/{session.name}")
@@ -266,6 +339,16 @@ def test_rule_requires_a_threshold():
 def test_rule_rejects_unknown_action():
     with pytest.raises(ValueError, match="action"):
         retention.validate_rules([{"name": "bad", "max_age_days": 30, "action": "purge"}])
+
+
+def test_rule_rejects_unknown_missing_signal_policy():
+    with pytest.raises(ValueError, match="on_missing_access_signal"):
+        retention.validate_rules([{"name": "bad", "max_unused_days": 30, "action": "delete", "on_missing_access_signal": "nuke"}])
+
+
+def test_rule_defaults_missing_signal_to_skip():
+    rules = retention.validate_rules([{"name": "r", "max_unused_days": 30, "action": "delete"}])
+    assert rules[0]["on_missing_access_signal"] == "skip"
 
 
 def test_load_rules_from_config_yaml_block():

--- a/tests/platform_integrations/test_retention_plugin.py
+++ b/tests/platform_integrations/test_retention_plugin.py
@@ -1,0 +1,293 @@
+"""Tests for the evolve-lite plugin retention engine (plugin-source/lib/retention.py).
+
+Imported directly from plugin-source (the source of truth), like test_pii.py.
+Runs against a fabricated ``.evolve/`` tree in tmp_path; ``now`` is injected
+and file ages are set via ``os.utime`` for stable, deterministic ages.
+"""
+
+import datetime
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "plugin-source" / "lib"))
+import config  # noqa: E402
+import retention  # noqa: E402
+
+pytestmark = [pytest.mark.platform_integrations, pytest.mark.unit]
+
+NOW = datetime.datetime(2026, 6, 29, tzinfo=datetime.timezone.utc)
+
+
+def _set_age(path, days_old):
+    ts = (NOW - datetime.timedelta(days=days_old)).timestamp()
+    os.utime(path, (ts, ts))
+
+
+def _write_entity(evolve_dir, name, type="guideline", days_old=0, trajectory=None):
+    type_dir = evolve_dir / "entities" / type
+    type_dir.mkdir(parents=True, exist_ok=True)
+    lines = ["---", f"type: {type}", "trigger: when testing"]
+    if trajectory:
+        lines.append(f"trajectory: {trajectory}")
+    lines += ["---", "", f"content of {name}", ""]
+    path = type_dir / f"{name}.md"
+    path.write_text("\n".join(lines), encoding="utf-8")
+    _set_age(path, days_old)
+    return path
+
+
+def _write_trajectory(evolve_dir, name, days_old=0):
+    traj_dir = evolve_dir / "trajectories"
+    traj_dir.mkdir(parents=True, exist_ok=True)
+    path = traj_dir / name
+    path.write_text(json.dumps({"messages": [{"role": "user", "content": "hi"}]}), encoding="utf-8")
+    _set_age(path, days_old)
+    return path
+
+
+def _recall(evolve_dir, entity_id, days_ago):
+    row = {
+        "event": "recall",
+        "session_id": "s1",
+        "entities": [entity_id],
+        "ts": (NOW - datetime.timedelta(days=days_ago)).isoformat(),
+    }
+    with (evolve_dir / "audit.log").open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(row) + "\n")
+
+
+@pytest.fixture
+def evolve_dir(tmp_path):
+    d = tmp_path / ".evolve"
+    d.mkdir()
+    return d
+
+
+def _rules(*raw):
+    return retention.validate_rules(list(raw))
+
+
+# ── age-based ─────────────────────────────────────────────────────────
+
+
+def test_age_flag_marks_old_entities_without_deleting(evolve_dir):
+    old = _write_entity(evolve_dir, "old", days_old=100)
+    young = _write_entity(evolve_dir, "young", days_old=10)
+    rules = _rules({"name": "stale", "max_age_days": 90, "action": "flag"})
+
+    report = retention.run(evolve_dir, rules, dry_run=False, now=NOW)
+
+    assert [a["id"] for a in report["flagged"]] == ["guideline/old"]
+    assert report["deleted"] == []
+    text = old.read_text(encoding="utf-8")
+    assert "retention_flagged_at:" in text
+    assert "retention_reason: age" in text
+    assert "retention_rule: stale" in text
+    assert "retention_" not in young.read_text(encoding="utf-8")
+
+
+def test_age_delete_removes_old_entities(evolve_dir):
+    old = _write_entity(evolve_dir, "ancient", days_old=400)
+    rules = _rules({"name": "old", "max_age_days": 365, "action": "delete"})
+
+    report = retention.run(evolve_dir, rules, dry_run=False, now=NOW)
+
+    assert [a["id"] for a in report["deleted"]] == ["guideline/ancient"]
+    assert not old.exists()
+
+
+# ── unused-based ──────────────────────────────────────────────────────
+
+
+def test_unused_uses_recall_audit_when_present(evolve_dir):
+    _write_entity(evolve_dir, "used", days_old=300)
+    _write_entity(evolve_dir, "idle", days_old=300)
+    _recall(evolve_dir, "guideline/used", days_ago=5)
+    _recall(evolve_dir, "guideline/idle", days_ago=60)
+    rules = _rules({"name": "idle", "max_unused_days": 30, "action": "flag"})
+
+    report = retention.run(evolve_dir, rules, dry_run=False, now=NOW)
+
+    assert [a["id"] for a in report["flagged"]] == ["guideline/idle"]
+    assert report["flagged"][0]["reason"] == "unused"
+
+
+def test_unused_falls_back_to_mtime_when_never_recalled_and_says_so(evolve_dir):
+    never_recalled = _write_entity(evolve_dir, "forgotten", days_old=60)
+    rules = _rules({"name": "idle", "max_unused_days": 30, "action": "delete"})
+
+    report = retention.run(evolve_dir, rules, dry_run=False, now=NOW)
+
+    assert [a["id"] for a in report["deleted"]] == ["guideline/forgotten"]
+    assert not never_recalled.exists()
+    # the degraded signal is reported, not silently substituted
+    assert "file mtime" in report["deleted"][0]["detail"]
+    assert len(report["warnings"]) == 1
+    assert "no recall row" in report["warnings"][0]
+
+
+def test_no_degraded_signal_warning_without_an_unused_rule(evolve_dir):
+    _write_entity(evolve_dir, "old", days_old=400)
+    rules = _rules({"name": "old", "max_age_days": 365, "action": "flag"})
+
+    report = retention.run(evolve_dir, rules, dry_run=True, now=NOW)
+
+    assert report["warnings"] == []
+    assert "file mtime" in report["flagged"][0]["detail"]
+
+
+# ── dry run ───────────────────────────────────────────────────────────
+
+
+def test_dry_run_reports_without_mutating(evolve_dir):
+    doomed = _write_entity(evolve_dir, "doomed", days_old=400)
+    flaggable = _write_entity(evolve_dir, "flaggable", type="note", days_old=200)
+    before = flaggable.read_text(encoding="utf-8")
+    rules = _rules(
+        {"name": "old", "entity_type": "guideline", "max_age_days": 90, "action": "delete"},
+        {"name": "stale-notes", "entity_type": "note", "max_age_days": 90, "action": "flag"},
+    )
+
+    report = retention.run(evolve_dir, rules, dry_run=True, now=NOW)
+
+    assert report["dry_run"] is True
+    assert [a["id"] for a in report["deleted"]] == ["guideline/doomed"]  # would delete
+    assert [a["id"] for a in report["flagged"]] == ["note/flaggable"]  # would flag
+    assert doomed.exists()  # but did not delete
+    assert flaggable.read_text(encoding="utf-8") == before  # and did not flag
+    assert not (evolve_dir / "audit.log").exists()  # no audit rows on dry run
+
+
+# ── session retention + provenance cascade ────────────────────────────
+
+
+def test_cascade_delete_removes_derived_memories(evolve_dir):
+    session = _write_trajectory(evolve_dir, "trajectory_2025-05-01T00-00-00_T1.json", days_old=400)
+    derived = _write_entity(evolve_dir, "derived", days_old=1, trajectory=f".evolve/trajectories/{session.name}")
+    unrelated = _write_entity(evolve_dir, "unrelated", days_old=1, trajectory=".evolve/trajectories/trajectory_other_T2.json")
+    rules = _rules({"name": "old-sessions", "entity_type": "trajectory", "max_age_days": 365, "action": "delete", "cascade_derived": True})
+
+    report = retention.run(evolve_dir, rules, dry_run=False, now=NOW)
+
+    deleted_ids = {a["id"] for a in report["deleted"]}
+    assert deleted_ids == {f"trajectories/{session.name}", "guideline/derived"}
+    assert not session.exists()
+    assert not derived.exists()
+    assert unrelated.exists()  # different session, untouched
+    cascade = next(a for a in report["deleted"] if a["id"] == "guideline/derived")
+    assert cascade["reason"] == f"cascade:{session.name}"
+    assert "trajectory: frontmatter" in cascade["detail"]
+
+
+def test_cascade_is_inert_without_a_trajectory_frontmatter_link(evolve_dir):
+    """Documented gap: nothing in the shipped plugin writes ``trajectory:``.
+
+    A memory saved by the normal flow carries no link, so deleting its session
+    does NOT cascade to it — unlike the package side, where the link is
+    metadata the writers actually stamp.
+    """
+    session = _write_trajectory(evolve_dir, "trajectory_2025-05-01T00-00-00_T1.json", days_old=400)
+    unlinked = _write_entity(evolve_dir, "saved-normally", days_old=1)
+    rules = _rules({"name": "old-sessions", "entity_type": "trajectory", "max_age_days": 365, "action": "delete", "cascade_derived": True})
+
+    report = retention.run(evolve_dir, rules, dry_run=False, now=NOW)
+
+    assert {a["id"] for a in report["deleted"]} == {f"trajectories/{session.name}"}
+    assert unlinked.exists()
+
+
+def test_cascade_off_leaves_derived_memories(evolve_dir):
+    session = _write_trajectory(evolve_dir, "trajectory_2025-05-01T00-00-00_T1.json", days_old=400)
+    derived = _write_entity(evolve_dir, "derived", days_old=1, trajectory=f".evolve/trajectories/{session.name}")
+    rules = _rules({"name": "old-sessions", "entity_type": "trajectory", "max_age_days": 365, "action": "delete"})
+
+    report = retention.run(evolve_dir, rules, dry_run=False, now=NOW)
+
+    assert {a["id"] for a in report["deleted"]} == {f"trajectories/{session.name}"}
+    assert derived.exists()
+
+
+# ── flag mechanics ────────────────────────────────────────────────────
+
+
+def test_flag_preserves_mtime_so_age_clock_is_stable(evolve_dir):
+    old = _write_entity(evolve_dir, "old", days_old=100)
+    mtime_before = old.stat().st_mtime
+    rules = _rules({"name": "stale", "max_age_days": 90, "action": "flag"})
+
+    retention.run(evolve_dir, rules, dry_run=False, now=NOW)
+
+    assert old.stat().st_mtime == pytest.approx(mtime_before)
+    # Re-running upserts (no duplicate marker lines).
+    retention.run(evolve_dir, rules, dry_run=False, now=NOW)
+    text = old.read_text(encoding="utf-8")
+    assert text.count("retention_flagged_at:") == 1
+
+
+def test_apply_appends_retention_audit_rows(evolve_dir):
+    _write_entity(evolve_dir, "old", days_old=400)
+    rules = _rules({"name": "old", "max_age_days": 365, "action": "delete"})
+
+    retention.run(evolve_dir, rules, dry_run=False, now=NOW)
+
+    rows = [json.loads(line) for line in (evolve_dir / "audit.log").read_text(encoding="utf-8").splitlines()]
+    assert any(r.get("event") == "retention" and r.get("action") == "delete" and r.get("entity") == "guideline/old" for r in rows)
+
+
+# ── scope ─────────────────────────────────────────────────────────────
+
+
+def test_subscribed_entities_are_out_of_scope(evolve_dir):
+    sub_dir = evolve_dir / "entities" / "subscribed" / "team-repo" / "guideline"
+    sub_dir.mkdir(parents=True)
+    sub = sub_dir / "shared.md"
+    sub.write_text("---\ntype: guideline\ntrigger: t\n---\n\nshared\n", encoding="utf-8")
+    _set_age(sub, 400)
+    rules = _rules({"name": "old", "max_age_days": 90, "action": "delete"})
+
+    report = retention.run(evolve_dir, rules, dry_run=False, now=NOW)
+
+    assert report["deleted"] == []
+    assert sub.exists()
+
+
+# ── rule schema ───────────────────────────────────────────────────────
+
+
+def test_rule_requires_a_threshold():
+    with pytest.raises(ValueError, match="max_age_days"):
+        retention.validate_rules([{"name": "bad"}])
+
+
+def test_rule_rejects_unknown_action():
+    with pytest.raises(ValueError, match="action"):
+        retention.validate_rules([{"name": "bad", "max_age_days": 30, "action": "purge"}])
+
+
+def test_load_rules_from_config_yaml_block():
+    cfg = config._parse_yaml(
+        "retention:\n"
+        "  rules:\n"
+        "    - name: stale\n"
+        "      entity_type: guideline\n"
+        "      max_age_days: 90\n"
+        "      action: flag\n"
+        "    - name: old-sessions\n"
+        "      entity_type: trajectory\n"
+        "      max_age_days: 365\n"
+        "      action: delete\n"
+        "      cascade_derived: true\n"
+    )
+    rules = retention.load_rules(cfg)
+    assert [r["name"] for r in rules] == ["stale", "old-sessions"]
+    assert rules[0]["action"] == "flag"
+    assert rules[1]["cascade_derived"] is True
+
+
+def test_load_rules_defaults_to_empty():
+    assert retention.load_rules({}) == []
+    assert retention.load_rules(None) == []

--- a/tests/unit/test_retention.py
+++ b/tests/unit/test_retention.py
@@ -108,18 +108,73 @@ def test_unused_uses_last_accessed_when_present():
     assert report.warnings == []
 
 
-def test_unused_without_access_stamp_falls_back_to_created_at_and_says_so():
-    """The PoC silently used created_at here. Now the fallback is reported."""
+def test_unused_delete_without_access_stamp_skips_by_default_and_reports_it():
+    """FIX 2: an unused DELETE on a never-stamped entity must not silently
+    destroy it. The fail-safe default (on_missing_access_signal='skip') spares
+    it, records it in report.skipped, and still emits the degraded-signal warning."""
     client = FakeClient([_entity("1", created_days_ago=60)])
     policy = RetentionPolicy(rules=[RetentionRule(name="idle", max_unused_days=30, action="delete")])
 
     report = RetentionEngine(client).apply("ns", policy, now=NOW, dry_run=True)
 
+    assert report.deleted == []  # not deleted on the created_at fallback
+    assert [i.entity_id for i in report.skipped] == ["1"]
+    skip_detail = report.skipped[0].detail
+    assert "on_missing_access_signal=skip" in skip_detail
+    assert "created_at" in skip_detail and "AccessStampPlugin" in skip_detail
+    assert len(report.warnings) == 1
+    assert "1 of 1 entities carry no metadata.last_accessed" in report.warnings[0]
+
+
+def test_unused_delete_without_stamp_deletes_when_opted_in():
+    """on_missing_access_signal='delete' restores the explicit opt-in behaviour."""
+    client = FakeClient([_entity("1", created_days_ago=60)])
+    policy = RetentionPolicy(rules=[RetentionRule(name="idle", max_unused_days=30, action="delete", on_missing_access_signal="delete")])
+
+    report = RetentionEngine(client).apply("ns", policy, now=NOW, dry_run=True)
+
     assert [i.entity_id for i in report.deleted] == ["1"]
+    assert report.skipped == []
     detail = report.deleted[0].detail
     assert "created_at" in detail and "AccessStampPlugin" in detail
     assert len(report.warnings) == 1
-    assert "1 of 1 entities carry no metadata.last_accessed" in report.warnings[0]
+
+
+def test_unused_delete_without_stamp_downgrades_to_flag_when_configured():
+    """on_missing_access_signal='flag' turns the destructive action into a flag."""
+    client = FakeClient([_entity("1", created_days_ago=60)])
+    policy = RetentionPolicy(rules=[RetentionRule(name="idle", max_unused_days=30, action="delete", on_missing_access_signal="flag")])
+
+    report = RetentionEngine(client).apply("ns", policy, now=NOW, dry_run=False)
+
+    assert report.deleted == []
+    assert [i.entity_id for i in report.flagged] == ["1"]
+    assert "downgraded delete->flag" in report.flagged[0].detail
+    assert client.store["1"].metadata["retention_reason"] == "unused"
+
+
+def test_unused_delete_with_real_stamp_deletes_normally_regardless_of_missing_signal_knob():
+    """A real last_accessed stamp is unaffected by on_missing_access_signal."""
+    stamped = _entity("1", created_days_ago=300, metadata={"last_accessed": (NOW - datetime.timedelta(days=60)).isoformat()})
+    client = FakeClient([stamped])
+    policy = RetentionPolicy(rules=[RetentionRule(name="idle", max_unused_days=30, action="delete")])  # skip default
+
+    report = RetentionEngine(client).apply("ns", policy, now=NOW, dry_run=False)
+
+    assert [i.entity_id for i in report.deleted] == ["1"]
+    assert report.skipped == []
+
+
+def test_flag_rule_flags_never_stamped_entity_even_with_default_skip():
+    """skip only bites deletes — a flag action is not data loss, so a flag rule
+    flags a never-stamped entity as usual under the default."""
+    client = FakeClient([_entity("1", created_days_ago=60)])
+    policy = RetentionPolicy(rules=[RetentionRule(name="idle", max_unused_days=30, action="flag")])
+
+    report = RetentionEngine(client).apply("ns", policy, now=NOW, dry_run=False)
+
+    assert [i.entity_id for i in report.flagged] == ["1"]
+    assert report.skipped == []
 
 
 def test_no_degraded_signal_warning_without_an_unused_rule():
@@ -277,6 +332,78 @@ def test_cascade_off_leaves_derived_memories():
     assert "g1" in client.store
 
 
+def test_empty_trace_id_does_not_cascade_unrelated_entities():
+    """FIX 1: an empty-string trace_id must not bucket every no-provenance
+    entity together and cascade-delete them."""
+    trajectory = _entity("traj", type="trajectory", created_days_ago=400, metadata={"trace_id": ""})
+    # two unrelated guidelines that happen to carry an empty/absent source link
+    a = _entity("g1", type="guideline", created_days_ago=1, metadata={"source_task_id": ""})
+    b = _entity("g2", type="guideline", created_days_ago=1, metadata={})
+    client = FakeClient([trajectory, a, b])
+    policy = RetentionPolicy(
+        rules=[RetentionRule(name="old-sessions", entity_type="trajectory", max_age_days=365, action="delete", cascade_derived=True)]
+    )
+
+    report = RetentionEngine(client).apply("ns", policy, now=NOW, dry_run=False)
+
+    # only the trajectory itself ages out; nothing cascades off the empty trace
+    assert {i.entity_id for i in report.deleted} == {"traj"}
+    assert "g1" in client.store
+    assert "g2" in client.store
+
+
+def test_cascade_does_not_match_across_types_on_empty_values():
+    """An empty source_task_id must never join a cascade bucket even if the
+    session's trace id is also falsy."""
+    trajectory = _entity("traj", type="trajectory", created_days_ago=400, metadata={"task_id": ""})
+    derived = _entity("g1", type="guideline", created_days_ago=1, metadata={"source_task_id": ""})
+    client = FakeClient([trajectory, derived])
+    policy = RetentionPolicy(
+        rules=[RetentionRule(name="old-sessions", entity_type="trajectory", max_age_days=365, action="delete", cascade_derived=True)]
+    )
+
+    report = RetentionEngine(client).apply("ns", policy, now=NOW, dry_run=False)
+
+    assert {i.entity_id for i in report.deleted} == {"traj"}
+    assert "g1" in client.store
+
+
+def test_cascade_matches_int_trace_id_against_str_source_task_id():
+    """FIX 1: coercion is consistent — an int trace_id matches a str
+    source_task_id of the same non-empty value."""
+    trajectory = _entity("traj", type="trajectory", created_days_ago=400, metadata={"trace_id": 1})
+    derived = _entity("g1", type="guideline", created_days_ago=1, metadata={"source_task_id": "1"})
+    client = FakeClient([trajectory, derived])
+    policy = RetentionPolicy(
+        rules=[RetentionRule(name="old-sessions", entity_type="trajectory", max_age_days=365, action="delete", cascade_derived=True)]
+    )
+
+    report = RetentionEngine(client).apply("ns", policy, now=NOW, dry_run=False)
+
+    assert {i.entity_id for i in report.deleted} == {"traj", "g1"}
+    assert next(i for i in report.deleted if i.entity_id == "g1").reason == "cascade:1"
+
+
+def test_scan_limit_boundary_emits_warning():
+    """FIX 3: when the fetch returns exactly the limit, warn that entities
+    beyond it were not evaluated."""
+    client = FakeClient([_entity(str(i), created_days_ago=400) for i in range(3)])
+    policy = RetentionPolicy(rules=[RetentionRule(name="old", max_age_days=90, action="delete")])
+
+    report = RetentionEngine(client).apply("ns", policy, now=NOW, dry_run=True, scan_limit=3)
+
+    assert any("fetch limit of 3" in w for w in report.warnings)
+
+
+def test_scan_limit_under_boundary_emits_no_warning():
+    client = FakeClient([_entity(str(i), created_days_ago=400) for i in range(2)])
+    policy = RetentionPolicy(rules=[RetentionRule(name="old", max_age_days=90, action="delete")])
+
+    report = RetentionEngine(client).apply("ns", policy, now=NOW, dry_run=True, scan_limit=100)
+
+    assert not any("fetch limit" in w for w in report.warnings)
+
+
 def test_cascade_delete_supersedes_a_flag_from_an_earlier_rule():
     trajectory = _entity("traj", type="trajectory", created_days_ago=400, metadata={"trace_id": "T1"})
     derived = _entity("g1", type="guideline", created_days_ago=200, metadata={"source_task_id": "T1"})
@@ -329,7 +456,9 @@ def test_record_access_makes_the_unused_rule_meaningful():
     client = FakeClient([old_but_used, old_and_idle])
     # Simulate what record_access / AccessStampPlugin write.
     client.patch_entity_metadata("ns", "1", {"last_accessed": (NOW - datetime.timedelta(days=1)).isoformat()})
-    policy = RetentionPolicy(rules=[RetentionRule(name="idle", max_unused_days=90, action="delete")])
+    # opt into deleting on the created_at fallback so the never-stamped "2" is
+    # the one this test exercises (the fail-safe default would merely skip it).
+    policy = RetentionPolicy(rules=[RetentionRule(name="idle", max_unused_days=90, action="delete", on_missing_access_signal="delete")])
 
     report = RetentionEngine(client).apply("ns", policy, now=NOW, dry_run=False)
 
@@ -346,6 +475,34 @@ def test_record_access_skips_failures_without_raising(tmp_path):
     client.ensure_namespace("ns")
 
     client.record_access("ns", ["does-not-exist"])  # must not raise
+
+
+def test_real_store_dry_run_mutates_nothing(tmp_path):
+    """FIX 5: the primary safety guarantee, against a real filesystem backend.
+
+    Seed an old entity, run apply(dry_run=True), and assert it still exists and
+    no retention_* metadata was written to it."""
+    from altk_evolve.backend.filesystem import FilesystemSettings
+    from altk_evolve.config.evolve import EvolveConfig
+    from altk_evolve.frontend.client.evolve_client import EvolveClient
+    from altk_evolve.schema.core import Entity
+
+    client = EvolveClient(EvolveConfig(backend="filesystem", settings=FilesystemSettings(data_dir=str(tmp_path))))
+    client.ensure_namespace("ns")
+    client.update_entities("ns", [Entity(content="an old guideline", type="guideline")], enable_conflict_resolution=False)
+    entity = client.get_all_entities("ns")[0]
+    policy = RetentionPolicy(rules=[RetentionRule(name="old", max_age_days=90, action="delete")])
+    # evaluate as-of far in the future so the just-created entity is well past 90d.
+    future = entity.created_at + datetime.timedelta(days=500)
+
+    report = RetentionEngine(client).apply("ns", policy, now=future, dry_run=True)
+
+    # dry run would delete it, but must not have
+    assert [i.entity_id for i in report.deleted] == [entity.id]
+    survivors = client.get_all_entities("ns")
+    assert [e.id for e in survivors] == [entity.id]  # still there
+    meta = survivors[0].metadata or {}
+    assert "retention_flagged_at" not in meta and "retention_reason" not in meta
 
 
 # ── policy schema ─────────────────────────────────────────────────────
@@ -392,4 +549,8 @@ def test_shipped_example_policy_is_valid():
 
     example = Path(__file__).resolve().parents[2] / "examples" / "retention.example.yaml"
     policy = RetentionPolicy.from_file(example)
-    assert [r.name for r in policy.rules] == ["stale-guidelines", "unused-guidelines", "old-sessions"]
+    # DELETE rule ordered before the FLAG rule so it is reachable (first-match).
+    assert [r.name for r in policy.rules] == ["unused-guidelines", "stale-guidelines", "old-sessions"]
+    unused = policy.rules[0]
+    assert unused.action == "delete"
+    assert unused.on_missing_access_signal == "skip"  # fail-safe default, explicit in the example

--- a/tests/unit/test_retention.py
+++ b/tests/unit/test_retention.py
@@ -384,6 +384,29 @@ def test_cascade_matches_int_trace_id_against_str_source_task_id():
     assert next(i for i in report.deleted if i.entity_id == "g1").reason == "cascade:1"
 
 
+def test_cascade_only_fires_for_trajectory_typed_deletes():
+    """A cascade_derived delete of a NON-trajectory entity must not fan out
+    along source_task_id. A rule with entity_type=None + cascade_derived=True
+    that matches a non-trajectory carrier (here a guideline holding a trace_id)
+    would otherwise mass-delete every entity linked by source_task_id."""
+    # A non-trajectory entity that happens to carry a trace/task id ...
+    carrier = _entity("carrier", type="guideline", created_days_ago=400, metadata={"trace_id": "T1", "task_id": "T1"})
+    # ... and unrelated entities linked to that id via source_task_id.
+    linked_a = _entity("g1", type="guideline", created_days_ago=1, metadata={"source_task_id": "T1"})
+    linked_b = _entity("n1", type="note", created_days_ago=1, metadata={"source_task_id": "T1"})
+    client = FakeClient([carrier, linked_a, linked_b])
+    # entity_type=None matches any type; cascade_derived is on.
+    policy = RetentionPolicy(rules=[RetentionRule(name="broad", entity_type=None, max_age_days=365, action="delete", cascade_derived=True)])
+
+    report = RetentionEngine(client).apply("ns", policy, now=NOW, dry_run=False)
+
+    # Only the carrier (which aged out) is deleted; nothing cascades because it
+    # is not a trajectory.
+    assert {i.entity_id for i in report.deleted} == {"carrier"}
+    assert "g1" in client.store
+    assert "n1" in client.store
+
+
 def test_scan_limit_boundary_emits_warning():
     """FIX 3: when the fetch returns exactly the limit, warn that entities
     beyond it were not evaluated."""

--- a/tests/unit/test_retention.py
+++ b/tests/unit/test_retention.py
@@ -1,0 +1,395 @@
+"""Tests for the data-retention engine and policy (issue #275).
+
+The engine is exercised against an in-memory fake client so the tests are fast,
+deterministic and backend-agnostic. ``now`` is injected for stable ages.
+"""
+
+import datetime
+
+import pytest
+
+from altk_evolve.retention.engine import RetentionEngine
+from altk_evolve.retention.policy import RetentionPolicy, RetentionRule
+from altk_evolve.schema.core import RecordedEntity
+
+pytestmark = pytest.mark.unit
+
+NOW = datetime.datetime(2026, 6, 29, tzinfo=datetime.UTC)
+
+
+def _entity(id, type="guideline", content="x", created_days_ago=0, metadata=None):
+    return RecordedEntity(
+        id=id,
+        type=type,
+        content=content,
+        metadata=metadata or {},
+        created_at=NOW - datetime.timedelta(days=created_days_ago),
+    )
+
+
+class FakeClient:
+    """Minimal stand-in implementing only what RetentionEngine calls."""
+
+    def __init__(self, entities):
+        self.store = {e.id: e for e in entities}
+        self.deleted: list[str] = []
+
+    def get_all_entities(self, namespace_id, filters=None, limit=100):
+        return list(self.store.values())
+
+    def delete_entity_by_id(self, namespace_id, entity_id):
+        self.deleted.append(entity_id)
+        self.store.pop(entity_id, None)
+
+    def patch_entity_metadata(self, namespace_id, entity_id, metadata_updates):
+        e = self.store[entity_id]
+        e.metadata = {**(e.metadata or {}), **metadata_updates}
+        return e
+
+
+# ── age-based ─────────────────────────────────────────────────────────
+
+
+def test_age_flag_marks_old_entities_without_deleting():
+    client = FakeClient([_entity("1", created_days_ago=100), _entity("2", created_days_ago=10)])
+    policy = RetentionPolicy(rules=[RetentionRule(name="stale", max_age_days=90, action="flag")])
+
+    report = RetentionEngine(client).apply("ns", policy, now=NOW, dry_run=False)
+
+    assert [i.entity_id for i in report.flagged] == ["1"]
+    assert report.deleted == []
+    assert client.store["1"].metadata["retention_reason"] == "age"
+    assert client.store["1"].metadata["retention_rule"] == "stale"
+    assert "retention_flagged_at" in client.store["1"].metadata
+    # entity "2" is young; untouched
+    assert "retention_flagged_at" not in client.store["2"].metadata
+
+
+def test_age_delete_removes_old_entities():
+    client = FakeClient([_entity("1", created_days_ago=400)])
+    policy = RetentionPolicy(rules=[RetentionRule(name="old", max_age_days=365, action="delete")])
+
+    report = RetentionEngine(client).apply("ns", policy, now=NOW, dry_run=False)
+
+    assert client.deleted == ["1"]
+    assert [i.entity_id for i in report.deleted] == ["1"]
+    assert "max_age_days=365" in report.deleted[0].detail
+
+
+def test_first_matching_rule_wins():
+    client = FakeClient([_entity("1", type="guideline", created_days_ago=400)])
+    policy = RetentionPolicy(
+        rules=[
+            RetentionRule(name="flag-first", max_age_days=90, action="flag"),
+            RetentionRule(name="delete-later", max_age_days=365, action="delete"),
+        ]
+    )
+
+    report = RetentionEngine(client).apply("ns", policy, now=NOW, dry_run=False)
+
+    assert [i.rule for i in report.flagged] == ["flag-first"]
+    assert report.deleted == []
+
+
+# ── unused-based ──────────────────────────────────────────────────────
+
+
+def test_unused_uses_last_accessed_when_present():
+    recently_used = _entity("1", created_days_ago=300, metadata={"last_accessed": (NOW - datetime.timedelta(days=5)).isoformat()})
+    long_idle = _entity("2", created_days_ago=300, metadata={"last_accessed": (NOW - datetime.timedelta(days=60)).isoformat()})
+    policy = RetentionPolicy(rules=[RetentionRule(name="idle", max_unused_days=30, action="flag")])
+
+    report = RetentionEngine(FakeClient([recently_used, long_idle])).apply("ns", policy, now=NOW, dry_run=False)
+
+    assert [i.entity_id for i in report.flagged] == ["2"]
+    assert report.flagged[0].reason == "unused"
+    assert "metadata.last_accessed" in report.flagged[0].detail
+    # every entity carried a stamp, so no degraded-signal warning
+    assert report.warnings == []
+
+
+def test_unused_without_access_stamp_falls_back_to_created_at_and_says_so():
+    """The PoC silently used created_at here. Now the fallback is reported."""
+    client = FakeClient([_entity("1", created_days_ago=60)])
+    policy = RetentionPolicy(rules=[RetentionRule(name="idle", max_unused_days=30, action="delete")])
+
+    report = RetentionEngine(client).apply("ns", policy, now=NOW, dry_run=True)
+
+    assert [i.entity_id for i in report.deleted] == ["1"]
+    detail = report.deleted[0].detail
+    assert "created_at" in detail and "AccessStampPlugin" in detail
+    assert len(report.warnings) == 1
+    assert "1 of 1 entities carry no metadata.last_accessed" in report.warnings[0]
+
+
+def test_no_degraded_signal_warning_without_an_unused_rule():
+    client = FakeClient([_entity("1", created_days_ago=400)])
+    policy = RetentionPolicy(rules=[RetentionRule(name="old", max_age_days=365, action="delete")])
+
+    report = RetentionEngine(client).apply("ns", policy, now=NOW, dry_run=True)
+
+    assert report.warnings == []
+
+
+def test_malformed_last_accessed_is_treated_as_missing():
+    client = FakeClient([_entity("1", created_days_ago=60, metadata={"last_accessed": "not-a-date"})])
+    policy = RetentionPolicy(rules=[RetentionRule(name="idle", max_unused_days=30, action="flag")])
+
+    report = RetentionEngine(client).apply("ns", policy, now=NOW, dry_run=True)
+
+    assert [i.entity_id for i in report.flagged] == ["1"]
+    assert "created_at" in report.flagged[0].detail
+
+
+# ── dry run ───────────────────────────────────────────────────────────
+
+
+def test_dry_run_reports_without_mutating():
+    client = FakeClient([_entity("1", created_days_ago=400), _entity("2", type="note", created_days_ago=400)])
+    policy = RetentionPolicy(
+        rules=[
+            RetentionRule(name="old", entity_type="guideline", max_age_days=90, action="delete"),
+            RetentionRule(name="stale-notes", entity_type="note", max_age_days=90, action="flag"),
+        ]
+    )
+
+    report = RetentionEngine(client).apply("ns", policy, now=NOW, dry_run=True)
+
+    assert report.dry_run is True
+    assert [i.entity_id for i in report.deleted] == ["1"]  # would delete
+    assert [i.entity_id for i in report.flagged] == ["2"]  # would flag
+    assert client.deleted == []  # but did not
+    assert "1" in client.store
+    assert "retention_flagged_at" not in client.store["2"].metadata
+
+
+def test_apply_defaults_to_dry_run():
+    client = FakeClient([_entity("1", created_days_ago=400)])
+    policy = RetentionPolicy(rules=[RetentionRule(name="old", max_age_days=90, action="delete")])
+
+    report = RetentionEngine(client).apply("ns", policy, now=NOW)
+
+    assert report.dry_run is True
+    assert client.deleted == []
+
+
+def test_backend_failure_is_recorded_and_sweep_continues():
+    class Exploding(FakeClient):
+        def delete_entity_by_id(self, namespace_id, entity_id):
+            if entity_id == "1":
+                raise RuntimeError("legal hold")
+            super().delete_entity_by_id(namespace_id, entity_id)
+
+    client = Exploding([_entity("1", created_days_ago=400), _entity("2", created_days_ago=400)])
+    policy = RetentionPolicy(rules=[RetentionRule(name="old", max_age_days=90, action="delete")])
+
+    report = RetentionEngine(client).apply("ns", policy, now=NOW, dry_run=False)
+
+    assert client.deleted == ["2"]
+    assert [i.entity_id for i in report.deleted] == ["2"]
+    assert report.errors == ["delete 1: legal hold"]
+
+
+# ── session retention + provenance cascade ────────────────────────────
+
+
+def test_cascade_delete_removes_derived_memories():
+    trajectory = _entity("traj", type="trajectory", created_days_ago=400, metadata={"trace_id": "T1"})
+    derived = _entity("g1", type="guideline", created_days_ago=1, metadata={"source_task_id": "T1"})
+    unrelated = _entity("g2", type="guideline", created_days_ago=1, metadata={"source_task_id": "T2"})
+    client = FakeClient([trajectory, derived, unrelated])
+    policy = RetentionPolicy(
+        rules=[RetentionRule(name="old-sessions", entity_type="trajectory", max_age_days=365, action="delete", cascade_derived=True)]
+    )
+
+    report = RetentionEngine(client).apply("ns", policy, now=NOW, dry_run=False)
+
+    deleted_ids = {i.entity_id for i in report.deleted}
+    assert deleted_ids == {"traj", "g1"}  # the young derived guideline goes with its session
+    assert "g2" not in deleted_ids  # different trace, untouched
+    cascade = next(i for i in report.deleted if i.entity_id == "g1")
+    assert cascade.reason == "cascade:T1"
+    assert "derived from session traj" in cascade.detail
+
+
+def test_cascade_works_for_mcp_shaped_sessions_normalized_by_the_hook_seam():
+    """MetadataNormalizerPlugin copies MCP's ``task_id`` into ``trace_id``.
+
+    An MCP-saved trajectory written through the seam therefore carries BOTH
+    keys, and the cascade keys on ``trace_id`` exactly as for Phoenix sync.
+    """
+    from altk_evolve.hooks.plugins.normalizer import normalize_entities
+
+    raw = [{"content": "session", "type": "trajectory", "metadata": {"task_id": "T9"}}]
+    normalized = normalize_entities(raw, stamp_created_at=False)
+    assert normalized is not None
+    assert normalized[0]["metadata"]["trace_id"] == "T9"
+
+    trajectory = _entity("traj", type="trajectory", created_days_ago=400, metadata=normalized[0]["metadata"])
+    derived = _entity("g1", type="guideline", created_days_ago=1, metadata={"source_task_id": "T9"})
+    client = FakeClient([trajectory, derived])
+    policy = RetentionPolicy(
+        rules=[RetentionRule(name="old-sessions", entity_type="trajectory", max_age_days=365, action="delete", cascade_derived=True)]
+    )
+
+    report = RetentionEngine(client).apply("ns", policy, now=NOW, dry_run=False)
+
+    assert {i.entity_id for i in report.deleted} == {"traj", "g1"}
+
+
+def test_cascade_falls_back_to_task_id_for_pre_normalizer_sessions():
+    """Sessions written before the normalizer carry only ``task_id``."""
+    trajectory = _entity("traj", type="trajectory", created_days_ago=400, metadata={"task_id": "T5"})
+    derived = _entity("g1", type="guideline", created_days_ago=1, metadata={"source_task_id": "T5"})
+    client = FakeClient([trajectory, derived])
+    policy = RetentionPolicy(
+        rules=[RetentionRule(name="old-sessions", entity_type="trajectory", max_age_days=365, action="delete", cascade_derived=True)]
+    )
+
+    report = RetentionEngine(client).apply("ns", policy, now=NOW, dry_run=False)
+
+    assert {i.entity_id for i in report.deleted} == {"traj", "g1"}
+    assert next(i for i in report.deleted if i.entity_id == "g1").reason == "cascade:T5"
+
+
+def test_trace_id_wins_over_task_id_when_both_present():
+    trajectory = _entity("traj", type="trajectory", created_days_ago=400, metadata={"trace_id": "T1", "task_id": "T1"})
+    derived = _entity("g1", type="guideline", created_days_ago=1, metadata={"source_task_id": "T1"})
+    client = FakeClient([trajectory, derived])
+    policy = RetentionPolicy(
+        rules=[RetentionRule(name="old-sessions", entity_type="trajectory", max_age_days=365, action="delete", cascade_derived=True)]
+    )
+
+    report = RetentionEngine(client).apply("ns", policy, now=NOW, dry_run=False)
+
+    assert next(i for i in report.deleted if i.entity_id == "g1").reason == "cascade:T1"
+
+
+def test_cascade_off_leaves_derived_memories():
+    trajectory = _entity("traj", type="trajectory", created_days_ago=400, metadata={"trace_id": "T1"})
+    derived = _entity("g1", type="guideline", created_days_ago=1, metadata={"source_task_id": "T1"})
+    client = FakeClient([trajectory, derived])
+    policy = RetentionPolicy(rules=[RetentionRule(name="old-sessions", entity_type="trajectory", max_age_days=365, action="delete")])
+
+    report = RetentionEngine(client).apply("ns", policy, now=NOW, dry_run=False)
+
+    assert {i.entity_id for i in report.deleted} == {"traj"}
+    assert "g1" in client.store
+
+
+def test_cascade_delete_supersedes_a_flag_from_an_earlier_rule():
+    trajectory = _entity("traj", type="trajectory", created_days_ago=400, metadata={"trace_id": "T1"})
+    derived = _entity("g1", type="guideline", created_days_ago=200, metadata={"source_task_id": "T1"})
+    client = FakeClient([trajectory, derived])
+    policy = RetentionPolicy(
+        rules=[
+            RetentionRule(name="stale-guidelines", entity_type="guideline", max_age_days=90, action="flag"),
+            RetentionRule(name="old-sessions", entity_type="trajectory", max_age_days=365, action="delete", cascade_derived=True),
+        ]
+    )
+
+    report = RetentionEngine(client).apply("ns", policy, now=NOW, dry_run=False)
+
+    assert {i.entity_id for i in report.deleted} == {"traj", "g1"}
+    assert report.flagged == []
+
+
+# ── record_access: the explicit half of the access signal ─────────────
+
+
+def test_record_access_stamps_the_same_key_and_format_as_the_plugin(tmp_path):
+    """``record_access`` and ``AccessStampPlugin`` must not diverge.
+
+    Both go through ``build_access_stamps``, so one batch shares one ISO-8601
+    UTC ``last_accessed`` stamp under the same metadata key.
+    """
+    from altk_evolve.backend.filesystem import FilesystemSettings
+    from altk_evolve.config.evolve import EvolveConfig
+    from altk_evolve.frontend.client.evolve_client import EvolveClient
+    from altk_evolve.hooks.plugins.access_stamp import build_access_stamps
+    from altk_evolve.schema.core import Entity
+
+    client = EvolveClient(EvolveConfig(backend="filesystem", settings=FilesystemSettings(data_dir=str(tmp_path))))
+    client.ensure_namespace("ns")
+    client.update_entities("ns", [Entity(content="a guideline", type="guideline")], enable_conflict_resolution=False)
+    entity_id = client.get_all_entities("ns")[0].id
+
+    client.record_access("ns", [entity_id], when=NOW)
+
+    stamped = client.get_all_entities("ns")[0]
+    assert stamped.metadata["last_accessed"] == NOW.isoformat()
+    # identical to what the plugin core would have produced for the same read
+    assert build_access_stamps([{"id": entity_id}], now=lambda: NOW) == [(entity_id, {"last_accessed": NOW.isoformat()})]
+
+
+def test_record_access_makes_the_unused_rule_meaningful():
+    """A recently recorded access rescues an old entity from an unused rule."""
+    old_but_used = _entity("1", created_days_ago=300)
+    old_and_idle = _entity("2", created_days_ago=300)
+    client = FakeClient([old_but_used, old_and_idle])
+    # Simulate what record_access / AccessStampPlugin write.
+    client.patch_entity_metadata("ns", "1", {"last_accessed": (NOW - datetime.timedelta(days=1)).isoformat()})
+    policy = RetentionPolicy(rules=[RetentionRule(name="idle", max_unused_days=90, action="delete")])
+
+    report = RetentionEngine(client).apply("ns", policy, now=NOW, dry_run=False)
+
+    assert [i.entity_id for i in report.deleted] == ["2"]
+    assert "1" in client.store
+
+
+def test_record_access_skips_failures_without_raising(tmp_path):
+    from altk_evolve.backend.filesystem import FilesystemSettings
+    from altk_evolve.config.evolve import EvolveConfig
+    from altk_evolve.frontend.client.evolve_client import EvolveClient
+
+    client = EvolveClient(EvolveConfig(backend="filesystem", settings=FilesystemSettings(data_dir=str(tmp_path))))
+    client.ensure_namespace("ns")
+
+    client.record_access("ns", ["does-not-exist"])  # must not raise
+
+
+# ── policy schema ─────────────────────────────────────────────────────
+
+
+def test_rule_requires_a_threshold():
+    with pytest.raises(ValueError, match="max_age_days"):
+        RetentionRule(name="bad")
+
+
+def test_rule_rejects_unknown_action():
+    with pytest.raises(ValueError):
+        RetentionRule(name="bad", max_age_days=30, action="purge")
+
+
+def test_policy_from_mapping_roundtrip():
+    policy = RetentionPolicy.from_mapping({"rules": [{"name": "r", "entity_type": "guideline", "max_age_days": 30, "action": "delete"}]})
+    assert policy.rules[0].name == "r"
+    assert policy.rules[0].action == "delete"
+
+
+def test_policy_from_mapping_accepts_none():
+    assert RetentionPolicy.from_mapping(None).rules == []
+
+
+def test_policy_from_file_json(tmp_path):
+    p = tmp_path / "policy.json"
+    p.write_text('{"rules": [{"name": "r", "max_age_days": 30}]}', encoding="utf-8")
+    policy = RetentionPolicy.from_file(p)
+    assert policy.rules[0].max_age_days == 30
+    assert policy.rules[0].action == "flag"  # default
+
+
+def test_policy_from_file_yaml(tmp_path):
+    p = tmp_path / "policy.yaml"
+    p.write_text("rules:\n  - name: r\n    entity_type: trajectory\n    max_age_days: 365\n    action: delete\n", encoding="utf-8")
+    policy = RetentionPolicy.from_file(p)
+    assert policy.rules[0].entity_type == "trajectory"
+    assert policy.rules[0].action == "delete"
+
+
+def test_shipped_example_policy_is_valid():
+    from pathlib import Path
+
+    example = Path(__file__).resolve().parents[2] / "examples" / "retention.example.yaml"
+    policy = RetentionPolicy.from_file(example)
+    assert [r.name for r in policy.rules] == ["stale-guidelines", "unused-guidelines", "old-sessions"]


### PR DESCRIPTION
## What

Adds **data retention** — the half of #275 that main still lacks. A declarative policy selects entities by type and age and either **flags** them for review or **deletes** them, with a session → derived cascade. Dry run everywhere by default.

PII is deliberately out of scope for this PR.

## Why

Memories accumulate: some go stale, some are never read again, and session transcripts often carry data with a bounded agreed retention. Deleting a session without deleting the memories extracted from it just leaves the same data behind under another name — hence the provenance cascade.

## Policy

```yaml
rules:
  - name: stale-guidelines
    entity_type: guideline
    max_age_days: 90
    action: flag

  - name: unused-guidelines
    entity_type: guideline
    max_unused_days: 180
    action: delete

  - name: old-sessions
    entity_type: trajectory
    max_age_days: 365
    action: delete
    cascade_derived: true
```

```bash
evolve retention run --policy examples/retention.example.yaml            # dry run
evolve retention run --policy examples/retention.example.yaml --apply    # enforce
```

Rules are evaluated top-to-bottom, first match wins; a cascade `delete` supersedes an earlier `flag`. The engine drives the `EvolveClient` public API, so it is backend-agnostic **and every delete flows through `memory_pre_delete`** — a legal-hold plugin can veto a retention delete, and the veto lands in `report.errors` without aborting the sweep.

## Synergy with the merged hook seam (#287)

This is the substantive improvement over the earlier prototype. The seam changed two things in retention's favour and both are wired up here:

**1. `last_accessed` is now actually populated.** `AccessStampPlugin` stamps it on `memory_post_read`, so `max_unused_days` finally has a real signal — in the prototype `record_access` had *zero* callers, so the unused rule silently degraded into an age rule for every entity. Now the fallback is explicit rather than silent: an entity with no stamp gets a per-item `detail` naming the fallback, and the run carries a `RetentionReport.warning`:

```
FLAG    1   guideline  reason=unused       rule=unused-guidelines
        why: not read for 200.0d > max_unused_days=90 — no metadata.last_accessed on this
             entity, so disuse was measured from created_at; enable AccessStampPlugin (or
             call EvolveClient.record_access) for a real recall signal
warning: 4 of 5 entities carry no metadata.last_accessed, so their disuse was measured from
created_at — for those entities an unused rule behaves like an age rule.
```

**2. `trace_id` is now reliably stamped.** `MetadataNormalizerPlugin` copies `task_id` → `trace_id`, closing the MCP-vs-Phoenix convention split that previously broke the cascade for MCP-saved trajectories. The engine additionally falls back to `task_id` at read time so sessions written *before* the normalizer still cascade (`trace_id` wins when both are present). Both conventions are covered by tests, including one that runs the actual `normalize_entities` core over an MCP-shaped payload.

**`record_access` decision — kept, but no longer a second disjoint mechanism.** It now shares the plugin's `build_access_stamps` core, so key, format and one-stamp-per-batch behaviour cannot drift. The plugin is the automatic path; `record_access` is the explicit path for callers not running hooks, or for recording a *use* that was not a store read (a memory pulled from cache and acted on). A test asserts the two produce byte-identical stamps. Dropping it would have left non-hook users with no way to feed the unused rule at all.

## Plugin-side parity, and its gaps

`evolve-lite` gets a stdlib-only `retention` lib + skill rendered to all four variants (claude / claw-code / codex / bob), with the same schema, actions, dry-run default and cascade concept over the `.evolve/` file store, auditing every applied action. The signals are genuinely weaker, and the code, the skill and the guide all say so rather than implying parity:

| Signal | Package | Plugin | Consequence |
|---|---|---|---|
| age | `created_at` | **file mtime** — no `created_at` exists in the store | mtime is a modification time: editing an entity resets its age. Flagging deliberately restores mtime so the sweep never resets it. |
| unused | `metadata.last_accessed` (automatic, `AccessStampPlugin`) | latest `recall` row in `.evolve/audit.log` | the recall audit is **model-invoked**, so a missing row means "no recorded recall", not "not used". Same degraded-signal warning is emitted. |
| cascade | `metadata.source_task_id == trace_id` | a `trajectory:` frontmatter key | **nothing in the shipped plugin writes that key today.** `entity_io` supports and preserves it, but neither the save flow nor `adapt-memory` populates it — so `cascade_derived` is effectively inert plugin-side. A test pins this so it cannot be mistaken for working. |

Out of scope for the plugin sweep: `entities/subscribed/` (sync-owned git clones — a local delete would just be restored), `public/`, symlinks, `.git`.

## Safety

`RetentionEngine.apply()` defaults to `dry_run=True` and the CLI requires an explicit `--apply`. A dry run computes every decision and mutates nothing; the report is identical in shape to an enforced one. `delete` has no undo — `flag` exists so you can stage a review queue first.

## Test evidence

- Full suite: **930 passed, 1 skipped** (`uv run --no-sync pytest tests -q`).
- 26 new package tests (`tests/unit/test_retention.py`) and 16 plugin tests (`tests/platform_integrations/test_retention_plugin.py`), covering age/unused/dry-run/cascade, the degraded-signal reporting, both trace-id conventions, first-match-wins, delete-supersedes-flag, per-entity failure isolation, and the `record_access` ↔ plugin equivalence.
- `uv lock --check` clean; `pre-commit run --all-files` green (mypy, ruff, detect-secrets, plugins-rendered).
- `examples/retention_demo.py` run end-to-end: dry run shows every decision with its "why" and mutates nothing, `--apply` flags the stale guideline, deletes the 400-day-old session together with the memory derived from it (matched via `task_id`), and leaves the guideline recalled yesterday alone.

Closes part of #275 (retention half).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added policy-driven data retention to evaluate entity age/unused signals and flag or delete accordingly.
  * Introduced `retention run` CLI with YAML/JSON policies, namespace sweep, dry-run default, and `--apply` enforcement.
  * Added degraded-signal handling with “skipped” reporting, plus optional cascading deletion of derived entities.
  * Added manual access recording to improve unused detection.
* **Documentation**
  * Added retention guides, CLI reference, examples, and platform-specific retention skill docs.
* **Tests**
  * Added unit and integration coverage for policy parsing/validation, dry-run vs apply behavior, warnings/errors, and cascading rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Post-review fixes (tiered internal review)

A tiered review (fast-model diff mapping → higher-tier adversarial review with repro-verified fixes) ran over this PR. All findings reproduced, fixed, and re-verified by re-running the repros:

- **[HIGH · data-loss] Cascade over-deletion on empty/falsy trace id.** A trajectory carrying `trace_id=""` cascade-deleted every entity with `source_task_id==""`, regardless of real provenance. Fixed: falsy ids never form a cascade bucket (guarded on both package and plugin side); genuine matches (including int↔str, e.g. `1` ↔ `"1"`) still cascade. Regression tests added.
- **Unstamped `unused`-delete → configurable, fail-safe.** An `unused` DELETE rule previously deleted never-access-stamped entities by measuring disuse from `created_at` — silent data loss when stamping is off. Now a per-rule `on_missing_access_signal: skip | flag | delete` with a fail-safe **`skip`** default; skipped entities are surfaced in the report and CLI. Wired through the engine, the plugin (all 4 variants), the CLI, and the docs.
- **Configurable scan limit + truncation warning.** The 100k fetch cap is now a `scan_limit` parameter and emits a warning when a namespace may exceed it (previously silent).
- **Example policy fixed.** Reordered so every shipped rule is reachable (first-match escalation), with a docs section on first-match shadowing.
- **Test gap closed.** Added a real-filesystem dry-run non-mutation test (previously only the fake client proved this package-side).

Retention tests 42 → 59; full suite green.
