### PR TITLE
fix(ci): wait for release assets before publishing to PyPI

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -37,26 +37,46 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.event.release.tag_name }}
         run: |
-          mkdir dist
+          mkdir -p dist
+          shopt -s nullglob
+
+          # Retry until BOTH artifact types are present, not merely until the
+          # download command succeeds. `gh release download` only errors when
+          # *no* pattern matches anything; when the wheel is up but the sdist is
+          # not, it downloads the wheel and exits 0. On v1.1.6 those two landed
+          # one second apart, so a partial download is the likely case here, not
+          # a corner case -- breaking on it would fail the job and still require
+          # the manual re-run this change exists to remove.
+          #
+          # --clobber lets a retry replace what a partial attempt already wrote;
+          # without it `gh release download` exits 1 on the pre-existing file and
+          # the loop could never recover.
           for attempt in $(seq 1 30); do
-            if gh release download "$TAG" \
-                 --repo "${{ github.repository }}" \
-                 --pattern "*.tar.gz" \
-                 --pattern "*.whl" \
-                 --dir dist/; then
-              echo "Downloaded release assets on attempt $attempt."
+            gh release download "$TAG" \
+              --repo "${{ github.repository }}" \
+              --pattern "*.tar.gz" \
+              --pattern "*.whl" \
+              --dir dist/ \
+              --clobber || true
+
+            sdists=(dist/*.tar.gz)
+            wheels=(dist/*.whl)
+            if [ ${#sdists[@]} -gt 0 ] && [ ${#wheels[@]} -gt 0 ]; then
+              echo "Got sdist and wheel for $TAG on attempt $attempt."
               break
             fi
-            echo "Assets for $TAG not available yet (attempt $attempt/30); retrying in 10s..."
+
+            echo "Incomplete assets for $TAG (${#sdists[@]} sdist, ${#wheels[@]} wheel) on attempt $attempt/30; retrying in 10s..."
             sleep 10
           done
-          # Fail loudly rather than handing an empty directory to the publish
-          # step, which would otherwise succeed while uploading nothing.
-          shopt -s nullglob
+
+          # Retained as a safeguard: never hand a partial or empty directory to
+          # the publish step, which would otherwise succeed while uploading an
+          # incomplete set.
           sdists=(dist/*.tar.gz)
           wheels=(dist/*.whl)
           if [ ${#sdists[@]} -eq 0 ] || [ ${#wheels[@]} -eq 0 ]; then
-            echo "::error::No sdist and/or wheel found for $TAG after 5 minutes of retries."
+            echo "::error::Expected both an sdist and a wheel for $TAG; found ${#sdists[@]} sdist(s) and ${#wheels[@]} wheel(s) after 5 minutes of retries."
             ls -la dist/ || true
             exit 1
           fi

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -36,37 +36,86 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.event.release.tag_name }}
+          REPO: ${{ github.repository }}
         run: |
           mkdir -p dist
           shopt -s nullglob
 
-          # Retry until BOTH artifact types are present, not merely until the
-          # download command succeeds. `gh release download` only errors when
-          # *no* pattern matches anything; when the wheel is up but the sdist is
-          # not, it downloads the wheel and exits 0. On v1.1.6 those two landed
-          # one second apart, so a partial download is the likely case here, not
-          # a corner case -- breaking on it would fail the job and still require
-          # the manual re-run this change exists to remove.
+          # `gh release download` opens the destination with O_TRUNC before it
+          # copies and does not remove it when the copy fails, so "the file is
+          # on disk" is not the same as "the file is usable". Reading the
+          # contents is what keeps the counts below honest: a zero-byte or
+          # half-written artifact left behind by a failed transfer would
+          # otherwise satisfy the break condition and get published.
+          usable() {
+            local f="$1"
+            [ -s "$f" ] || return 1
+            case "$f" in
+              # Decompresses the whole stream, so a truncated sdist fails here.
+              *.tar.gz) tar -tzf "$f" >/dev/null 2>&1 || return 1 ;;
+              # ZipFile() needs the central directory, which is written last,
+              # and testzip() CRC-checks every member.
+              *.whl) python3 -c 'import sys, zipfile; sys.exit(1 if zipfile.ZipFile(sys.argv[1]).testzip() else 0)' "$f" 2>/dev/null || return 1 ;;
+              *) return 1 ;;
+            esac
+            return 0
+          }
+
+          # Delete whatever failed validation, so the next attempt re-downloads
+          # it instead of counting it as already present.
+          prune_unusable() {
+            local f
+            for f in dist/*.tar.gz dist/*.whl; do
+              if usable "$f"; then
+                continue
+              fi
+              echo "Discarding unusable artifact $f ($(wc -c <"$f") bytes)."
+              rm -f "$f"
+            done
+            return 0
+          }
+
+          # Retry until BOTH artifact types are present and readable, not merely
+          # until the download command succeeds. `gh release download` only
+          # errors when *no* pattern matches anything; when the wheel is up but
+          # the sdist is not, it downloads the wheel and exits 0. On v1.1.6 those
+          # two landed one second apart, so a partial download is the likely case
+          # here, not a corner case -- breaking on it would fail the job and
+          # still require the manual re-run this change exists to remove.
           #
           # --clobber lets a retry replace what a partial attempt already wrote;
           # without it `gh release download` exits 1 on the pre-existing file and
           # the loop could never recover.
-          for attempt in $(seq 1 30); do
+          #
+          # The bound is a wall-clock deadline checked *before* the sleep, so
+          # every delay is followed by another download. A fixed attempt count
+          # sleeps after its final attempt and then gives up without looking
+          # again, losing an asset that landed during that last delay -- the same
+          # sub-second race this step exists to absorb.
+          deadline=$(( $(date +%s) + 300 ))
+          attempt=0
+          while :; do
+            attempt=$(( attempt + 1 ))
             gh release download "$TAG" \
-              --repo "${{ github.repository }}" \
+              --repo "$REPO" \
               --pattern "*.tar.gz" \
               --pattern "*.whl" \
               --dir dist/ \
               --clobber || true
 
+            prune_unusable
             sdists=(dist/*.tar.gz)
             wheels=(dist/*.whl)
             if [ ${#sdists[@]} -gt 0 ] && [ ${#wheels[@]} -gt 0 ]; then
-              echo "Got sdist and wheel for $TAG on attempt $attempt."
+              echo "Got a usable sdist and wheel for $TAG on attempt $attempt."
               break
             fi
 
-            echo "Incomplete assets for $TAG (${#sdists[@]} sdist, ${#wheels[@]} wheel) on attempt $attempt/30; retrying in 10s..."
+            remaining=$(( deadline - $(date +%s) ))
+            if [ "$remaining" -le 0 ]; then
+              break
+            fi
+            echo "Incomplete assets for $TAG (${#sdists[@]} sdist, ${#wheels[@]} wheel) on attempt $attempt; ${remaining}s of wait left, retrying in 10s..."
             sleep 10
           done
 
@@ -76,7 +125,7 @@ jobs:
           sdists=(dist/*.tar.gz)
           wheels=(dist/*.whl)
           if [ ${#sdists[@]} -eq 0 ] || [ ${#wheels[@]} -eq 0 ]; then
-            echo "::error::Expected both an sdist and a wheel for $TAG; found ${#sdists[@]} sdist(s) and ${#wheels[@]} wheel(s) after 5 minutes of retries."
+            echo "::error::Expected a usable sdist and a usable wheel for $TAG; found ${#sdists[@]} sdist(s) and ${#wheels[@]} wheel(s) after $attempt attempts over ~5 minutes."
             ls -la dist/ || true
             exit 1
           fi

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -16,16 +16,52 @@ jobs:
       name: pypi
       url: https://pypi.org/project/altk-evolve
     steps:
+      # Wait for the release assets instead of assuming they are already there.
+      #
+      # GitHub fires `release: published` as soon as the release is published,
+      # but release-github.yaml attaches the sdist/wheel *after* that point, so
+      # this job can start before the assets exist. On v1.1.6 it started at
+      # 18:23:46 and failed at 18:23:47 with "no assets to download", while the
+      # wheel landed at 18:23:46 and the sdist at 18:23:47 — lost by under a
+      # second (run 32287087213), leaving a tagged release whose artifacts never
+      # reached PyPI and had to be published by re-running this job by hand.
+      #
+      # Retrying turns that manual re-run into something automatic. We
+      # deliberately keep downloading the release's own assets rather than
+      # rebuilding here: the artifacts are produced by `uv build` inside
+      # semantic-release's build_command, which first runs the npm UI build and
+      # rewrites README/install.sh for the new version. A plain `python -m build`
+      # in this job would silently omit all of that.
       - name: Download release assets
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.release.tag_name }}
         run: |
           mkdir dist
-          gh release download "${{ github.event.release.tag_name }}" \
-            --repo "${{ github.repository }}" \
-            --pattern "*.tar.gz" \
-            --pattern "*.whl" \
-            --dir dist/
+          for attempt in $(seq 1 30); do
+            if gh release download "$TAG" \
+                 --repo "${{ github.repository }}" \
+                 --pattern "*.tar.gz" \
+                 --pattern "*.whl" \
+                 --dir dist/; then
+              echo "Downloaded release assets on attempt $attempt."
+              break
+            fi
+            echo "Assets for $TAG not available yet (attempt $attempt/30); retrying in 10s..."
+            sleep 10
+          done
+          # Fail loudly rather than handing an empty directory to the publish
+          # step, which would otherwise succeed while uploading nothing.
+          shopt -s nullglob
+          sdists=(dist/*.tar.gz)
+          wheels=(dist/*.whl)
+          if [ ${#sdists[@]} -eq 0 ] || [ ${#wheels[@]} -eq 0 ]; then
+            echo "::error::No sdist and/or wheel found for $TAG after 5 minutes of retries."
+            ls -la dist/ || true
+            exit 1
+          fi
+          echo "Found ${#sdists[@]} sdist(s) and ${#wheels[@]} wheel(s):"
+          ls -la dist/
       - name: Publish release distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
## Problem

`python-publish.yml` triggers on `release: published` and immediately runs
`gh release download`. But `release-github.yaml` attaches the sdist/wheel *after* the release is
published, so this job can start before the assets exist.

That is what happened on **v1.1.6** ([run 32287087213](https://github.com/AgentToolkit/altk-evolve/actions/runs/32287087213)):

```
18:21:33  release created (draft)
18:23:39  release published        <- publish workflow triggers
18:23:46  download step starts     <- wheel finishes uploading this same second
18:23:47  "no assets to download" -> exit 1
18:23:47  sdist upload finishes    <- 0.5s too late
```

Result: a tagged release with assets attached, but nothing on PyPI until the job was re-run by hand.

## Fix

Retry the download for up to 5 minutes, then **assert** that both an sdist and a wheel are present.

The assertion is worth having on its own: `gh release download` **exits 0 when it matches nothing**,
so an empty `dist/` previously flowed straight into the publish step and "succeeded" while uploading
nothing at all.

## Why not build the dists here instead?

That was the first thing I tried, and it would ship a broken wheel. The artifacts are produced by
`uv build` inside semantic-release's `build_command`, which first runs the **npm UI build** —
`altk_evolve/frontend/ui/dist` is not tracked in git — and rewrites `README.md`/`install.sh` for the
new version. A plain `python -m build` in this job would silently omit all of it.

Publishing the release's own assets also keeps the guarantee that PyPI and the GitHub release carry
byte-identical artifacts (verified for v1.1.6: both wheels are sha256 `112854f9…67d6`).

## Verification

Executed the step's logic against a stubbed `gh`:

| scenario | expected | result |
|---|---|---|
| assets appear on the 3rd attempt | succeed | ✅ succeeds after 2 retries |
| assets never appear | fail | ✅ fails after 30 attempts |
| `gh` exits 0 but `dist/` is empty | fail | ✅ fails with `::error::` |
| only a wheel, no sdist | fail | ✅ fails with `::error::` |

No change to the publish step, the `pypi` environment, or `id-token: write`, so the existing PyPI
trusted-publisher config keeps working untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release publishing reliability by retrying unavailable or unusable package downloads.
  * Added validation to reject empty files, truncated source packages, and corrupted wheel packages.
  * Invalid or incomplete artifacts are now removed and re-downloaded automatically.
  * Publishing retries continue for up to five minutes and provide clearer progress, success, and failure details.
  * Releases stop with clear validation feedback when required package files are missing or unusable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->