### PR TITLE
fix(conflicts): survive real-world conflict-resolution responses

### DIFF
--- a/altk_evolve/llm/conflict_resolution/conflict_resolution.py
+++ b/altk_evolve/llm/conflict_resolution/conflict_resolution.py
@@ -7,7 +7,7 @@ from altk_evolve.schema.conflict_resolution import SimpleEntity, EntityUpdate
 from altk_evolve.schema.core import RecordedEntity
 from altk_evolve.schema.exceptions import EvolveException
 from altk_evolve.utils.utils import clean_llm_response, serialize_content
-from litellm import completion
+from litellm import completion, get_supported_openai_params
 from pathlib import Path
 
 
@@ -21,15 +21,42 @@ _GROQ_GPT_OSS_CONFLICT_MAX_TOKENS = 8192
 
 
 def _conflict_resolution_completion_options() -> dict[str, object]:
-    """Keep GPT-OSS reasoning from exhausting the conflict JSON budget."""
+    """Per-provider completion options for conflict resolution.
+
+    Two independent concerns:
+    - GPT-OSS on Groq spends the completion budget on reasoning tokens, leaving
+      nothing for the conflict JSON, so cap tokens and lower reasoning effort.
+    - Ask for JSON mode where the provider handles it, so the reply is
+      constrained at the source instead of being recovered afterwards.
+
+    Groq is deliberately excluded from response_format on the same grounds as
+    guideline generation (#264): LiteLLM reports response-format support for
+    groq/openai/gpt-oss while the model can still fail when a schema- or
+    tool-backed response is required. Groq therefore stays on the
+    prompt-and-parse path, protected by the token budget above and by
+    clean_llm_response recovery. Do not enable it here without live-testing
+    groq/openai/gpt-oss-120b first.
+    """
     model = llm_settings.conflict_resolution_model.strip().lower()
     provider = (llm_settings.custom_llm_provider or "").strip().lower()
