### PR TITLE
feat(reaper): purge service instance data

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ OPENAI_API_KEY="<YOUR_OPENAI_API_KEY>"
 # Optional: Evolve Backend Configuration (default: filesystem)
 # EVOLVE_BACKEND=filesystem  # Options: filesystem, postgres, milvus
 # EVOLVE_NAMESPACE_ID=evolve
+# EVOLVE_SERVICE_INSTANCE_ID=  # Deployment ownership marker for new entities
 
 # Optional: LLM Configuration
 # EVOLVE_MODEL_NAME=gpt-4o

--- a/Dockerfile.core
+++ b/Dockerfile.core
@@ -21,8 +21,8 @@ COPY pyproject.toml uv.lock ./
 COPY altk_evolve ./altk_evolve
 COPY README.md LICENSE MANIFEST.in ./
 
-# Install dependencies using uv (no extras needed for milvus as it's in base dependencies)
-RUN uv sync --frozen --no-dev
+# Include the lightweight psycopg dependency used by the Kubernetes reaper.
+RUN uv sync --frozen --no-dev --extra reaper
 
 # Set environment variables for filesystem backend
 ENV EVOLVE_BACKEND=filesystem

--- a/altk_evolve/backend/base.py
+++ b/altk_evolve/backend/base.py
@@ -16,7 +16,7 @@ from altk_evolve.hooks.manager import (
 )
 from altk_evolve.hooks.types import HookType
 from altk_evolve.schema.conflict_resolution import EntityUpdate
-from altk_evolve.schema.core import Entity, Namespace, RecordedEntity
+from altk_evolve.schema.core import SERVICE_INSTANCE_METADATA_KEY, Entity, Namespace, RecordedEntity
 from altk_evolve.schema.exceptions import EvolveException
 from altk_evolve.utils.utils import serialize_content
 
@@ -253,15 +253,26 @@ class BaseEntityBackend(ABC):
 
         if enable_conflict_resolution:
             old_entities: list[RecordedEntity] = []
+            instance_ids = {
+                str(entity.metadata.get(SERVICE_INSTANCE_METADATA_KEY)).strip()
+                for entity in entities
+                if entity.metadata and entity.metadata.get(SERVICE_INSTANCE_METADATA_KEY)
+            }
+            all_entities_are_instance_scoped = len(instance_ids) == 1 and all(
+                entity.metadata and entity.metadata.get(SERVICE_INSTANCE_METADATA_KEY) for entity in entities
+            )
             for entity in entities:
                 query_str = serialize_content(entity.content)
+                filters = {"type": entity_type}
+                if all_entities_are_instance_scoped:
+                    filters[f"metadata.{SERVICE_INSTANCE_METADATA_KEY}"] = next(iter(instance_ids))
                 # Internal pre-read for conflict resolution — must not fire
                 # memory_post_read (public-API reads only).
                 old_entities.extend(
                     self._search_entities_impl(
                         namespace_id=namespace_id,
                         query=query_str,
-                        filters={"type": entity_type},
+                        filters=filters,
                         limit=10,
                     )
                 )

--- a/altk_evolve/cli/cli.py
+++ b/altk_evolve/cli/cli.py
@@ -28,6 +28,7 @@ skills_app = typer.Typer(help="Skill management commands")
 viz_app = typer.Typer(help="Visualization commands")
 hooks_app = typer.Typer(help="Hook seam management commands")
 retention_app = typer.Typer(help="Data retention commands")
+purge_app = typer.Typer(help="Operator-facing destructive cleanup commands")
 
 app.add_typer(namespaces_app, name="namespaces")
 app.add_typer(entities_app, name="entities")
@@ -36,6 +37,7 @@ app.add_typer(skills_app, name="skills")
 app.add_typer(viz_app, name="viz")
 app.add_typer(hooks_app, name="hooks")
 app.add_typer(retention_app, name="retention")
+app.add_typer(purge_app, name="purge")
 
 console = Console()
 
@@ -43,6 +45,54 @@ console = Console()
 def get_client() -> EvolveClient:
     """Get a EvolveClient instance."""
     return EvolveClient()
+
+
+# =============================================================================
+# Operator Purge Commands
+# =============================================================================
+
+
+@purge_app.command("service-instance")
+def purge_service_instance(
+    service_instance_id: Annotated[
+        str,
+        typer.Option(
+            "--service-instance-id",
+            envvar="EVOLVE_SERVICE_INSTANCE_ID",
+            help="Service instance whose attributed Evolve entities should be purged.",
+        ),
+    ],
+    dry_run: Annotated[
+        bool,
+        typer.Option("--dry-run", help="Count matching entities without deleting them."),
+    ] = False,
+):
+    """Purge all Evolve records attributed to one service instance."""
+    from altk_evolve.config.evolve import evolve_config
+    from altk_evolve.reaper import purge_service_instance_records
+
+    if evolve_config.backend != "postgres":
+        console.print("[red]Service-instance purge requires EVOLVE_BACKEND=postgres.[/red]")
+        raise typer.Exit(1)
+
+    try:
+        result = purge_service_instance_records(service_instance_id, dry_run=dry_run)
+    except Exception as exc:
+        console.print(f"[red]Failed to purge service-instance data:[/red] {exc}")
+        raise typer.Exit(1) from exc
+
+    console.print(
+        json.dumps(
+            {
+                "service_instance_id": result.service_instance_id,
+                "dry_run": result.dry_run,
+                "deleted_records": result.deleted_records,
+                "tables": result.tables,
+            },
+            sort_keys=True,
+        ),
+        markup=False,
+    )
 
 
 # =============================================================================