-    if "gpt-oss" in model and (provider == "groq" or model.startswith("groq/")):
-        return {
-            "max_tokens": _GROQ_GPT_OSS_CONFLICT_MAX_TOKENS,
-            "reasoning_effort": "low",
-        }
-    return {}
+    is_groq = provider == "groq" or model.startswith("groq/")
+
+    options: dict[str, object] = {}
+    if is_groq:
+        if "gpt-oss" in model:
+            options["max_tokens"] = _GROQ_GPT_OSS_CONFLICT_MAX_TOKENS
+            options["reasoning_effort"] = "low"
+        return options
+
+    supported_params = get_supported_openai_params(
+        model=llm_settings.conflict_resolution_model,
+        custom_llm_provider=llm_settings.custom_llm_provider,
+    )
+    if supported_params and "response_format" in supported_params:
+        # Plain JSON mode, not a schema: the prompt already fixes the shape, and
+        # json_object needs no tool routing.
+        options["response_format"] = {"type": "json_object"}
+    return options
 
 
 def resolve_conflicts(
@@ -60,11 +87,29 @@ def resolve_conflicts(
                 custom_llm_provider=llm_settings.custom_llm_provider,
                 **_conflict_resolution_completion_options(),
             )
-            response = completion_response.choices[0].message.content or ""  # type: ignore[union-attr]
-            response = clean_llm_response(response)
+            choice = completion_response.choices[0]
+            # A budget-capped reply is a different failure from a malformed one and
+            # needs a different fix (raise the budget or send fewer entities), so
+            # name it rather than surfacing a generic JSON error. Checked only when
+            # the content does not parse: a reply can stop exactly at the limit and
+            # still be complete, and rejecting that would throw away good output.
+            truncated = str(getattr(choice, "finish_reason", "") or "") == "length"
+            response = clean_llm_response(choice.message.content or "")  # type: ignore[union-attr]
             if not response:
-                raise ValueError("Conflict resolution LLM returned an empty response")
-            parsed = json.loads(response)
+                raise ValueError(
+                    "Conflict resolution LLM returned an empty response"
+                    + (" because the completion budget was spent before any JSON (finish_reason=length)" if truncated else "")
+                )
+            try:
+                parsed = json.loads(response)
+            except json.JSONDecodeError as decode_error:
+                if truncated:
+                    raise ValueError(
+                        "Conflict resolution response was cut off by the completion"
+                        " budget (finish_reason=length); raise max_tokens or send"
+                        " fewer entities per request"
+                    ) from decode_error
+                raise
             entity_updates = [EntityUpdate.model_validate(event) for event in parsed["entities"]]
             for update in entity_updates:
                 if update.event == "ADD":

--- a/altk_evolve/llm/conflict_resolution/conflict_resolution.py
+++ b/altk_evolve/llm/conflict_resolution/conflict_resolution.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 from jinja2 import Template
 from altk_evolve.config.llm import llm_settings
@@ -20,41 +21,57 @@ _STICKY_STORED_METADATA_KEYS = ("generation_method",)
 _GROQ_GPT_OSS_CONFLICT_MAX_TOKENS = 8192
 
 
+def _is_groq_gpt_oss_target() -> bool:
+    """Is the conflict model GPT-OSS served by Groq, reached by any route?
+
+    Provider and model prefix are not enough. wxo-agentic-memory sets
+    EVOLVE_CUSTOM_LLM_PROVIDER=openai whenever it routes through its AI gateway,
+    so a Groq-backed model arrives looking like OpenAI and the budget below
+    silently stops applying -- on the one model whose reasoning tokens eat the
+    reply. Measured against Groq gpt-oss-120b: ~2400 characters of reasoning
+    without the cap, ~350 with it.
+    """
+    model = llm_settings.conflict_resolution_model.strip().lower()
+    if "gpt-oss" not in model:
+        return False
+    provider = (llm_settings.custom_llm_provider or "").strip().lower()
+    if provider == "groq" or model.startswith("groq/"):
+        return True
+    base_url = (os.getenv("OPENAI_BASE_URL") or os.getenv("OPENAI_API_BASE") or "").lower()
+    return "groq" in base_url
+
+
 def _conflict_resolution_completion_options() -> dict[str, object]:
     """Per-provider completion options for conflict resolution.
 
-    Two independent concerns:
-    - GPT-OSS on Groq spends the completion budget on reasoning tokens, leaving
-      nothing for the conflict JSON, so cap tokens and lower reasoning effort.
-    - Ask for JSON mode where the provider handles it, so the reply is
-      constrained at the source instead of being recovered afterwards.
+    Ask for JSON mode wherever the provider handles it, so the reply is
+    constrained at the source rather than repaired afterwards. Plain
+    {"type": "json_object"} rather than a schema: the prompt already fixes the
+    shape, and json_object needs no tool routing -- which is what #264 found
+    Groq failing on. Verified live against Groq gpt-oss-120b through both the
+    groq provider and an OpenAI-compatible base URL.
 
-    Groq is deliberately excluded from response_format on the same grounds as
-    guideline generation (#264): LiteLLM reports response-format support for
-    groq/openai/gpt-oss while the model can still fail when a schema- or
-    tool-backed response is required. Groq therefore stays on the
-    prompt-and-parse path, protected by the token budget above and by
-    clean_llm_response recovery. Do not enable it here without live-testing
-    groq/openai/gpt-oss-120b first.
+    GPT-OSS on Groq additionally needs its reasoning bounded, or it spends the
+    completion budget before emitting any JSON.
     """
-    model = llm_settings.conflict_resolution_model.strip().lower()
-    provider = (llm_settings.custom_llm_provider or "").strip().lower()
-    is_groq = provider == "groq" or model.startswith("groq/")
-
-    options: dict[str, object] = {}
-    if is_groq:
-        if "gpt-oss" in model:
-            options["max_tokens"] = _GROQ_GPT_OSS_CONFLICT_MAX_TOKENS
-            options["reasoning_effort"] = "low"
-        return options
-
-    supported_params = get_supported_openai_params(
-        model=llm_settings.conflict_resolution_model,
-        custom_llm_provider=llm_settings.custom_llm_provider,
+    supported_params = (
+        get_supported_openai_params(
+            model=llm_settings.conflict_resolution_model,
+            custom_llm_provider=llm_settings.custom_llm_provider,
+        )
+        or []
     )
-    if supported_params and "response_format" in supported_params:
-        # Plain JSON mode, not a schema: the prompt already fixes the shape, and
-        # json_object needs no tool routing.
+    options: dict[str, object] = {}
+
+    if _is_groq_gpt_oss_target():
+        options["max_tokens"] = _GROQ_GPT_OSS_CONFLICT_MAX_TOKENS
+        # litellm RAISES UnsupportedParamsError rather than dropping this when the
+        # provider is openai, even though the Groq endpoint behind it accepts it,
+        # so it has to be gated on what litellm thinks it can send.
+        if "reasoning_effort" in supported_params:
+            options["reasoning_effort"] = "low"
+
+    if "response_format" in supported_params:
         options["response_format"] = {"type": "json_object"}
     return options
 

--- a/altk_evolve/llm/conflict_resolution/conflict_resolution.py
+++ b/altk_evolve/llm/conflict_resolution/conflict_resolution.py
@@ -17,6 +17,20 @@ from pathlib import Path
 # NOT listed: those should refresh to the incoming write's normalized values.
 _STICKY_STORED_METADATA_KEYS = ("generation_method",)
 
+_GROQ_GPT_OSS_CONFLICT_MAX_TOKENS = 8192
+
+
+def _conflict_resolution_completion_options() -> dict[str, object]:
+    """Keep GPT-OSS reasoning from exhausting the conflict JSON budget."""
+    model = llm_settings.conflict_resolution_model.strip().lower()
+    provider = (llm_settings.custom_llm_provider or "").strip().lower()
+    if "gpt-oss" in model and (provider == "groq" or model.startswith("groq/")):
+        return {
+            "max_tokens": _GROQ_GPT_OSS_CONFLICT_MAX_TOKENS,
+            "reasoning_effort": "low",
+        }
+    return {}
+
 
 def resolve_conflicts(
     old_entities: list[RecordedEntity], new_entities: list[RecordedEntity], custom_update_entities_prompt: str | None = None
@@ -44,9 +58,12 @@ def resolve_conflicts(
                 model=llm_settings.conflict_resolution_model,
                 messages=llm_messages,
                 custom_llm_provider=llm_settings.custom_llm_provider,
+                **_conflict_resolution_completion_options(),
             )
             response = completion_response.choices[0].message.content or ""  # type: ignore[union-attr]
             response = clean_llm_response(response)
+            if not response:
+                raise ValueError("Conflict resolution LLM returned an empty response")
             parsed = json.loads(response)
             entity_updates = [EntityUpdate.model_validate(event) for event in parsed["entities"]]
             for update in entity_updates:

--- a/altk_evolve/utils/utils.py
+++ b/altk_evolve/utils/utils.py
@@ -1,5 +1,6 @@
 import json
 import re
+from json import JSONDecodeError
 
 
 def serialize_content(content: str | list | dict) -> str:
@@ -24,8 +25,50 @@ def clean_llm_response(content: str) -> str:
     Actions:
     - Returns the inner content of a Markdown code block.
     - If Markdown code blocks are not present, remove thought and reasoning blocks entirely.
+    - Extracts an embedded JSON object/array when the provider adds text around it.
     """
-    pattern = r"^```[a-zA-Z0-9]*\n(.*?)\n```$"
-    match = re.match(pattern, content.strip(), flags=re.MULTILINE | re.DOTALL)
-    match_res = match.group(1).strip() if match else content.strip()
-    return re.sub(r"<(?:think(?:ing)?|reflection)>.*?</(?:think(?:ing)?|reflection)>", "", match_res, flags=re.DOTALL).strip()
+    cleaned = re.sub(
+        r"<(?:think(?:ing)?|reflection)>.*?</(?:think(?:ing)?|reflection)>",
+        "",
+        content.strip(),
+        flags=re.DOTALL,
+    ).strip()
+
+    json_payload = _extract_json_payload(cleaned)
+    return json_payload if json_payload is not None else cleaned
+
+
+def _extract_json_payload(content: str) -> str | None:
+    decoder = json.JSONDecoder()
+
+    for match in re.finditer(
+        r"```[a-zA-Z0-9_-]*\s*\n(.*?)```",
+        content,
+        flags=re.MULTILINE | re.DOTALL,
+    ):
+        payload = _decode_json_fragment(match.group(1).strip(), decoder)
+        if payload is not None:
+            return payload
+
+    payload = _decode_json_fragment(content, decoder)
+    if payload is not None:
+        return payload
+
+    for index, char in enumerate(content):
+        if char not in "{[":
+            continue
+        payload = _decode_json_fragment(content[index:], decoder)
+        if payload is not None:
+            return payload
+
+    return None
+
+
+def _decode_json_fragment(fragment: str, decoder: json.JSONDecoder) -> str | None:
+    fragment = fragment.strip()
+    try:
+        _, end = decoder.raw_decode(fragment)
+    except JSONDecodeError:
+        return None
+
+    return fragment[:end].strip()

--- a/altk_evolve/utils/utils.py
+++ b/altk_evolve/utils/utils.py
@@ -46,29 +46,51 @@ def _extract_json_payload(content: str) -> str | None:
         content,
         flags=re.MULTILINE | re.DOTALL,
     ):
-        payload = _decode_json_fragment(match.group(1).strip(), decoder)
+        payload, _ = _decode_json_prefix(match.group(1).strip(), decoder)
         if payload is not None:
             return payload
 
-    payload = _decode_json_fragment(content, decoder)
+    payload, _ = _decode_json_prefix(content, decoder)
     if payload is not None:
         return payload
 
     for index, char in enumerate(content):
         if char not in "{[":
             continue
-        payload = _decode_json_fragment(content[index:], decoder)
+        payload, incomplete = _decode_json_prefix(content[index:], decoder)
         if payload is not None:
             return payload
+        if incomplete:
+            # This container never closed, so it runs to the end of the input and
+            # every later `{`/`[` is nested inside it. Decoding one of those would
+            # return a FRAGMENT of the reply while looking like a success: a
+            # truncated {"entities": [...]} yields a lone entity object, and a
+            # truncated [{"entities": [...]}, ...] yields a complete-looking
+            # response holding only the events that arrived. Both hide the
+            # truncation from the caller, and the second would be applied.
+            # Give up instead, so the caller sees a parse failure and can report
+            # the reply as cut short.
+            return None
 
     return None
 
 
-def _decode_json_fragment(fragment: str, decoder: json.JSONDecoder) -> str | None:
+def _decode_json_prefix(fragment: str, decoder: json.JSONDecoder) -> tuple[str | None, bool]:
+    """Decode the JSON value starting at the beginning of *fragment*.
+
+    Returns (payload, incomplete). `incomplete` distinguishes "ran out of input"
+    from "not JSON": the decoder either reports a position at the end of the
+    input, or names an unterminated construct. Only the former means a later
+    fragment would be nested inside something unfinished.
+    """
     fragment = fragment.strip()
+    if not fragment:
+        return None, False
+
     try:
         _, end = decoder.raw_decode(fragment)
-    except JSONDecodeError:
-        return None
+    except JSONDecodeError as error:
+        incomplete = error.pos >= len(fragment) or error.msg.startswith("Unterminated")
+        return None, incomplete
 
-    return fragment[:end].strip()
+    return fragment[:end].strip(), False

--- a/tests/unit/test_conflict_resolution.py
+++ b/tests/unit/test_conflict_resolution.py
@@ -13,6 +13,7 @@ from altk_evolve.llm.conflict_resolution.conflict_resolution import (
 )
 from altk_evolve.schema.conflict_resolution import SimpleEntity
 from altk_evolve.schema.core import RecordedEntity
+from altk_evolve.utils.utils import clean_llm_response
 
 
 # =============================================================================
@@ -146,6 +147,31 @@ def mock_llm_response_with_markdown():
     ]
 }
 ```"""
+
+
+@pytest.mark.unit
+def test_clean_llm_response_extracts_embedded_json():
+    """Test JSON extraction when providers add explanatory text around the payload."""
+    expected = {"entities": []}
+
+    assert (
+        json.loads(
+            clean_llm_response(
+                """
+Here is the reconciled output:
+
+```json
+{"entities": []}
+```
+
+Done.
+"""
+            )
+        )
+        == expected
+    )
+
+    assert json.loads(clean_llm_response('Result: {"entities": []}\nThanks.')) == expected
 
 
 # =============================================================================
@@ -324,6 +350,18 @@ def test_resolve_conflicts_response_parsing(
     mock_response = Mock()
     mock_response.choices = [Mock()]
     mock_response.choices[0].message.content = mock_llm_response_with_markdown
+    mock_completion.return_value = mock_response
+
+    result = resolve_conflicts(
+        sample_recorded_entities,
+        sample_recorded_entities,
+    )
+
+    assert len(result) == 1
+    assert result[0].event == "NONE"
+
+    # Test that provider-added text around a code block is cleaned before parsing
+    mock_response.choices[0].message.content = f"Here is the reconciled output:\n{mock_llm_response_with_markdown}\nDone."
     mock_completion.return_value = mock_response
 
     result = resolve_conflicts(

--- a/tests/unit/test_conflict_resolution.py
+++ b/tests/unit/test_conflict_resolution.py
@@ -747,3 +747,72 @@ def test_complete_reply_at_the_budget_limit_is_still_accepted(mock_completion, s
     assert len(result) == 1
     assert result[0].event == "NONE"
     assert mock_completion.call_count == 1
+
+
+# =============================================================================
+# Truncated replies must not be recovered from a nested fragment
+# =============================================================================
+
+
+TRUNCATED_ENTITIES_ARRAY = '{"entities": [{"id": "e1", "type": "guideline", "content": "x", "event": "NONE"}, {"id": "e2", "cont'
+TRUNCATED_OUTER_ARRAY = '[{"entities": [{"id": "e1", "type": "guideline", "content": "x", "event": "DELETE"}]}, {"entiti'
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "label,reply",
+    [
+        ("entities array cut mid-entity", TRUNCATED_ENTITIES_ARRAY),
+        ("outer array cut after first response", TRUNCATED_OUTER_ARRAY),
+        ("cut immediately after a key", '{"entities": [{"id": "e1"}, {"id": '),
+    ],
+)
+def test_truncated_reply_is_not_recovered_from_a_nested_fragment(label, reply):
+    """A cut-off document must stay a parse failure.
+
+    Scanning for an embedded payload used to accept any decodable `{`/`[`, so a
+    truncated document handed back a complete NESTED value: the first case yields
+    a lone entity object, and the second a response object holding only the
+    events that arrived. Both parse, so the finish_reason=length diagnosis was
+    lost — and the second still has an "entities" key, so a partial verdict
+    including a DELETE would have been applied as if it were the whole answer.
+    """
+    cleaned = clean_llm_response(reply)
+
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(cleaned)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "label,reply",
+    [
+        ("prose preamble", 'Here is the reconciliation:\n{"entities": []}'),
+        # A brace in the prose must not stop the scan: the first candidate fails
+        # because it is not JSON, which is different from being unfinished.
+        ("brace in prose", 'The rule mentions {discount_pct} so:\n{"entities": []}'),
+        ("fenced with trailing text", '```json\n{"entities": []}\n```\nLet me know.'),
+        ("bare object", '{"entities": []}'),
+    ],
+)
+def test_wrapped_but_complete_replies_are_still_recovered(label, reply):
+    parsed = json.loads(clean_llm_response(reply))
+
+    assert parsed == {"entities": []}
+
+
+@pytest.mark.unit
+@patch("altk_evolve.llm.conflict_resolution.conflict_resolution.completion")
+def test_truncated_nested_fragment_still_reports_the_budget(mock_completion, sample_recorded_entities):
+    """End to end: the reason a caller is given must name the real problem.
+
+    Before the recovery scan was tightened this surfaced as a KeyError on
+    parsed["entities"] after three attempts, pointing a reader at the schema
+    rather than at the completion budget.
+    """
+    mock_completion.return_value = _mock_reply(TRUNCATED_ENTITIES_ARRAY, finish_reason="length")
+
+    with pytest.raises(EvolveException) as excinfo:
+        resolve_conflicts(sample_recorded_entities, sample_recorded_entities)
+
+    assert "cut off by the completion budget" in str(excinfo.value.__cause__)

--- a/tests/unit/test_conflict_resolution.py
+++ b/tests/unit/test_conflict_resolution.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+from altk_evolve.config.llm import llm_settings
 from altk_evolve.llm.conflict_resolution.conflict_resolution import (
     resolve_conflicts,
     get_update_entities_messages,
@@ -399,6 +400,34 @@ def test_resolve_conflicts_retry_logic(
 
     # Verify it tried 3 times
     assert mock_completion.call_count == 3
+
+
+@pytest.mark.unit
+@patch("altk_evolve.llm.conflict_resolution.conflict_resolution.completion")
+def test_resolve_conflicts_expands_groq_gpt_oss_output_budget(
+    mock_completion,
+    monkeypatch,
+    sample_recorded_entities,
+    sample_new_recorded_entities,
+    mock_llm_response_add,
+):
+    """GPT-OSS needs room for both reasoning tokens and the conflict JSON."""
+    monkeypatch.setattr(
+        llm_settings,
+        "conflict_resolution_model",
+        "groq/openai/gpt-oss-120b",
+    )
+    monkeypatch.setattr(llm_settings, "custom_llm_provider", "groq")
+    mock_response = Mock()
+    mock_response.choices = [Mock()]
+    mock_response.choices[0].message.content = mock_llm_response_add
+    mock_completion.return_value = mock_response
+
+    resolve_conflicts(sample_recorded_entities, sample_new_recorded_entities)
+
+    call_kwargs = mock_completion.call_args.kwargs
+    assert call_kwargs["max_tokens"] == 8192
+    assert call_kwargs["reasoning_effort"] == "low"
 
 
 @pytest.mark.unit

--- a/tests/unit/test_conflict_resolution.py
+++ b/tests/unit/test_conflict_resolution.py
@@ -8,9 +8,12 @@ import pytest
 
 from altk_evolve.config.llm import llm_settings
 from altk_evolve.llm.conflict_resolution.conflict_resolution import (
+    _GROQ_GPT_OSS_CONFLICT_MAX_TOKENS,
+    _conflict_resolution_completion_options,
     resolve_conflicts,
     get_update_entities_messages,
 )
+from altk_evolve.schema.exceptions import EvolveException
 from altk_evolve.schema.conflict_resolution import SimpleEntity
 from altk_evolve.schema.core import RecordedEntity
 from altk_evolve.utils.utils import clean_llm_response
@@ -596,3 +599,119 @@ def test_resolve_conflicts_update_unions_generation_methods(mock_completion):
     assert result[0].metadata.get("generation_method") == "standard"
     assert "generation_methods" not in result[0].metadata
     assert result[0].metadata.get("category") == "style"
+
+
+# =============================================================================
+# Completion options: token budget, JSON mode, and the Groq carve-out
+# =============================================================================
+
+
+def _set_conflict_model(monkeypatch, model, provider):
+    monkeypatch.setattr(llm_settings, "conflict_resolution_model", model)
+    monkeypatch.setattr(llm_settings, "custom_llm_provider", provider)
+
+
+@pytest.mark.unit
+def test_groq_gpt_oss_gets_a_token_budget_and_no_response_format(monkeypatch):
+    """Groq keeps the prompt-and-parse path.
+
+    LiteLLM reports response-format support for groq/openai/gpt-oss while the
+    model can still fail when a schema/tool-backed reply is required (#264), so
+    the fix here is a completion budget, not constrained decoding. If this starts
+    failing because response_format was enabled for Groq, live-test
+    groq/openai/gpt-oss-120b before accepting the change.
+    """
+    _set_conflict_model(monkeypatch, "groq/openai/gpt-oss-120b", "groq")
+
+    options = _conflict_resolution_completion_options()
+
+    assert options["max_tokens"] == _GROQ_GPT_OSS_CONFLICT_MAX_TOKENS
+    assert options["reasoning_effort"] == "low"
+    assert "response_format" not in options
+
+
+@pytest.mark.unit
+def test_capable_provider_gets_json_mode(monkeypatch):
+    _set_conflict_model(monkeypatch, "gpt-4o", "openai")
+
+    options = _conflict_resolution_completion_options()
+
+    assert options["response_format"] == {"type": "json_object"}
+    # The budget override is Groq-specific and must not leak to other providers.
+    assert "max_tokens" not in options
+    assert "reasoning_effort" not in options
+
+
+@pytest.mark.unit
+def test_provider_without_response_format_support_gets_no_options(monkeypatch):
+    _set_conflict_model(monkeypatch, "gpt-4o", "openai")
+
+    with patch(
+        "altk_evolve.llm.conflict_resolution.conflict_resolution.get_supported_openai_params",
+        return_value=["temperature"],
+    ):
+        options = _conflict_resolution_completion_options()
+
+    assert options == {}
+
+
+# =============================================================================
+# finish_reason: truncation is a distinct failure from malformed output
+# =============================================================================
+
+
+def _mock_reply(content, finish_reason="stop"):
+    response = Mock()
+    choice = Mock()
+    choice.message.content = content
+    choice.finish_reason = finish_reason
+    response.choices = [choice]
+    return response
+
+
+@pytest.mark.unit
+@patch("altk_evolve.llm.conflict_resolution.conflict_resolution.completion")
+def test_truncated_reply_is_reported_as_a_budget_problem(mock_completion, sample_recorded_entities):
+    mock_completion.return_value = _mock_reply(
+        '{"entities": [{"id": "e1", "type": "guideline", "content": "Valid',
+        finish_reason="length",
+    )
+
+    with pytest.raises(EvolveException) as excinfo:
+        resolve_conflicts(sample_recorded_entities, sample_recorded_entities)
+
+    # The actionable cause is surfaced on the chained error, not buried in a
+    # generic "Expecting value" JSON message.
+    assert "cut off by the completion budget" in str(excinfo.value.__cause__)
+
+
+@pytest.mark.unit
+@patch("altk_evolve.llm.conflict_resolution.conflict_resolution.completion")
+def test_empty_truncated_reply_names_the_budget(mock_completion, sample_recorded_entities):
+    mock_completion.return_value = _mock_reply("", finish_reason="length")
+
+    with pytest.raises(EvolveException) as excinfo:
+        resolve_conflicts(sample_recorded_entities, sample_recorded_entities)
+
+    assert "completion budget was spent before any JSON" in str(excinfo.value.__cause__)
+
+
+@pytest.mark.unit
+@patch("altk_evolve.llm.conflict_resolution.conflict_resolution.completion")
+def test_complete_reply_at_the_budget_limit_is_still_accepted(mock_completion, sample_recorded_entities):
+    """finish_reason=length does not by itself mean the JSON is unusable.
+
+    A reply can stop exactly at the limit and still be complete; rejecting on the
+    flag alone would discard good output, so truncation is only reported when the
+    content also fails to parse.
+    """
+    mock_completion.return_value = _mock_reply(
+        json.dumps({"entities": [{"id": "e1", "type": "guideline", "content": "x", "event": "NONE"}]}),
+        finish_reason="length",
+    )
+
+    result = resolve_conflicts(sample_recorded_entities, sample_recorded_entities)
+
+    assert len(result) == 1
+    assert result[0].event == "NONE"
+    assert mock_completion.call_count == 1

--- a/tests/unit/test_conflict_resolution.py
+++ b/tests/unit/test_conflict_resolution.py
@@ -612,14 +612,12 @@ def _set_conflict_model(monkeypatch, model, provider):
 
 
 @pytest.mark.unit
-def test_groq_gpt_oss_gets_a_token_budget_and_no_response_format(monkeypatch):
-    """Groq keeps the prompt-and-parse path.
+def test_groq_gpt_oss_gets_budget_reasoning_cap_and_json_mode(monkeypatch):
+    """The Groq path needs its reasoning bounded, and tolerates JSON mode.
 
-    LiteLLM reports response-format support for groq/openai/gpt-oss while the
-    model can still fail when a schema/tool-backed reply is required (#264), so
-    the fix here is a completion budget, not constrained decoding. If this starts
-    failing because response_format was enabled for Groq, live-test
-    groq/openai/gpt-oss-120b before accepting the change.
+    #264 excluded Groq from *schema/tool-backed* response_format after the model
+    failed when no tool call was produced. Plain json_object involves no tool
+    routing, and was verified live against groq/openai/gpt-oss-120b.
     """
     _set_conflict_model(monkeypatch, "groq/openai/gpt-oss-120b", "groq")
 
@@ -627,12 +625,45 @@ def test_groq_gpt_oss_gets_a_token_budget_and_no_response_format(monkeypatch):
 
     assert options["max_tokens"] == _GROQ_GPT_OSS_CONFLICT_MAX_TOKENS
     assert options["reasoning_effort"] == "low"
-    assert "response_format" not in options
+    assert options["response_format"] == {"type": "json_object"}
+
+
+@pytest.mark.unit
+def test_groq_behind_an_openai_compatible_base_url_still_gets_the_budget(monkeypatch):
+    """The gateway shape: Groq reached with custom_llm_provider=openai.
+
+    wxo-agentic-memory sets provider=openai when it routes through its AI
+    gateway, so provider and model prefix alone miss a Groq-backed model. Losing
+    the budget here is not cosmetic: measured live, reasoning grew from ~350 to
+    ~2400 characters without the cap, on the model whose reasoning is what
+    exhausts the reply in the first place.
+    """
+    _set_conflict_model(monkeypatch, "openai/gpt-oss-120b", "openai")
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://api.groq.com/openai/v1")
+
+    options = _conflict_resolution_completion_options()
+
+    assert options["max_tokens"] == _GROQ_GPT_OSS_CONFLICT_MAX_TOKENS
+    # litellm raises UnsupportedParamsError for reasoning_effort under the openai
+    # provider, so it must be omitted rather than sent hopefully.
+    assert "reasoning_effort" not in options
+    assert options["response_format"] == {"type": "json_object"}
+
+
+@pytest.mark.unit
+def test_non_groq_base_url_does_not_trigger_the_groq_budget(monkeypatch):
+    _set_conflict_model(monkeypatch, "openai/gpt-oss-120b", "openai")
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://api.openai.com/v1")
+
+    options = _conflict_resolution_completion_options()
+
+    assert "max_tokens" not in options
 
 
 @pytest.mark.unit
 def test_capable_provider_gets_json_mode(monkeypatch):
     _set_conflict_model(monkeypatch, "gpt-4o", "openai")
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
 
     options = _conflict_resolution_completion_options()
 
@@ -645,6 +676,7 @@ def test_capable_provider_gets_json_mode(monkeypatch):
 @pytest.mark.unit
 def test_provider_without_response_format_support_gets_no_options(monkeypatch):
     _set_conflict_model(monkeypatch, "gpt-4o", "openai")
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
 
     with patch(
         "altk_evolve.llm.conflict_resolution.conflict_resolution.get_supported_openai_params",


### PR DESCRIPTION
## Summary

Conflict resolution parsed unconstrained model output with a strict
`json.loads`, so a reply that was empty, truncated, or wrapped in prose failed
the whole reconciliation. All three attempts reuse a prompt built once outside
the retry loop, so the retry is byte-identical and the failure is deterministic
rather than transient. Downstream, that surfaced as an unavailable write:
`wxo-agentic-memory` turns it into an HTTP 500 and stores nothing, after the
generation cost has already been paid.

Found while certifying guideline memory with `groq/openai/gpt-oss-120b`, where
three replays of the same eligible trajectory failed 3/3 once a store existed.

- **Reserve completion budget for the JSON.** GPT-OSS on Groq spends the budget
  on reasoning tokens and returns empty content, so cap `max_tokens` and lower
  `reasoning_effort` for that path. (Recovered from an unmerged branch — it was
  written against a branch that had already been squash-merged, so it never
  reached `main`.)
- **Recover JSON that providers wrap in prose.** `clean_llm_response` only
  unwrapped a fenced block anchored to the whole string, so a preamble, trailing
  commentary, or an unfenced object went to `json.loads` verbatim. Strip
  reasoning blocks first, then locate a decodable object/array with
  `raw_decode`. Truncated output still fails — `raw_decode` finds no complete
  value — so an incomplete reply is never half-applied.
- **Ask for JSON mode where the provider supports it**, so the reply is
  constrained at the source rather than repaired afterwards. Plain
  `{"type": "json_object"}` rather than a schema: the prompt already fixes the
  shape and `json_object` needs no tool routing.
- **Diagnose truncation by name.** A reply cut off by the budget produced a
  generic `Expecting value`, which points at the wrong fix. `finish_reason` is
  now read and reported. Checked only when the content fails to parse: a reply
  can stop exactly at the limit and still be complete, and rejecting on the flag
  alone would discard usable output.

### Groq detection, and JSON mode on Groq

Live testing against `groq/openai/gpt-oss-120b` changed two decisions here.

**Provider detection was wrong for gateway deployments.** `wxo-agentic-memory`
sets `EVOLVE_CUSTOM_LLM_PROVIDER=openai` whenever it routes through its AI
gateway, so a Groq-backed model arrives looking like OpenAI and the completion
budget silently stopped applying — on the one model whose reasoning is what
exhausts the reply. Same prompt, measured: **~350 characters of reasoning with
the cap, ~2400 without.** Detection now also checks the base URL.

`reasoning_effort` is gated on what litellm will accept: under the `openai`
provider it **raises** `UnsupportedParamsError` rather than dropping the
parameter, even though the Groq endpoint behind it accepts it. Fixing detection
without that gate would have turned a silent budget loss into a hard failure on
every gateway-routed call.

**JSON mode is now enabled for Groq too.** #264 excluded Groq from
`response_format` after schema/tool-backed replies failed when the model
produced no tool call, and asked for live testing before re-enabling. That
testing is done: `json_object` involves no tool routing, and parses correctly on
`groq/openai/gpt-oss-120b` through both the `groq` provider and an
OpenAI-compatible base URL, with slightly *lower* reasoning under JSON mode.
Guideline generation's exclusion is untouched and still needs its own live test.

## Test plan

- [x] `pytest tests/unit` — 649 passed, 8 skipped (the 6 `[asyncio-milvus]`
      parametrizations error at fixture setup on a pre-existing, unrelated
      missing `pymilvus` in this environment)
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy` on the changed modules — clean
- [x] **Live against `groq/openai/gpt-oss-120b`**, both provider shapes:
      `provider=groq` with `groq/` prefix, and `provider=openai` behind
      `https://api.groq.com/openai/v1`. Both return `events=['NONE']` for a
      paraphrase of an existing guideline — the correct verdict — with the
      budget applied in both cases after the detection fix
- [x] Live measurement of the reasoning cap: ~350 chars of reasoning with
      `reasoning_effort=low`, ~2400 without, on an identical prompt
- [x] Live confirmation that `json_object` parses on Groq gpt-oss via both
      routes, which is what #264 asked for before enabling it
- [x] Live confirmation that `reasoning_effort` raises
      `UnsupportedParamsError` under the `openai` provider, which is why it is
      capability-gated
- [x] Unit coverage for the failing shapes: empty content, `None` content,
      reasoning-only, truncated-before-close, prose preamble, missing
      `entities` key, hallucinated entity id — plus controls for bare and
      fenced JSON
- [x] Unit coverage for the option matrix: groq provider, Groq behind an
      OpenAI-compatible URL, a non-Groq URL, a capable provider, and a provider
      without `response_format` support

## Notes for review

- The consumer-side half of this lives in `wxo-agentic-memory`, where a
  reconciliation failure no longer fails the write. Closing the certification
  gate needs a release cut from this branch and that repo's
  `altk-evolve==1.1.4` pin bumped.
- `max_tokens=8192` is fixed regardless of entity count, while the caller
  serializes every existing guideline into the prompt. Worth tuning together
  once real prompt sizes are visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of AI responses containing reasoning text, provider-added content, fenced JSON, or embedded JSON.
  * Added clearer errors for empty or incomplete conflict-resolution responses.
  * Ensured complete JSON responses are accepted even when providers report a length limit.
  * Prevented truncated responses from being mistaken for valid nested JSON.

* **Improvements**
  * Tuned completion settings for Groq-routed GPT-OSS models.
  * Enabled plain JSON responses where supported.
  * Preserved response metadata during JSON extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