--- a/altk_evolve/config/evolve.py
+++ b/altk_evolve/config/evolve.py
@@ -1,4 +1,4 @@
-from pydantic import Field, model_validator
+from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing import Literal
 
@@ -9,6 +9,7 @@ class EvolveConfig(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="EVOLVE_", env_file=".env", extra="ignore")
     backend: Literal["milvus", "filesystem", "postgres"] = "filesystem"
     namespace_id: str = "evolve"
+    service_instance_id: str | None = None
     settings: BaseSettings | None = None
     clustering_threshold: float = 0.80
     segmentation_enabled: bool = True
@@ -36,6 +37,13 @@ class EvolveConfig(BaseSettings):
     retrieval_near_core_thresh: float = Field(default=0.75, ge=0.0, le=1.0)
     retrieval_dedup_thresh: float = Field(default=0.90, ge=0.0, le=1.0)
     evidence_filter: Literal["all", "success", "failure"] = "all"
+
+    @field_validator("service_instance_id", mode="before")
+    @classmethod
+    def _normalize_service_instance_id(cls, value: object) -> object:
+        if isinstance(value, str):
+            return value.strip() or None
+        return value
 
     @model_validator(mode="after")
     def _check_support_thresholds(self) -> "EvolveConfig":

--- a/altk_evolve/frontend/client/evolve_client.py
+++ b/altk_evolve/frontend/client/evolve_client.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, cast
 from altk_evolve.backend.base import BaseEntityBackend
 from altk_evolve.config.evolve import EvolveConfig
 from altk_evolve.schema.conflict_resolution import EntityUpdate
-from altk_evolve.schema.core import Entity, Namespace, RecordedEntity
+from altk_evolve.schema.core import SERVICE_INSTANCE_METADATA_KEY, Entity, Namespace, RecordedEntity
 from altk_evolve.schema.exceptions import NamespaceAlreadyExistsException, NamespaceNotFoundException
 from altk_evolve.schema.guidelines import ConsolidationResult
 
@@ -100,9 +100,27 @@ class EvolveClient:
         """Delete a namespace that entities exist in."""
         self.backend.delete_namespace(namespace_id)
 
-    def update_entities(self, namespace_id: str, entities: list[Entity], enable_conflict_resolution: bool = True) -> list[EntityUpdate]:
-        """Add multiple entities to a namespace."""
-        return self.backend.update_entities(namespace_id, entities, enable_conflict_resolution)
+    def update_entities(
+        self,
+        namespace_id: str,
+        entities: list[Entity],
+        enable_conflict_resolution: bool = True,
+    ) -> list[EntityUpdate]:
+        """Add multiple entities to a namespace.
+
+        When configured, ``EVOLVE_SERVICE_INSTANCE_ID`` is persisted as
+        reserved metadata on every entity in the batch. Caller-provided values
+        for that metadata key are ignored.
+        """
+        attributed_entities: list[Entity] = []
+        for entity in entities:
+            metadata = dict(entity.metadata or {})
+            metadata.pop(SERVICE_INSTANCE_METADATA_KEY, None)
+            if self.config.service_instance_id is not None:
+                metadata[SERVICE_INSTANCE_METADATA_KEY] = self.config.service_instance_id
+            attributed_entities.append(entity.model_copy(update={"metadata": metadata}))
+
+        return self.backend.update_entities(namespace_id, attributed_entities, enable_conflict_resolution)
 
     def search_entities(
         self, namespace_id: str, query: str | None = None, filters: dict | None = None, limit: int = 10

--- a/altk_evolve/frontend/mcp/mcp_server.py
+++ b/altk_evolve/frontend/mcp/mcp_server.py
@@ -27,7 +27,7 @@ from altk_evolve.llm.fact_extraction.fact_extraction import (
 )
 from altk_evolve.llm.guidelines.guidelines import generate_guidelines
 from altk_evolve.schema.conflict_resolution import EntityUpdate
-from altk_evolve.schema.core import Entity, RecordedEntity
+from altk_evolve.schema.core import SERVICE_INSTANCE_METADATA_KEY, Entity, RecordedEntity
 from altk_evolve.schema.exceptions import EvolveException, NamespaceNotFoundException
 
 logging.basicConfig(level=logging.INFO)
@@ -241,17 +241,18 @@ def _persist_entities(
     namespace_id: str | None,
     entities: list[Entity],
     enable_conflict_resolution: bool = False,
-) -> tuple[list[EntityUpdate], str]:
+) -> tuple[list[EntityUpdate], str, str | None]:
     """Persist entities with a single retry if the namespace cache is stale.
 
     Resolves ``namespace_id`` (falling back to the configured default), writes
     via ``update_entities``, and on ``NamespaceNotFoundException`` evicts the
-    cached entry, re-resolves, and retries once. Returns the update records
-    and the namespace actually written to.
+    cached entry, re-resolves, and retries once. Returns the update records,
+    namespace, and configured service-instance attribution used for the write.
     """
     resolved_ns = _resolve_namespace(namespace_id)
     try:
-        updates = get_client().update_entities(
+        client = get_client()
+        updates = client.update_entities(
             namespace_id=resolved_ns,
             entities=entities,
             enable_conflict_resolution=enable_conflict_resolution,
@@ -259,12 +260,13 @@ def _persist_entities(
     except NamespaceNotFoundException:
         _evict_namespace(resolved_ns)
         resolved_ns = _resolve_namespace(namespace_id)
-        updates = get_client().update_entities(
+        client = get_client()
+        updates = client.update_entities(
             namespace_id=resolved_ns,
             entities=entities,
             enable_conflict_resolution=enable_conflict_resolution,
         )
-    return updates, resolved_ns
+    return updates, resolved_ns, client.config.service_instance_id
 
 
 @mcp.tool()
@@ -401,6 +403,7 @@ def store_user_facts(
         return _empty_store_user_facts_response(user_id)
 
     base_metadata: dict[str, Any] = dict(metadata_dict)
+    base_metadata.pop(SERVICE_INSTANCE_METADATA_KEY, None)
     base_metadata["user_id"] = user_id
 
     extracted = extract_facts_from_messages([{"role": "user", "content": trimmed_message}])
@@ -418,7 +421,7 @@ def store_user_facts(
     if not entities:
         return _empty_store_user_facts_response(user_id)
 
-    updates, _ = _persist_entities(
+    updates, _, _ = _persist_entities(
         namespace_id=None,
         entities=entities,
         enable_conflict_resolution=enable_conflict_resolution,
@@ -573,7 +576,7 @@ def save_trajectory(
             )
         )
 
-    _, resolved_ns = _persist_entities(
+    _, resolved_ns, service_instance_id = _persist_entities(
         namespace_id=namespace_id,
         entities=entities,
         enable_conflict_resolution=False,
@@ -668,6 +671,8 @@ def save_trajectory(
         )
 
     readback_filters: dict = {"type": "trajectory", "metadata.task_id": task_id}
+    if service_instance_id:
+        readback_filters[f"metadata.{SERVICE_INSTANCE_METADATA_KEY}"] = service_instance_id
     if effective_user_id:
         readback_filters["metadata.user_id"] = effective_user_id
     if session_id:
@@ -712,7 +717,13 @@ def create_entity(
         if visibility == "public" and not owner_id:
             return json.dumps({"error": "Missing owner_id", "message": "public entities must have an owner_id"})
 
-        _RESERVED_KEYS = {"owner_id", "visibility", "published_at", "creation_mode"}
+        _RESERVED_KEYS = {
+            "owner_id",
+            "visibility",
+            "published_at",
+            "creation_mode",
+            SERVICE_INSTANCE_METADATA_KEY,
+        }
 
         metadata_dict = {}
         if metadata:
@@ -741,7 +752,7 @@ def create_entity(
 
         entity = Entity(type=entity_type, content=content, metadata=metadata_dict)
 
-        updates, _ = _persist_entities(
+        updates, _, _ = _persist_entities(
             namespace_id=namespace_id,
             entities=[entity],
             enable_conflict_resolution=enable_conflict_resolution,

--- a/altk_evolve/reaper/__init__.py
+++ b/altk_evolve/reaper/__init__.py
@@ -1,0 +1,5 @@
+"""Operator-facing cleanup utilities."""
+
+from altk_evolve.reaper.service_instance import ServiceInstancePurgeResult, purge_service_instance_records
+
+__all__ = ["ServiceInstancePurgeResult", "purge_service_instance_records"]

--- a/altk_evolve/reaper/service_instance.py
+++ b/altk_evolve/reaper/service_instance.py
@@ -1,0 +1,123 @@
+"""Delete Postgres entities owned by one service instance."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import psycopg
+from psycopg import sql
+
+from altk_evolve.config.postgres import PostgresDBSettings
+from altk_evolve.schema.core import SERVICE_INSTANCE_METADATA_KEY
+
+
+@dataclass(frozen=True)
+class ServiceInstancePurgeResult:
+    """Summary of a service-instance purge or dry run."""
+
+    service_instance_id: str
+    dry_run: bool
+    deleted_records: int
+    tables: dict[str, int]
+
+
+def _namespace_tables(conn: Any) -> list[tuple[str, str]]:
+    """Discover Evolve namespace tables in the active Postgres schema."""
+    with conn.cursor() as cur:
+        cur.execute(
+            r"""
+            SELECT t.table_schema, t.table_name
+            FROM information_schema.tables AS t
+            WHERE t.table_type = 'BASE TABLE'
+              AND t.table_schema = current_schema()
+              AND t.table_name LIKE 'ns\_%' ESCAPE '\'
+              AND EXISTS (
+                  SELECT 1
+                  FROM information_schema.columns AS c
+                  WHERE c.table_schema = t.table_schema
+                    AND c.table_name = t.table_name
+                    AND c.column_name = 'metadata'
+                    AND c.data_type = 'jsonb'
+              )
+              AND EXISTS (
+                  SELECT 1
+                  FROM information_schema.columns AS c
+                  WHERE c.table_schema = t.table_schema
+                    AND c.table_name = t.table_name
+                    AND c.column_name = 'id'
+              )
+            ORDER BY t.table_schema, t.table_name
+            """
+        )
+        return [(str(schema), str(table)) for schema, table in cur.fetchall()]
+
+
+def _purge_connection(conn: Any, service_instance_id: str, *, dry_run: bool) -> ServiceInstancePurgeResult:
+    tables = _namespace_tables(conn)
+    affected: dict[str, int] = {}
+
+    try:
+        with conn.cursor() as cur:
+            for schema_name, table_name in tables:
+                table = sql.Identifier(schema_name, table_name)
+                key = table_name if schema_name == "public" else f"{schema_name}.{table_name}"
+                if dry_run:
+                    cur.execute(
+                        sql.SQL("SELECT COUNT(*) FROM {} WHERE metadata ->> %s = %s").format(table),
+                        (SERVICE_INSTANCE_METADATA_KEY, service_instance_id),
+                    )
+                    row = cur.fetchone()
+                    affected[key] = int(row[0]) if row else 0
+                else:
+                    cur.execute(
+                        sql.SQL("DELETE FROM {} WHERE metadata ->> %s = %s").format(table),
+                        (SERVICE_INSTANCE_METADATA_KEY, service_instance_id),
+                    )
+                    affected[key] = max(cur.rowcount, 0)
+
+        if dry_run:
+            conn.rollback()
+        else:
+            conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+
+    return ServiceInstancePurgeResult(
+        service_instance_id=service_instance_id,
+        dry_run=dry_run,
+        deleted_records=sum(affected.values()),
+        tables=affected,
+    )
+
+
+def purge_service_instance_records(
+    service_instance_id: str,
+    *,
+    dry_run: bool = False,
+    settings: PostgresDBSettings | None = None,
+) -> ServiceInstancePurgeResult:
+    """Delete every attributed entity for ``service_instance_id``.
+
+    This path connects with psycopg directly and intentionally does not create
+    an ``EvolveClient`` or load an embedding model. Namespace catalog rows are
+    tenant-level metadata and are left intact.
+    """
+    service_instance_id = (service_instance_id or "").strip()
+    if not service_instance_id:
+        raise ValueError("service_instance_id is required")
+
+    resolved_settings = settings or PostgresDBSettings()
+    conn = psycopg.connect(
+        host=resolved_settings.host,
+        port=resolved_settings.port,
+        user=resolved_settings.user,
+        password=resolved_settings.password,
+        dbname=resolved_settings.dbname,
+        autocommit=False,
+    )
+    try:
+        return _purge_connection(conn, service_instance_id, dry_run=dry_run)
+    finally:
+        conn.close()

--- a/altk_evolve/schema/core.py
+++ b/altk_evolve/schema/core.py
@@ -2,6 +2,8 @@ from datetime import datetime
 from pydantic import BaseModel, Field
 from sqlite3 import Cursor, Row
 
+SERVICE_INSTANCE_METADATA_KEY = "service_instance_id"
+
 
 class Namespace(BaseModel):
     """Details of a namespace containing memories."""

--- a/docs/guides/backend-configuration.md
+++ b/docs/guides/backend-configuration.md
@@ -141,6 +141,7 @@ Evolve uses a layered identity model. Understanding how each layer maps to physi
 | Layer | Purpose | Scope |
 |---|---|---|
 | **Namespace** (`namespace_id`) | Org / tenant boundary | First-class — physically separates data |
+| **Service instance** (`service_instance_id`) | Deployment ownership / deprovisioning boundary | Reserved entity metadata |
 | **User** (`user_id`) | Individual user within a namespace | Metadata-only — stored in the entity `metadata` dict |
 | **Session** (`session_id`) | Single agent session / conversation | Metadata-only — stored in the entity `metadata` dict |
 
@@ -149,6 +150,7 @@ Evolve uses a layered identity model. Understanding how each layer maps to physi
 | Aspect | Filesystem | PostgreSQL (pgvector) | Milvus |
 |---|---|---|---|
 | **Namespace isolation** | One JSON file per namespace (`{id}.json`) | One table per namespace (`ns_{id}`) | One collection per namespace |
+| **`service_instance_id` storage** | `metadata.service_instance_id` in JSON entity dict | `metadata` JSONB column (`metadata->>'service_instance_id'`) | `metadata` JSON field (`metadata["service_instance_id"]`) |
 | **`user_id` storage** | `metadata.user_id` in JSON entity dict | `metadata` JSONB column (`metadata->>'user_id'`) | `metadata` JSON field (`metadata["user_id"]`) |
 | **`session_id` storage** | `metadata.session_id` in JSON entity dict | `metadata` JSONB column (`metadata->>'session_id'`) | `metadata` JSON field (`metadata["session_id"]`) |
 | **`user_id` index** | None (in-memory scan) | None (JSONB GIN possible but not created) | None (scan within collection) |
@@ -160,14 +162,16 @@ Evolve uses a layered identity model. Understanding how each layer maps to physi
 
 1. **Namespace is the only hard boundary.** Data in different namespaces is physically separated across all backends. There is no way to accidentally query across namespaces without explicitly iterating over them.
 
-2. **`user_id` and `session_id` are soft filters.** They rely on query-time filtering against the `metadata` dict. There are no dedicated columns, foreign keys, or indexes — a missing filter silently returns all entities in the namespace regardless of owner.
+2. **`service_instance_id`, `user_id`, and `session_id` are metadata boundaries.** `service_instance_id` identifies which deployment owns an entity and supports operator cleanup; it is not a replacement for namespace tenant isolation. Evolve reads this value only from `EVOLVE_SERVICE_INSTANCE_ID`; callers cannot assign it through entity metadata or MCP tool arguments. Existing entities are not backfilled and remain unattributed. User and session identifiers remain optional query-time filters.
 
-3. **No indexes on identity metadata.** For small-to-medium namespaces this is fine. For large namespaces with frequent per-user queries, consider adding:
+3. **Conflict resolution respects service-instance ownership.** When every entity in a write batch has the same `service_instance_id`, Evolve only compares it with existing entities carrying that same marker. This prevents one service instance from merging with or deleting another instance's memory.
+
+4. **No indexes on identity metadata.** For small-to-medium namespaces this is fine. For large namespaces with frequent per-user queries, consider adding:
    - **PostgreSQL:** A GIN index on the `metadata` JSONB column, or a partial index on `(metadata->>'user_id')`.
    - **Milvus:** A scalar index on `metadata["user_id"]` (supported in Milvus 2.3+).
    - **Filesystem:** Not applicable — the backend scans in memory regardless.
 
-4. **Public entity queries iterate namespaces.** `get_public_entities` loops over all namespaces and filters for `metadata.visibility = "public"`. This is O(N) in the number of namespaces and is not a concern at small scale but should be revisited for deployments with many tenants.
+5. **Public entity queries iterate namespaces.** `get_public_entities` loops over all namespaces and filters for `metadata.visibility = "public"`. This is O(N) in the number of namespaces and is not a concern at small scale but should be revisited for deployments with many tenants.
 
 ## Troubleshooting
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -45,6 +45,7 @@ All configuration variables are prefixed with `EVOLVE_`.
 |----------|-------------------------------------------------------------------------------|------------------------------------------|
 | `EVOLVE_BACKEND` | Backend provider (`milvus`, `filesystem`, or `postgres`)                      | `milvus`                                 |
 | `EVOLVE_NAMESPACE_ID` | Namespace ID for isolation                                                    | `evolve`                                 |
+| `EVOLVE_SERVICE_INSTANCE_ID` | Deployment ownership marker added to newly written entities. | unset |
 | `EVOLVE_GUIDELINES_MODE` | Guideline generation pipeline: `standard`, `consistency`, or `all` — see [Enabling Guidelines](guidelines.md) | `standard` |
 | `EVOLVE_CONSISTENCY_METHOD` | Consistency mode only: `fast` (LLM self-judged) or `accurate` (resampling based) — see [Enabling Guidelines](guidelines.md#choosing-a-consistency-method) | `fast` |
 | `EVOLVE_GUIDELINES_MODEL` | Model for guideline generation only | `EVOLVE_MODEL_NAME` -> `gpt-4o` |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -85,6 +85,28 @@ the rule that decided it, and the evidence behind it. See the
 [Data Retention guide](../guides/retention.md) for the policy format and the
 `AccessStampPlugin` dependency of `max_unused_days` rules.
 
+### Service Instance Cleanup
+
+Kubernetes operators can remove all Postgres entities attributed to a
+deprovisioned service instance. Preview the operation first, then apply it:
+
+```bash
+evolve purge service-instance --service-instance-id "$SERVICE_INSTANCE_ID" --dry-run
+evolve purge service-instance --service-instance-id "$SERVICE_INSTANCE_ID"
+```
+
+The command requires `EVOLVE_BACKEND=postgres`, uses the existing
+`EVOLVE_PG_*` connection settings, emits a JSON summary, and exits non-zero on
+failure. `--service-instance-id` can also be supplied through
+`EVOLVE_SERVICE_INSTANCE_ID`, which is convenient for a Kubernetes CronJob.
+
+The purge scans Evolve namespace tables and deletes rows whose
+`metadata.service_instance_id` exactly matches the requested value. It leaves
+other service instances, tenant-level namespace catalog rows, and legacy rows
+without an attribution marker intact. Run the reaper from a rebuilt
+`Dockerfile.core` image; the image includes the lightweight `reaper` extra and
+the command can be selected by overriding its default MCP entrypoint.
+
 ### Skill Management
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,10 @@ pgvector = [
     "pgvector>=0.3",
 ]
 
+reaper = [
+    "psycopg[binary]>=3.1",
+]
+
 # Optional plugin/hook framework (CPEX). Kept out of core deps because cpex
 # pulls heavy transitive dependencies (fastapi, mcp, prometheus). Without this
 # extra installed, the hook seam is a fast no-op.

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -22,6 +22,7 @@ pytestmark = pytest.mark.unit
 def mock_get_client():
     with patch("altk_evolve.frontend.mcp.mcp_server.get_client") as mock:
         client_instance = mock.return_value
+        client_instance.config.service_instance_id = None
         yield client_instance
 
 
@@ -109,6 +110,21 @@ def test_create_entity_no_metadata_injection_for_other_types(mock_get_client):
     assert "creation_mode" not in (entity.metadata or {})
 
 
+def test_create_entity_removes_caller_service_instance_metadata(mock_get_client):
+    mock_update = EntityUpdate(id="123", type="note", content="hello", event="ADD", metadata={})
+    mock_get_client.update_entities.return_value = [mock_update]
+
+    create_entity(
+        content="hello",
+        entity_type="note",
+        metadata=json.dumps({"service_instance_id": "spoofed", "source": "external"}),
+    )
+
+    entity = mock_get_client.update_entities.call_args.kwargs["entities"][0]
+    assert entity.metadata["source"] == "external"
+    assert "service_instance_id" not in entity.metadata
+
+
 def test_get_client_uses_idempotent_namespace_bootstrap(monkeypatch):
     original_client = mcp_server_module._client
     original_namespaces = mcp_server_module._initialized_namespaces.copy()
@@ -190,6 +206,7 @@ def test_resolve_namespace_caches_after_first_call(mock_get_client):
 
 def test_save_trajectory_with_user_and_session_metadata(mock_get_client):
     """save_trajectory should inject user_id and session_id into entity metadata."""
+    mock_get_client.config.service_instance_id = "instance-a"
     with patch("altk_evolve.frontend.mcp.mcp_server.generate_guidelines") as mock_gen:
         mock_result = MagicMock()
         mock_guideline = MagicMock()
@@ -225,6 +242,9 @@ def test_save_trajectory_with_user_and_session_metadata(mock_get_client):
         assert guide_entity.metadata["user_id"] == "user-42"
         assert guide_entity.metadata["owner_id"] == "user-42"
         assert guide_entity.metadata["session_id"] == "session-7"
+
+        readback_filters = mock_get_client.search_entities.call_args.kwargs["filters"]
+        assert readback_filters["metadata.service_instance_id"] == "instance-a"
 
 
 def test_save_trajectory_with_namespace_override(mock_get_client):
@@ -440,7 +460,7 @@ def test_store_user_facts_returns_structured_payload(mock_get_client):
             store_user_facts(
                 user_id="user-123",
                 message="I prefer concise answers.",
-                metadata=json.dumps({"source": "cuga-lite"}),
+                metadata=json.dumps({"source": "external", "service_instance_id": "spoofed"}),
             )
         )
 
@@ -458,7 +478,8 @@ def test_store_user_facts_returns_structured_payload(mock_get_client):
     assert entities[0].type == "fact"
     assert entities[0].metadata["user_id"] == "user-123"
     assert entities[0].metadata["category"] == "style"
-    assert entities[0].metadata["source"] == "cuga-lite"
+    assert entities[0].metadata["source"] == "external"
+    assert "service_instance_id" not in entities[0].metadata
     assert call_kwargs["enable_conflict_resolution"] is False
 
 

--- a/tests/unit/test_service_instance_reaper.py
+++ b/tests/unit/test_service_instance_reaper.py
@@ -1,0 +1,230 @@
+"""Service-instance attribution and operator purge tests."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from altk_evolve.backend.filesystem import FilesystemEntityBackend, FilesystemSettings
+from altk_evolve.cli.cli import app
+from altk_evolve.config.evolve import EvolveConfig
+from altk_evolve.frontend.client.evolve_client import EvolveClient
+from altk_evolve.reaper.service_instance import _purge_connection
+from altk_evolve.schema.conflict_resolution import EntityUpdate
+from altk_evolve.schema.core import Entity
+
+pytestmark = pytest.mark.unit
+
+
+def _client_with_backend(service_instance_id: str | None = None) -> tuple[EvolveClient, MagicMock]:
+    client = EvolveClient.__new__(EvolveClient)
+    client.config = EvolveConfig(backend="filesystem", service_instance_id=service_instance_id)
+    client.backend = MagicMock()
+    client.backend.update_entities.return_value = []
+    return client, client.backend
+
+
+def test_client_attributes_every_entity_from_configured_service_instance():
+    client, backend = _client_with_backend(service_instance_id="instance-a")
+    entities = [
+        Entity(type="trajectory", content="one", metadata={"task_id": "task-1"}),
+        Entity(type="trajectory", content="two", metadata={"service_instance_id": "spoofed"}),
+    ]
+
+    client.update_entities("tenant-a", entities, False)
+
+    stored = backend.update_entities.call_args.args[1]
+    assert [entity.metadata["service_instance_id"] for entity in stored] == ["instance-a", "instance-a"]
+    assert stored[0].metadata["task_id"] == "task-1"
+    assert entities[1].metadata["service_instance_id"] == "spoofed"
+
+
+def test_client_uses_normalized_configured_service_instance():
+    client, backend = _client_with_backend(service_instance_id=" instance-from-env ")
+
+    client.update_entities("tenant-a", [Entity(type="fact", content="one")], False)
+
+    stored = backend.update_entities.call_args.args[1]
+    assert stored[0].metadata["service_instance_id"] == "instance-from-env"
+
+
+def test_client_removes_caller_service_instance_metadata_when_unconfigured():
+    client, backend = _client_with_backend()
+
+    client.update_entities(
+        "tenant-a",
+        [Entity(type="fact", content="one", metadata={"service_instance_id": "spoofed"})],
+        False,
+    )
+
+    stored = backend.update_entities.call_args.args[1]
+    assert "service_instance_id" not in stored[0].metadata
+
+
+def test_evolve_config_reads_service_instance_environment(monkeypatch):
+    monkeypatch.setenv("EVOLVE_SERVICE_INSTANCE_ID", " instance-a ")
+
+    assert EvolveConfig().service_instance_id == "instance-a"
+
+
+def test_conflict_resolution_only_compares_entities_from_same_service_instance(tmp_path, monkeypatch):
+    backend = FilesystemEntityBackend(FilesystemSettings(data_dir=str(tmp_path)))
+    backend.create_namespace("tenant-a")
+    filters_seen: list[dict | None] = []
+    original_search = backend._search_entities_impl
+
+    def capture_search(namespace_id: str, query: str | None = None, filters: dict | None = None, limit: int = 10):
+        filters_seen.append(filters)
+        return original_search(namespace_id, query, filters, limit)
+
+    monkeypatch.setattr(backend, "_search_entities_impl", capture_search)
+    entity = Entity(
+        type="guideline",
+        content="Keep writes scoped",
+        metadata={"service_instance_id": "instance-a"},
+    )
+    update = EntityUpdate(id="unused", type="guideline", content=entity.content, event="NONE", metadata=entity.metadata)
+
+    with patch("altk_evolve.llm.conflict_resolution.conflict_resolution.resolve_conflicts", return_value=[update]):
+        backend.update_entities("tenant-a", [entity], enable_conflict_resolution=True)
+
+    assert filters_seen == [{"type": "guideline", "metadata.service_instance_id": "instance-a"}]
+
+
+class _FakeCursor:
+    def __init__(self, conn: "_FakeConnection"):
+        self.conn = conn
+        self.rowcount = -1
+        self._one: tuple[int] | None = None
+        self._all: list[tuple[str, str]] = []
+
+    def __enter__(self) -> "_FakeCursor":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def execute(self, statement: Any, params: tuple[str, str] | None = None) -> None:
+        rendered = repr(statement)
+        if isinstance(statement, str):
+            assert "t.table_name LIKE 'ns\\_%'" in statement
+            assert "c.column_name = 'metadata'" in statement
+            self._all = [("public", name) for name in sorted(self.conn.records)]
+            return
+
+        table_name = next(name for name in self.conn.records if name in rendered)
+        assert params is not None
+        metadata_key, service_instance_id = params
+        matches = [row for row in self.conn.records[table_name] if row.get(metadata_key) == service_instance_id]
+        if "SELECT COUNT" in rendered:
+            self._one = (len(matches),)
+            return
+        assert "DELETE FROM" in rendered
+        self.conn.records[table_name] = [row for row in self.conn.records[table_name] if row.get(metadata_key) != service_instance_id]
+        self.rowcount = len(matches)
+
+    def fetchall(self) -> list[tuple[str, str]]:
+        return self._all
+
+    def fetchone(self) -> tuple[int] | None:
+        return self._one
+
+
+class _FakeConnection:
+    def __init__(self):
+        self.records = {
+            "ns_tenant_a": [
+                {"service_instance_id": "instance-a", "content": "remove"},
+                {"service_instance_id": "instance-b", "content": "keep"},
+                {"content": "legacy-unattributed"},
+            ],
+            "ns_tenant_b": [
+                {"service_instance_id": "instance-a", "content": "remove too"},
+                {"service_instance_id": "instance-b", "content": "keep too"},
+            ],
+        }
+        self.commits = 0
+        self.rollbacks = 0
+
+    def cursor(self) -> _FakeCursor:
+        return _FakeCursor(self)
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+
+def test_purge_deletes_target_instance_and_preserves_other_instance_records():
+    conn = _FakeConnection()
+
+    result = _purge_connection(conn, "instance-a", dry_run=False)
+
+    assert result.deleted_records == 2
+    assert result.tables == {"ns_tenant_a": 1, "ns_tenant_b": 1}
+    assert conn.commits == 1
+    assert conn.rollbacks == 0
+    assert conn.records == {
+        "ns_tenant_a": [
+            {"service_instance_id": "instance-b", "content": "keep"},
+            {"content": "legacy-unattributed"},
+        ],
+        "ns_tenant_b": [{"service_instance_id": "instance-b", "content": "keep too"}],
+    }
+
+
+def test_purge_dry_run_counts_without_deleting():
+    conn = _FakeConnection()
+    original = {name: [dict(row) for row in rows] for name, rows in conn.records.items()}
+
+    result = _purge_connection(conn, "instance-a", dry_run=True)
+
+    assert result.deleted_records == 2
+    assert result.dry_run is True
+    assert conn.records == original
+    assert conn.commits == 0
+    assert conn.rollbacks == 1
+
+
+def test_purge_cli_requires_postgres(monkeypatch):
+    import altk_evolve.config.evolve as evolve_config_module
+
+    monkeypatch.setattr(evolve_config_module.evolve_config, "backend", "filesystem")
+
+    result = CliRunner().invoke(app, ["purge", "service-instance", "--service-instance-id", "instance-a"])
+
+    assert result.exit_code == 1
+    assert "requires EVOLVE_BACKEND=postgres" in result.stdout
+
+
+def test_purge_cli_emits_machine_readable_summary(monkeypatch):
+    import altk_evolve.config.evolve as evolve_config_module
+    from altk_evolve import reaper
+    from altk_evolve.reaper import ServiceInstancePurgeResult
+
+    monkeypatch.setattr(evolve_config_module.evolve_config, "backend", "postgres")
+    purge = MagicMock(
+        return_value=ServiceInstancePurgeResult(
+            service_instance_id="instance-[red]a[/red]",
+            dry_run=False,
+            deleted_records=2,
+            tables={"ns_tenant_a": 2},
+        )
+    )
+    monkeypatch.setattr(reaper, "purge_service_instance_records", purge)
+
+    result = CliRunner().invoke(app, ["purge", "service-instance", "--service-instance-id", "instance-[red]a[/red]"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == {
+        "deleted_records": 2,
+        "dry_run": False,
+        "service_instance_id": "instance-[red]a[/red]",
+        "tables": {"ns_tenant_a": 2},
+    }
+    purge.assert_called_once_with("instance-[red]a[/red]", dry_run=False)

--- a/uv.lock
+++ b/uv.lock
@@ -246,6 +246,9 @@ pii-semantic = [
     { name = "readi-privacy" },
     { name = "spacy-curated-transformers" },
 ]
+reaper = [
+    { name = "psycopg", extra = ["binary"] },
+]
 secrets = [
     { name = "cpex" },
     { name = "cpex-secrets-detection" },
@@ -312,6 +315,7 @@ requires-dist = [
     { name = "pandas" },
     { name = "pgvector", marker = "extra == 'pgvector'", specifier = ">=0.3" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'pgvector'", specifier = ">=3.1" },
+    { name = "psycopg", extras = ["binary"], marker = "extra == 'reaper'", specifier = ">=3.1" },
     { name = "pydantic" },
     { name = "pymilvus", marker = "platform_machine == 'aarch64' and extra == 'milvus'", specifier = ">=2.6.2" },
     { name = "pymilvus", extras = ["milvus-lite"], marker = "platform_machine != 'aarch64' and extra == 'milvus'", specifier = ">=2.6.2" },
@@ -325,7 +329,7 @@ requires-dist = [
     { name = "uv", marker = "extra == 'build'" },
     { name = "uvicorn" },
 ]
-provides-extras = ["build", "tracing", "milvus", "pgvector", "hooks", "pii-regex", "pii", "pii-semantic", "secrets", "bench", "examples"]
+provides-extras = ["build", "tracing", "milvus", "pgvector", "reaper", "hooks", "pii-regex", "pii", "pii-semantic", "secrets", "bench", "examples"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Adds a generic Kubernetes/operator-facing cleanup path for Evolve data owned by a deprovisioned service instance.

- Reads optional deployment ownership from `EVOLVE_SERVICE_INSTANCE_ID` and persists it as reserved `metadata.service_instance_id` on every entity written through `EvolveClient.update_entities`.
- Keeps ownership server-controlled: MCP tools do not accept a service-instance identifier, and caller-supplied values in arbitrary entity metadata are removed.
- Scopes conflict-resolution candidates and trajectory readback to the configured service instance.
- Adds a lightweight operator command that connects directly with psycopg, avoiding embedding-model initialization:

```sh
evolve purge service-instance --service-instance-id <id> --dry-run
evolve purge service-instance --service-instance-id <id>
```

The command discovers Evolve Postgres namespace tables, deletes exact service-instance matches in one transaction, emits a machine-readable JSON summary, and exits non-zero on failure. `Dockerfile.core` includes the lightweight `reaper` extra, so a Kubernetes CronJob can use the rebuilt Evolve image and override its normal MCP entrypoint.

Platform integrations are responsible for mapping their deployment identifier to the generic `EVOLVE_SERVICE_INSTANCE_ID` contract.

## Safety properties

- A blank service-instance identifier is rejected.
- Only `ns_*` tables with Evolve's JSONB metadata shape are considered.
- Other service instances and unattributed records are preserved.
- Dry-run counts records without mutating them.
- Namespace catalog rows are intentionally retained.
- Service-instance ownership cannot be supplied through MCP arguments or arbitrary metadata.

## Compatibility caveat

Existing entities are not backfilled. Records written before service-instance attribution was enabled have no trustworthy ownership marker and are intentionally left untouched by the reaper.

The destructive reaper is Postgres-only and requires `EVOLVE_BACKEND=postgres` plus the existing `EVOLVE_PG_*` connection settings.

## Testing

- [x] `.venv/bin/pytest -q tests/unit/test_service_instance_reaper.py tests/unit/test_mcp_server.py tests/unit/test_client.py` (48 passed)
- [x] `.venv/bin/ruff check .`
- [x] `.venv/bin/mypy altk_evolve tests/unit/test_service_instance_reaper.py tests/unit/test_mcp_server.py`
- [x] pre-commit hooks (mypy, Ruff, formatting, large files, detect-secrets)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional service-instance attribution for newly stored entities.
  - Added `evolve purge service-instance` to remove records for a service instance, with PostgreSQL support, JSON results, and dry-run previews.
  - Added service-instance-scoped conflict resolution and filtering.

- **Bug Fixes**
  - Caller-supplied service-instance metadata is no longer trusted and is replaced with configured attribution.

- **Documentation**
  - Documented service-instance configuration, ownership, cleanup behavior, and CLI usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->